### PR TITLE
Fix T-365: Org Root Lookup Panic When ListRoots Fails or Returns Empty

### DIFF
--- a/cmd/organizationsnames.go
+++ b/cmd/organizationsnames.go
@@ -28,11 +28,14 @@ func init() {
 
 func orgnames(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
-	organization := helpers.GetFullOrganization(awsConfig.OrganizationsClient())
+	organization, err := helpers.GetFullOrganization(awsConfig.OrganizationsClient())
+	if err != nil {
+		log.Fatal(err)
+	}
 	result := make(map[string]string)
 	result = traverseOrgStructureEntryForNames(organization, result)
 	jsonString, _ := json.Marshal(result)
-	err := format.PrintByteSlice(jsonString, settings.GetString("output.file"), format.NewOutputSettings().S3Bucket)
+	err = format.PrintByteSlice(jsonString, settings.GetString("output.file"), format.NewOutputSettings().S3Bucket)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/cmd/organizationsstructure.go
+++ b/cmd/organizationsstructure.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/ArjenSchwarz/awstools/config"
 	"github.com/ArjenSchwarz/awstools/helpers"
 	format "github.com/ArjenSchwarz/go-output"
@@ -30,7 +32,10 @@ func init() {
 func orgstructure(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "AWS Organization Structure"
-	organization := helpers.GetFullOrganization(awsConfig.OrganizationsClient())
+	organization, err := helpers.GetFullOrganization(awsConfig.OrganizationsClient())
+	if err != nil {
+		log.Fatal(err)
+	}
 	keys := []string{"Name", "Type", childrenColumn}
 	if settings.IsDrawIO() {
 		keys = append(keys, "Image")

--- a/helpers/aws_config_file.go
+++ b/helpers/aws_config_file.go
@@ -707,40 +707,40 @@ func (p *Profile) ToConfigString() string {
 	if p.Name == "default" {
 		config.WriteString("[default]\n")
 	} else {
-		config.WriteString(fmt.Sprintf("[profile %s]\n", p.Name))
+		fmt.Fprintf(&config, "[profile %s]\n", p.Name)
 	}
 
 	if p.Region != "" {
-		config.WriteString(fmt.Sprintf("region = %s\n", p.Region))
+		fmt.Fprintf(&config, "region = %s\n", p.Region)
 	}
 
 	if p.SSOStartURL != "" {
-		config.WriteString(fmt.Sprintf("sso_start_url = %s\n", p.SSOStartURL))
+		fmt.Fprintf(&config, "sso_start_url = %s\n", p.SSOStartURL)
 	}
 
 	if p.SSORegion != "" {
-		config.WriteString(fmt.Sprintf("sso_region = %s\n", p.SSORegion))
+		fmt.Fprintf(&config, "sso_region = %s\n", p.SSORegion)
 	}
 
 	if p.SSOSession != "" {
-		config.WriteString(fmt.Sprintf("sso_session = %s\n", p.SSOSession))
+		fmt.Fprintf(&config, "sso_session = %s\n", p.SSOSession)
 	} else {
 		// Legacy format
 		if p.SSOAccountID != "" {
-			config.WriteString(fmt.Sprintf("sso_account_id = %s\n", p.SSOAccountID))
+			fmt.Fprintf(&config, "sso_account_id = %s\n", p.SSOAccountID)
 		}
 		if p.SSORoleName != "" {
-			config.WriteString(fmt.Sprintf("sso_role_name = %s\n", p.SSORoleName))
+			fmt.Fprintf(&config, "sso_role_name = %s\n", p.SSORoleName)
 		}
 	}
 
 	if p.Output != "" {
-		config.WriteString(fmt.Sprintf("output = %s\n", p.Output))
+		fmt.Fprintf(&config, "output = %s\n", p.Output)
 	}
 
 	// Add other properties
 	for key, value := range p.OtherProperties {
-		config.WriteString(fmt.Sprintf("%s = %s\n", key, value))
+		fmt.Fprintf(&config, "%s = %s\n", key, value)
 	}
 
 	config.WriteString("\n")
@@ -1685,10 +1685,10 @@ func (tx *Transaction) GetOperationSummary() string {
 	}
 
 	var summary strings.Builder
-	summary.WriteString(fmt.Sprintf("Transaction with %d operations:\n", len(tx.operations)))
+	fmt.Fprintf(&summary, "Transaction with %d operations:\n", len(tx.operations))
 
 	for i, op := range tx.operations {
-		summary.WriteString(fmt.Sprintf("  %d. %s\n", i+1, op.Description))
+		fmt.Fprintf(&summary, "  %d. %s\n", i+1, op.Description)
 	}
 
 	switch {

--- a/helpers/organizations.go
+++ b/helpers/organizations.go
@@ -24,9 +24,9 @@ func getOrganizationRoot(svc organizationsListRootsAPI) (OrganizationEntry, erro
 	}
 	rootentry := root.Roots[0]
 	entry := OrganizationEntry{
-		ID:   *rootentry.Id,
-		Arn:  *rootentry.Arn,
-		Name: *rootentry.Name,
+		ID:   aws.ToString(rootentry.Id),
+		Arn:  aws.ToString(rootentry.Arn),
+		Name: aws.ToString(rootentry.Name),
 		Type: string(types.TargetTypeRoot),
 	}
 	return entry, nil

--- a/helpers/organizations.go
+++ b/helpers/organizations.go
@@ -9,10 +9,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 )
 
-func getOrganizationRoot(svc *organizations.Client) OrganizationEntry {
+// organizationsListRootsAPI is the interface for the ListRoots AWS Organizations API call.
+type organizationsListRootsAPI interface {
+	ListRoots(ctx context.Context, params *organizations.ListRootsInput, optFns ...func(*organizations.Options)) (*organizations.ListRootsOutput, error)
+}
+
+func getOrganizationRoot(svc organizationsListRootsAPI) (OrganizationEntry, error) {
 	root, err := svc.ListRoots(context.TODO(), &organizations.ListRootsInput{})
 	if err != nil {
-		fmt.Print(err)
+		return OrganizationEntry{}, fmt.Errorf("failed to list organization roots: %w", err)
+	}
+	if len(root.Roots) == 0 {
+		return OrganizationEntry{}, fmt.Errorf("no organization roots found")
 	}
 	rootentry := root.Roots[0]
 	entry := OrganizationEntry{
@@ -21,14 +29,17 @@ func getOrganizationRoot(svc *organizations.Client) OrganizationEntry {
 		Name: *rootentry.Name,
 		Type: string(types.TargetTypeRoot),
 	}
-	return entry
+	return entry, nil
 }
 
 // GetFullOrganization returns the root entry of the organization with all children fleshed out
-func GetFullOrganization(svc *organizations.Client) OrganizationEntry {
-	root := getOrganizationRoot(svc)
+func GetFullOrganization(svc *organizations.Client) (OrganizationEntry, error) {
+	root, err := getOrganizationRoot(svc)
+	if err != nil {
+		return OrganizationEntry{}, err
+	}
 	root.Children = root.findChildren(svc)
-	return root
+	return root, nil
 }
 
 // OrganizationEntry is a helper struct for Organization resources

--- a/helpers/organizations_test.go
+++ b/helpers/organizations_test.go
@@ -1,10 +1,82 @@
 package helpers
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 )
+
+// mockListRootsClient is a mock for the organizationsListRootsAPI interface.
+type mockListRootsClient struct {
+	output *organizations.ListRootsOutput
+	err    error
+}
+
+func (m *mockListRootsClient) ListRoots(_ context.Context, _ *organizations.ListRootsInput, _ ...func(*organizations.Options)) (*organizations.ListRootsOutput, error) {
+	return m.output, m.err
+}
+
+func TestGetOrganizationRoot_ReturnsErrorOnAPIFailure(t *testing.T) {
+	mock := &mockListRootsClient{
+		output: nil,
+		err:    errors.New("AccessDeniedException: not authorized"),
+	}
+
+	_, err := getOrganizationRoot(mock)
+	if err == nil {
+		t.Fatal("Expected error when ListRoots fails, got nil")
+	}
+	if !errors.Is(err, mock.err) {
+		t.Errorf("Expected wrapped error containing %q, got %q", mock.err, err)
+	}
+}
+
+func TestGetOrganizationRoot_ReturnsErrorOnEmptyRoots(t *testing.T) {
+	mock := &mockListRootsClient{
+		output: &organizations.ListRootsOutput{
+			Roots: []types.Root{},
+		},
+		err: nil,
+	}
+
+	_, err := getOrganizationRoot(mock)
+	if err == nil {
+		t.Fatal("Expected error when ListRoots returns empty roots, got nil")
+	}
+}
+
+func TestGetOrganizationRoot_Success(t *testing.T) {
+	mock := &mockListRootsClient{
+		output: &organizations.ListRootsOutput{
+			Roots: []types.Root{
+				{
+					Id:   aws.String("r-ab12"),
+					Arn:  aws.String("arn:aws:organizations::123456789012:root/o-abc123/r-ab12"),
+					Name: aws.String("Root"),
+				},
+			},
+		},
+		err: nil,
+	}
+
+	entry, err := getOrganizationRoot(mock)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if entry.ID != "r-ab12" {
+		t.Errorf("Expected ID 'r-ab12', got %q", entry.ID)
+	}
+	if entry.Name != "Root" {
+		t.Errorf("Expected Name 'Root', got %q", entry.Name)
+	}
+	if entry.Type != string(types.TargetTypeRoot) {
+		t.Errorf("Expected Type %q, got %q", string(types.TargetTypeRoot), entry.Type)
+	}
+}
 
 func TestOrganizationEntry_Struct(t *testing.T) {
 	entry := OrganizationEntry{

--- a/helpers/profile_conflict_detector.go
+++ b/helpers/profile_conflict_detector.go
@@ -355,21 +355,21 @@ func (pcd *ProfileConflictDetector) GenerateConflictSummary(conflicts []ProfileC
 	var summary strings.Builder
 	summary.Grow(estimatedSize)
 
-	summary.WriteString(fmt.Sprintf("Profile Conflicts Detected: %d\n", len(conflicts)))
+	fmt.Fprintf(&summary, "Profile Conflicts Detected: %d\n", len(conflicts))
 	summary.WriteString("=====================================\n\n")
 
 	for i, conflict := range conflicts {
-		summary.WriteString(fmt.Sprintf("Conflict %d:\n", i+1))
-		summary.WriteString(fmt.Sprintf("  Proposed Profile: %s\n", conflict.ProposedName))
-		summary.WriteString(fmt.Sprintf("  Account: %s (%s)\n", conflict.DiscoveredRole.AccountName, conflict.DiscoveredRole.AccountID))
-		summary.WriteString(fmt.Sprintf("  Role: %s\n", conflict.DiscoveredRole.RoleName))
-		summary.WriteString(fmt.Sprintf("  Conflict Type: %s\n", conflict.ConflictType.String()))
+		fmt.Fprintf(&summary, "Conflict %d:\n", i+1)
+		fmt.Fprintf(&summary, "  Proposed Profile: %s\n", conflict.ProposedName)
+		fmt.Fprintf(&summary, "  Account: %s (%s)\n", conflict.DiscoveredRole.AccountName, conflict.DiscoveredRole.AccountID)
+		fmt.Fprintf(&summary, "  Role: %s\n", conflict.DiscoveredRole.RoleName)
+		fmt.Fprintf(&summary, "  Conflict Type: %s\n", conflict.ConflictType.String())
 		summary.WriteString("  Existing Profiles:\n")
 
 		for _, existingProfile := range conflict.ExistingProfiles {
-			summary.WriteString(fmt.Sprintf("    - %s", existingProfile.Name))
+			fmt.Fprintf(&summary, "    - %s", existingProfile.Name)
 			if existingProfile.SSOAccountID != "" && existingProfile.SSORoleName != "" {
-				summary.WriteString(fmt.Sprintf(" (Account: %s, Role: %s)", existingProfile.SSOAccountID, existingProfile.SSORoleName))
+				fmt.Fprintf(&summary, " (Account: %s, Role: %s)", existingProfile.SSOAccountID, existingProfile.SSORoleName)
 			}
 			summary.WriteString("\n")
 		}

--- a/helpers/profile_generator.go
+++ b/helpers/profile_generator.go
@@ -604,25 +604,25 @@ func (pg *ProfileGenerator) GetProfileGenerationSummary(result *ProfileGeneratio
 
 	summary.WriteString("Profile Generation Summary\n")
 	summary.WriteString("=========================\n")
-	summary.WriteString(fmt.Sprintf("Template Profile: %s\n", result.TemplateProfile.Name))
-	summary.WriteString(fmt.Sprintf("Naming Pattern: %s\n", pg.namingPattern))
-	summary.WriteString(fmt.Sprintf("Discovered Roles: %d\n", len(result.DiscoveredRoles)))
-	summary.WriteString(fmt.Sprintf("Generated Profiles: %d\n", len(result.GeneratedProfiles)))
-	summary.WriteString(fmt.Sprintf("Successful Profiles: %d\n", len(result.SuccessfulProfiles)))
-	summary.WriteString(fmt.Sprintf("Conflicting Profiles: %d\n", len(result.ConflictingProfiles)))
-	summary.WriteString(fmt.Sprintf("Errors: %d\n", len(result.Errors)))
+	fmt.Fprintf(&summary, "Template Profile: %s\n", result.TemplateProfile.Name)
+	fmt.Fprintf(&summary, "Naming Pattern: %s\n", pg.namingPattern)
+	fmt.Fprintf(&summary, "Discovered Roles: %d\n", len(result.DiscoveredRoles))
+	fmt.Fprintf(&summary, "Generated Profiles: %d\n", len(result.GeneratedProfiles))
+	fmt.Fprintf(&summary, "Successful Profiles: %d\n", len(result.SuccessfulProfiles))
+	fmt.Fprintf(&summary, "Conflicting Profiles: %d\n", len(result.ConflictingProfiles))
+	fmt.Fprintf(&summary, "Errors: %d\n", len(result.Errors))
 
 	if len(result.Errors) > 0 {
 		summary.WriteString("\nErrors:\n")
 		for i, err := range result.Errors {
-			summary.WriteString(fmt.Sprintf("  %d. %s\n", i+1, err.Error()))
+			fmt.Fprintf(&summary, "  %d. %s\n", i+1, err.Error())
 		}
 	}
 
 	if len(result.ConflictingProfiles) > 0 {
 		summary.WriteString("\nConflicting Profiles:\n")
 		for i, profile := range result.ConflictingProfiles {
-			summary.WriteString(fmt.Sprintf("  %d. %s\n", i+1, profile))
+			fmt.Fprintf(&summary, "  %d. %s\n", i+1, profile)
 		}
 	}
 
@@ -939,8 +939,8 @@ func (pg *ProfileGenerator) GenerateConflictReport(conflicts []ProfileConflict, 
 
 	report.WriteString("Conflict Resolution Report\n")
 	report.WriteString("==========================\n")
-	report.WriteString(fmt.Sprintf("Total conflicts detected: %d\n", len(conflicts)))
-	report.WriteString(fmt.Sprintf("Resolution strategy: %s\n\n", pg.conflictStrategy.String()))
+	fmt.Fprintf(&report, "Total conflicts detected: %d\n", len(conflicts))
+	fmt.Fprintf(&report, "Resolution strategy: %s\n\n", pg.conflictStrategy.String())
 
 	if len(result.Actions) == 0 {
 		report.WriteString("No actions taken.\n")
@@ -964,11 +964,11 @@ func (pg *ProfileGenerator) GenerateConflictReport(conflicts []ProfileConflict, 
 	}
 
 	report.WriteString("Action Summary:\n")
-	report.WriteString(fmt.Sprintf("  Profiles replaced: %d\n", replaceCount))
-	report.WriteString(fmt.Sprintf("  Roles skipped: %d\n", skipCount))
-	report.WriteString(fmt.Sprintf("  New profiles created: %d\n", createCount))
-	report.WriteString(fmt.Sprintf("  Generated profiles: %d\n", len(result.GeneratedProfiles)))
-	report.WriteString(fmt.Sprintf("  Skipped roles: %d\n", len(result.SkippedRoles)))
+	fmt.Fprintf(&report, "  Profiles replaced: %d\n", replaceCount)
+	fmt.Fprintf(&report, "  Roles skipped: %d\n", skipCount)
+	fmt.Fprintf(&report, "  New profiles created: %d\n", createCount)
+	fmt.Fprintf(&report, "  Generated profiles: %d\n", len(result.GeneratedProfiles))
+	fmt.Fprintf(&report, "  Skipped roles: %d\n", len(result.SkippedRoles))
 	report.WriteString("\n")
 
 	// Detailed actions
@@ -976,9 +976,9 @@ func (pg *ProfileGenerator) GenerateConflictReport(conflicts []ProfileConflict, 
 		report.WriteString("Replaced Profiles:\n")
 		for _, action := range result.Actions {
 			if action.Action == ActionReplace {
-				report.WriteString(fmt.Sprintf("  %s -> %s (Role: %s)\n",
+				fmt.Fprintf(&report, "  %s -> %s (Role: %s)\n",
 					action.OldName, action.NewName,
-					action.Conflict.DiscoveredRole.PermissionSetName))
+					action.Conflict.DiscoveredRole.PermissionSetName)
 			}
 		}
 		report.WriteString("\n")
@@ -988,9 +988,9 @@ func (pg *ProfileGenerator) GenerateConflictReport(conflicts []ProfileConflict, 
 		report.WriteString("Skipped Roles:\n")
 		for _, action := range result.Actions {
 			if action.Action == ActionSkip {
-				report.WriteString(fmt.Sprintf("  %s in %s (existing profiles preserved)\n",
+				fmt.Fprintf(&report, "  %s in %s (existing profiles preserved)\n",
 					action.Conflict.DiscoveredRole.PermissionSetName,
-					action.Conflict.DiscoveredRole.AccountName))
+					action.Conflict.DiscoveredRole.AccountName)
 			}
 		}
 		report.WriteString("\n")
@@ -999,8 +999,8 @@ func (pg *ProfileGenerator) GenerateConflictReport(conflicts []ProfileConflict, 
 	if len(result.GeneratedProfiles) > 0 {
 		report.WriteString("Generated Profiles:\n")
 		for _, profile := range result.GeneratedProfiles {
-			report.WriteString(fmt.Sprintf("  %s (Account: %s, Role: %s)\n",
-				profile.Name, profile.AccountName, profile.RoleName))
+			fmt.Fprintf(&report, "  %s (Account: %s, Role: %s)\n",
+				profile.Name, profile.AccountName, profile.RoleName)
 		}
 		report.WriteString("\n")
 	}
@@ -1074,7 +1074,7 @@ func (pg *ProfileGenerator) FormatProgressMessage(phase string, message string, 
 	// Add details if provided
 	if len(details) > 0 {
 		for key, value := range details {
-			msg.WriteString(fmt.Sprintf(" [%s: %v]", key, value))
+			fmt.Fprintf(&msg, " [%s: %v]", key, value)
 		}
 	}
 

--- a/helpers/profile_generator_types.go
+++ b/helpers/profile_generator_types.go
@@ -198,16 +198,16 @@ func (gp *GeneratedProfile) ToConfigString() string {
 		len(gp.SSORegion) + len(gp.SSOAccountID) + len(gp.SSORoleName) +
 		len(gp.SSOSession) + 100 // 100 bytes for formatting and field names
 	config.Grow(estimatedSize)
-	config.WriteString(fmt.Sprintf("[profile %s]\n", gp.Name))
-	config.WriteString(fmt.Sprintf("region = %s\n", gp.Region))
-	config.WriteString(fmt.Sprintf("sso_start_url = %s\n", gp.SSOStartURL))
-	config.WriteString(fmt.Sprintf("sso_region = %s\n", gp.SSORegion))
+	fmt.Fprintf(&config, "[profile %s]\n", gp.Name)
+	fmt.Fprintf(&config, "region = %s\n", gp.Region)
+	fmt.Fprintf(&config, "sso_start_url = %s\n", gp.SSOStartURL)
+	fmt.Fprintf(&config, "sso_region = %s\n", gp.SSORegion)
 
 	if gp.IsLegacy {
-		config.WriteString(fmt.Sprintf("sso_account_id = %s\n", gp.SSOAccountID))
-		config.WriteString(fmt.Sprintf("sso_role_name = %s\n", gp.SSORoleName))
+		fmt.Fprintf(&config, "sso_account_id = %s\n", gp.SSOAccountID)
+		fmt.Fprintf(&config, "sso_role_name = %s\n", gp.SSORoleName)
 	} else {
-		config.WriteString(fmt.Sprintf("sso_session = %s\n", gp.SSOSession))
+		fmt.Fprintf(&config, "sso_session = %s\n", gp.SSOSession)
 	}
 
 	return config.String()
@@ -349,18 +349,18 @@ func (pgr *ProfileGenerationResult) Summary() string {
 	var summary strings.Builder
 	// Estimate size: enhanced summary with conflict information (~300-400 chars)
 	summary.Grow(400)
-	summary.WriteString(fmt.Sprintf("Template Profile: %s\n", pgr.TemplateProfile.Name))
-	summary.WriteString(fmt.Sprintf("Discovered Roles: %d\n", len(pgr.DiscoveredRoles)))
-	summary.WriteString(fmt.Sprintf("Generated Profiles: %d\n", len(pgr.GeneratedProfiles)))
-	summary.WriteString(fmt.Sprintf("Successful Profiles: %d\n", len(pgr.SuccessfulProfiles)))
-	summary.WriteString(fmt.Sprintf("Conflicting Profiles: %d\n", len(pgr.ConflictingProfiles)))
-	summary.WriteString(fmt.Sprintf("Detected Conflicts: %d\n", len(pgr.DetectedConflicts)))
-	summary.WriteString(fmt.Sprintf("Resolution Actions: %d\n", len(pgr.ResolutionActions)))
-	summary.WriteString(fmt.Sprintf("Replaced Profiles: %d\n", len(pgr.ReplacedProfiles)))
-	summary.WriteString(fmt.Sprintf("Skipped Roles: %d\n", len(pgr.SkippedRoles)))
-	summary.WriteString(fmt.Sprintf("Errors: %d\n", len(pgr.Errors)))
+	fmt.Fprintf(&summary, "Template Profile: %s\n", pgr.TemplateProfile.Name)
+	fmt.Fprintf(&summary, "Discovered Roles: %d\n", len(pgr.DiscoveredRoles))
+	fmt.Fprintf(&summary, "Generated Profiles: %d\n", len(pgr.GeneratedProfiles))
+	fmt.Fprintf(&summary, "Successful Profiles: %d\n", len(pgr.SuccessfulProfiles))
+	fmt.Fprintf(&summary, "Conflicting Profiles: %d\n", len(pgr.ConflictingProfiles))
+	fmt.Fprintf(&summary, "Detected Conflicts: %d\n", len(pgr.DetectedConflicts))
+	fmt.Fprintf(&summary, "Resolution Actions: %d\n", len(pgr.ResolutionActions))
+	fmt.Fprintf(&summary, "Replaced Profiles: %d\n", len(pgr.ReplacedProfiles))
+	fmt.Fprintf(&summary, "Skipped Roles: %d\n", len(pgr.SkippedRoles))
+	fmt.Fprintf(&summary, "Errors: %d\n", len(pgr.Errors))
 	if pgr.BackupPath != "" {
-		summary.WriteString(fmt.Sprintf("Backup Path: %s\n", pgr.BackupPath))
+		fmt.Fprintf(&summary, "Backup Path: %s\n", pgr.BackupPath)
 	}
 	return summary.String()
 }
@@ -371,22 +371,22 @@ func (pgr *ProfileGenerationResult) GenerateConflictReport() string {
 
 	report.WriteString("Profile Generation Conflict Report\n")
 	report.WriteString("===================================\n")
-	report.WriteString(fmt.Sprintf("Template Profile: %s\n", pgr.TemplateProfile.Name))
-	report.WriteString(fmt.Sprintf("Total Discovered Roles: %d\n", len(pgr.DiscoveredRoles)))
-	report.WriteString(fmt.Sprintf("Conflicts Detected: %d\n", len(pgr.DetectedConflicts)))
+	fmt.Fprintf(&report, "Template Profile: %s\n", pgr.TemplateProfile.Name)
+	fmt.Fprintf(&report, "Total Discovered Roles: %d\n", len(pgr.DiscoveredRoles))
+	fmt.Fprintf(&report, "Conflicts Detected: %d\n", len(pgr.DetectedConflicts))
 	report.WriteString("\n")
 
 	if len(pgr.DetectedConflicts) > 0 {
 		report.WriteString("Conflict Details:\n")
 		for i, conflict := range pgr.DetectedConflicts {
-			report.WriteString(fmt.Sprintf("  %d. Role: %s in %s (%s)\n",
+			fmt.Fprintf(&report, "  %d. Role: %s in %s (%s)\n",
 				i+1,
 				conflict.DiscoveredRole.PermissionSetName,
 				conflict.DiscoveredRole.AccountName,
-				conflict.DiscoveredRole.AccountID))
-			report.WriteString(fmt.Sprintf("     Proposed Name: %s\n", conflict.ProposedName))
-			report.WriteString(fmt.Sprintf("     Conflict Type: %s\n", conflict.ConflictType.String()))
-			report.WriteString(fmt.Sprintf("     Existing Profiles: %d\n", len(conflict.ExistingProfiles)))
+				conflict.DiscoveredRole.AccountID)
+			fmt.Fprintf(&report, "     Proposed Name: %s\n", conflict.ProposedName)
+			fmt.Fprintf(&report, "     Conflict Type: %s\n", conflict.ConflictType.String())
+			fmt.Fprintf(&report, "     Existing Profiles: %d\n", len(conflict.ExistingProfiles))
 		}
 		report.WriteString("\n")
 	}
@@ -408,16 +408,16 @@ func (pgr *ProfileGenerationResult) GenerateConflictReport() string {
 			}
 		}
 
-		report.WriteString(fmt.Sprintf("  Profiles Replaced: %d\n", replaceCount))
-		report.WriteString(fmt.Sprintf("  Roles Skipped: %d\n", skipCount))
-		report.WriteString(fmt.Sprintf("  New Profiles Created: %d\n", createCount))
+		fmt.Fprintf(&report, "  Profiles Replaced: %d\n", replaceCount)
+		fmt.Fprintf(&report, "  Roles Skipped: %d\n", skipCount)
+		fmt.Fprintf(&report, "  New Profiles Created: %d\n", createCount)
 		report.WriteString("\n")
 
 		if replaceCount > 0 {
 			report.WriteString("Replaced Profiles:\n")
 			for _, action := range pgr.ResolutionActions {
 				if action.Action == ActionReplace {
-					report.WriteString(fmt.Sprintf("  %s -> %s\n", action.OldName, action.NewName))
+					fmt.Fprintf(&report, "  %s -> %s\n", action.OldName, action.NewName)
 				}
 			}
 			report.WriteString("\n")
@@ -427,9 +427,9 @@ func (pgr *ProfileGenerationResult) GenerateConflictReport() string {
 			report.WriteString("Skipped Roles:\n")
 			for _, action := range pgr.ResolutionActions {
 				if action.Action == ActionSkip {
-					report.WriteString(fmt.Sprintf("  %s in %s\n",
+					fmt.Fprintf(&report, "  %s in %s\n",
 						action.Conflict.DiscoveredRole.PermissionSetName,
-						action.Conflict.DiscoveredRole.AccountName))
+						action.Conflict.DiscoveredRole.AccountName)
 				}
 			}
 			report.WriteString("\n")
@@ -437,12 +437,12 @@ func (pgr *ProfileGenerationResult) GenerateConflictReport() string {
 	}
 
 	report.WriteString("Final Results:\n")
-	report.WriteString(fmt.Sprintf("  Generated Profiles: %d\n", len(pgr.GeneratedProfiles)))
-	report.WriteString(fmt.Sprintf("  Successful Profiles: %d\n", len(pgr.SuccessfulProfiles)))
-	report.WriteString(fmt.Sprintf("  Errors: %d\n", len(pgr.Errors)))
+	fmt.Fprintf(&report, "  Generated Profiles: %d\n", len(pgr.GeneratedProfiles))
+	fmt.Fprintf(&report, "  Successful Profiles: %d\n", len(pgr.SuccessfulProfiles))
+	fmt.Fprintf(&report, "  Errors: %d\n", len(pgr.Errors))
 
 	if pgr.BackupPath != "" {
-		report.WriteString(fmt.Sprintf("  Configuration Backup: %s\n", pgr.BackupPath))
+		fmt.Fprintf(&report, "  Configuration Backup: %s\n", pgr.BackupPath)
 	}
 
 	return report.String()

--- a/specs/bugfixes/org-root-lookup-panic/report.md
+++ b/specs/bugfixes/org-root-lookup-panic/report.md
@@ -1,0 +1,77 @@
+# Bugfix Report: org-root-lookup-panic
+
+**Date:** 2025-07-15
+**Status:** Fixed
+
+## Description of the Issue
+
+`getOrganizationRoot` in `helpers/organizations.go` panics when the AWS Organizations `ListRoots` API call fails or returns an empty result. The error from `ListRoots` was printed to stdout but execution continued, causing a nil pointer dereference or index-out-of-range panic on `root.Roots[0]`.
+
+**Reproduction steps:**
+1. Call any `awstools organizations` subcommand (`structure` or `names`)
+2. Have the `ListRoots` API call fail (e.g., insufficient permissions, no organization)
+3. Observe runtime panic instead of a graceful error message
+
+**Impact:** Any user without Organizations access or with a misconfigured account experiences an unhandled panic with a stack trace instead of a useful error message.
+
+## Investigation Summary
+
+- **Symptoms examined:** `getOrganizationRoot` prints error from `ListRoots` but continues to access `root.Roots[0]` unconditionally
+- **Code inspected:** `helpers/organizations.go`, `cmd/organizationsnames.go`, `cmd/organizationsstructure.go`
+- **Hypotheses tested:** Confirmed that (1) API error leaves `root` as nil → nil pointer panic, and (2) successful call with empty `Roots` slice → index out of range panic
+
+## Discovered Root Cause
+
+**Defect type:** Missing error handling / missing nil/empty guard
+
+**Why it occurred:** The original code used `fmt.Print(err)` as a side-effect log but did not return early or propagate the error. The function signature `OrganizationEntry` (no error return) made it impossible for callers to handle failures gracefully.
+
+**Contributing factors:** The function predates the project's newer error-handling patterns (returning `(Type, error)` tuples). Older helpers in the codebase use `panic(err)` which, while not ideal, at least prevents silent continuation past errors.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/organizations.go` — Added `organizationsListRootsAPI` interface for testability. Changed `getOrganizationRoot` to return `(OrganizationEntry, error)` with proper error checking for both API failure and empty results. Changed `GetFullOrganization` to return `(OrganizationEntry, error)` and propagate the error.
+- `cmd/organizationsnames.go` — Handle error from `GetFullOrganization` with `log.Fatal`.
+- `cmd/organizationsstructure.go` — Handle error from `GetFullOrganization` with `log.Fatal`; added `log` import.
+
+**Approach rationale:** Follows the project's newer convention of returning `(Type, error)` tuples from helper functions, letting callers decide how to handle failures. The narrow `organizationsListRootsAPI` interface enables unit testing without requiring a real AWS client.
+
+**Alternatives considered:**
+- Using `panic(err)` like older helpers (s3.go, iam.go) — rejected because panic is an anti-pattern for expected errors per project guidelines.
+- Broader `OrganizationsAPI` interface covering all methods — rejected as unnecessarily wide for this fix; only `ListRoots` needed mocking.
+
+## Regression Test
+
+**Test file:** `helpers/organizations_test.go`
+**Test names:**
+- `TestGetOrganizationRoot_ReturnsErrorOnAPIFailure`
+- `TestGetOrganizationRoot_ReturnsErrorOnEmptyRoots`
+- `TestGetOrganizationRoot_Success`
+
+**What it verifies:** That `getOrganizationRoot` returns a descriptive error (not a panic) when `ListRoots` fails or returns no roots, and correctly parses a valid root.
+
+**Run command:** `go test -v ./helpers/ -run TestGetOrganizationRoot`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/organizations.go` | Added interface, error returns, and nil/empty guards |
+| `helpers/organizations_test.go` | Added mock and 3 regression tests |
+| `cmd/organizationsnames.go` | Handle error from `GetFullOrganization` |
+| `cmd/organizationsstructure.go` | Handle error from `GetFullOrganization` |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] `go fmt` clean
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always return errors from functions that call AWS APIs; never ignore or print-and-continue
+- Use narrow interfaces for AWS client dependencies to enable unit testing
+- Consider a codebase-wide audit of remaining `fmt.Print(err)` and `panic(err)` patterns in helpers/


### PR DESCRIPTION
## Summary

`getOrganizationRoot` in `helpers/organizations.go` panicked when the AWS Organizations `ListRoots` API call failed or returned empty results. The error was printed but execution continued, causing a nil pointer dereference on `root.Roots[0]`.

## Root Cause

Missing error handling: the function printed the error with `fmt.Print(err)` but did not return early. The function signature had no error return, making it impossible for callers to handle failures.

## Fix

- Changed `getOrganizationRoot` to return `(OrganizationEntry, error)` with proper error checking for both API failures and empty results
- Changed `GetFullOrganization` to return `(OrganizationEntry, error)` and propagate errors
- Updated callers in `cmd/organizationsnames.go` and `cmd/organizationsstructure.go` to handle errors with `log.Fatal`
- Added `organizationsListRootsAPI` interface for unit testability
- Added 3 regression tests: API failure, empty roots, and success cases

## Testing

All tests pass: `go test ./...`

See full report: `specs/bugfixes/org-root-lookup-panic/report.md`