### PR TITLE
Fix T-338: S3 bucket ACL scan can panic on nil Grantee.URI

### DIFF
--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -75,13 +75,9 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 		if aclresp != nil {
 			acls = aclresp.Grants
 		}
-		openacls := false
-		for _, acl := range acls {
-			if acl.Grantee != nil && acl.Grantee.Type != types.TypeCanonicalUser &&
-				*acl.Grantee.URI != "http://acs.amazonaws.com/groups/s3/LogDelivery" {
-				openacls = true
-				isPublic = true
-			}
+		openacls := hasOpenACLs(acls)
+		if openacls {
+			isPublic = true
 		}
 		// PublicAccessBlock overrides other public making settings
 		publicresp, _ := svc.GetPublicAccessBlock(context.TODO(), &s3.GetPublicAccessBlockInput{Bucket: bucket.Name})
@@ -162,6 +158,23 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 
 	}
 	return result
+}
+
+// hasOpenACLs checks whether any grant in the list represents an open (public) ACL.
+// A grant is considered open if it targets a non-canonical-user grantee whose URI
+// is not the S3 LogDelivery group. Grants with a nil URI (e.g. email-based grants)
+// are also treated as open because they indicate a non-owner grant.
+func hasOpenACLs(acls []types.Grant) bool {
+	for _, acl := range acls {
+		if acl.Grantee == nil || acl.Grantee.Type == types.TypeCanonicalUser {
+			continue
+		}
+		uri := aws.ToString(acl.Grantee.URI)
+		if uri != "http://acs.amazonaws.com/groups/s3/LogDelivery" {
+			return true
+		}
+	}
+	return false
 }
 
 // GetReplicationStrings returns a slice of string representations of the bucket's replication rules

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -386,6 +386,114 @@ func TestResolveOwnerName(t *testing.T) {
 	}
 }
 
+// TestHasOpenACLs_NilGranteeURI is a regression test for T-338.
+// Grants with a nil URI (e.g. TypeAmazonCustomerByEmail) must not panic.
+func TestHasOpenACLs_NilGranteeURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		acls     []types.Grant
+		expected bool
+	}{
+		{
+			name:     "empty grants",
+			acls:     []types.Grant{},
+			expected: false,
+		},
+		{
+			name: "canonical user only",
+			acls: []types.Grant{
+				{
+					Grantee: &types.Grantee{
+						Type: types.TypeCanonicalUser,
+						ID:   aws.String("owner-id"),
+					},
+					Permission: types.PermissionFullControl,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "log delivery group (not open)",
+			acls: []types.Grant{
+				{
+					Grantee: &types.Grantee{
+						Type: types.TypeGroup,
+						URI:  aws.String("http://acs.amazonaws.com/groups/s3/LogDelivery"),
+					},
+					Permission: types.PermissionWrite,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "public all-users group (open)",
+			acls: []types.Grant{
+				{
+					Grantee: &types.Grantee{
+						Type: types.TypeGroup,
+						URI:  aws.String("http://acs.amazonaws.com/groups/global/AllUsers"),
+					},
+					Permission: types.PermissionRead,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "email grantee with nil URI must not panic (T-338)",
+			acls: []types.Grant{
+				{
+					Grantee: &types.Grantee{
+						Type:         types.TypeAmazonCustomerByEmail,
+						EmailAddress: aws.String("user@example.com"),
+						// URI is nil — this caused the original panic
+					},
+					Permission: types.PermissionRead,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nil Grantee pointer must not panic",
+			acls: []types.Grant{
+				{
+					Grantee:    nil,
+					Permission: types.PermissionRead,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "mixed grants with nil URI among others",
+			acls: []types.Grant{
+				{
+					Grantee: &types.Grantee{
+						Type: types.TypeCanonicalUser,
+						ID:   aws.String("owner-id"),
+					},
+					Permission: types.PermissionFullControl,
+				},
+				{
+					Grantee: &types.Grantee{
+						Type:         types.TypeAmazonCustomerByEmail,
+						EmailAddress: aws.String("user@example.com"),
+					},
+					Permission: types.PermissionRead,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasOpenACLs(tt.acls)
+			if result != tt.expected {
+				t.Errorf("hasOpenACLs() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestS3Bucket_PublicAccessBlockConfiguration(t *testing.T) {
 	bucket := S3Bucket{
 		PublicAccessBlockConfiguration: types.PublicAccessBlockConfiguration{

--- a/specs/bugfixes/s3-acl-nil-grantee-uri/report.md
+++ b/specs/bugfixes/s3-acl-nil-grantee-uri/report.md
@@ -1,0 +1,76 @@
+# Bugfix Report: s3-acl-nil-grantee-uri
+
+**Date:** 2026-03-13
+**Status:** Fixed
+**Transit Ticket:** T-338
+
+## Description of the Issue
+
+The `GetBucketDetails` function in `helpers/s3.go` panics with a nil pointer dereference when processing S3 bucket ACL grants that have a nil `Grantee.URI` field. This occurs for grant types like `TypeAmazonCustomerByEmail`, where `EmailAddress` is set but `URI` is nil.
+
+**Reproduction steps:**
+1. Have an S3 bucket with a grant of type `AmazonCustomerByEmail` (email-based ACL)
+2. Run any `s3 list` command that calls `GetBucketDetails`
+3. The program panics on `*acl.Grantee.URI` dereference
+
+**Impact:** Any AWS account with email-based S3 grants cannot use the `s3 list` commands — the entire scan aborts.
+
+## Investigation Summary
+
+- **Symptoms examined:** Panic on `*acl.Grantee.URI` at line 70 of `helpers/s3.go`
+- **Code inspected:** `GetBucketDetails` ACL processing loop in `helpers/s3.go`
+- **Hypotheses tested:** The `URI` field is only populated for `TypeGroup` grantees. For `TypeAmazonCustomerByEmail` and potentially other types, `URI` is nil.
+
+## Discovered Root Cause
+
+**Defect type:** Missing nil guard (nil pointer dereference)
+
+**Why it occurred:** The ACL loop checked `acl.Grantee.Type != types.TypeCanonicalUser` and then immediately dereferenced `*acl.Grantee.URI`. This assumes all non-canonical-user grantees have a URI, but `TypeAmazonCustomerByEmail` grantees use `EmailAddress` instead.
+
+**Contributing factors:** The AWS S3 SDK uses pointer fields for optional values. The `Grantee.URI` field is only set for group-type grantees, not for email-based grantees.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/s3.go` - Extracted inline ACL loop into `hasOpenACLs()` function with nil-safe URI handling via `aws.ToString()`
+- `helpers/s3_test.go` - Added `TestHasOpenACLs_NilGranteeURI` with 7 test cases covering nil URI, nil Grantee, and all grant types
+
+**Approach rationale:** Used `aws.ToString()` which safely returns `""` for nil `*string` pointers, consistent with the rest of the codebase. Extracted the logic to a named function to make it independently testable.
+
+**Alternatives considered:**
+- Inline nil check (`if acl.Grantee.URI != nil && ...`) — less testable, kept the complex condition inline
+- Type-switch on `Grantee.Type` — more verbose, and not all types are known ahead of time
+
+## Regression Test
+
+**Test file:** `helpers/s3_test.go`
+**Test name:** `TestHasOpenACLs_NilGranteeURI`
+
+**What it verifies:** That `hasOpenACLs` handles nil `Grantee.URI` (email grants), nil `Grantee` pointers, log delivery groups, public groups, and mixed grant lists without panicking and with correct boolean results.
+
+**Run command:** `go test ./helpers/ -run TestHasOpenACLs -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/s3.go` | Extracted `hasOpenACLs()` with nil-safe URI handling |
+| `helpers/s3_test.go` | Added regression test `TestHasOpenACLs_NilGranteeURI` |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes (7/7 subtests)
+- [x] Full test suite passes
+- [x] `go fmt` passes
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always use `aws.ToString()` instead of raw `*ptr` dereference for optional SDK string fields
+- Extract complex conditional logic into named functions for testability
+- Consider adding a linter rule for raw pointer dereferences on AWS SDK types
+
+## Related
+
+- Transit ticket: T-338


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic in `GetBucketDetails` when processing S3 ACL grants with a nil `Grantee.URI` field (e.g. `TypeAmazonCustomerByEmail` grants).

## Root Cause

The ACL loop dereferenced `*acl.Grantee.URI` without a nil guard. The `URI` field is only populated for group-type grantees — email-based grantees have `EmailAddress` set and `URI` nil.

## Changes

- **`helpers/s3.go`**: Extracted ACL check into `hasOpenACLs()` function using `aws.ToString()` for nil-safe URI handling
- **`helpers/s3_test.go`**: Added `TestHasOpenACLs_NilGranteeURI` regression test (7 subtests)
- **`specs/bugfixes/s3-acl-nil-grantee-uri/report.md`**: Full bugfix report

## Testing

All existing tests pass. New regression test covers: nil URI, nil Grantee, log delivery groups, public groups, and mixed grant lists.

Transit: T-338