### PR TITLE
Fix T-345: Handle Non-HTTP App Mesh Routes

### DIFF
--- a/helpers/appmesh.go
+++ b/helpers/appmesh.go
@@ -123,27 +123,57 @@ func getAllAppMeshVirtualServices(meshName *string, svc AppMeshAPI) []*types.Vir
 }
 
 // buildRoutesHolder processes route data and builds a map of router name to routes.
+// Handles HTTP, HTTP/2, gRPC, and TCP route types.
 func buildRoutesHolder(routes []*types.RouteData) map[string][]AppMeshVirtualServiceRoute {
 	routesholder := make(map[string][]AppMeshVirtualServiceRoute)
 	for _, route := range routes {
-		for _, action := range route.Spec.HttpRoute.Action.WeightedTargets {
+		var targets []types.WeightedTarget
+		var path string
+
+		switch {
+		case route.Spec.HttpRoute != nil:
+			targets = route.Spec.HttpRoute.Action.WeightedTargets
+			path = aws.ToString(route.Spec.HttpRoute.Match.Prefix)
+		case route.Spec.Http2Route != nil:
+			targets = route.Spec.Http2Route.Action.WeightedTargets
+			path = aws.ToString(route.Spec.Http2Route.Match.Prefix)
+		case route.Spec.GrpcRoute != nil:
+			targets = route.Spec.GrpcRoute.Action.WeightedTargets
+			path = grpcMatchPath(route.Spec.GrpcRoute.Match)
+		case route.Spec.TcpRoute != nil:
+			targets = route.Spec.TcpRoute.Action.WeightedTargets
+		default:
+			continue
+		}
+
+		routerName := aws.ToString(route.VirtualRouterName)
+		for _, action := range targets {
 			target := AppMeshVirtualServiceRoute{
-				Router:          aws.ToString(route.VirtualRouterName),
-				Path:            aws.ToString(route.Spec.HttpRoute.Match.Prefix),
+				Router:          routerName,
+				Path:            path,
 				DestinationNode: aws.ToString(action.VirtualNode),
 				Weight:          action.Weight,
 			}
-			routerName := aws.ToString(route.VirtualRouterName)
-			if targets, ok := routesholder[routerName]; ok {
-				routesholder[routerName] = append(targets, target)
-			} else {
-				values := []AppMeshVirtualServiceRoute{target}
-				routesholder[routerName] = values
-			}
-
+			routesholder[routerName] = append(routesholder[routerName], target)
 		}
 	}
 	return routesholder
+}
+
+// grpcMatchPath builds a path string from a gRPC route match.
+func grpcMatchPath(match *types.GrpcRouteMatch) string {
+	if match == nil {
+		return ""
+	}
+	serviceName := aws.ToString(match.ServiceName)
+	methodName := aws.ToString(match.MethodName)
+	if serviceName != "" && methodName != "" {
+		return serviceName + "/" + methodName
+	}
+	if serviceName != "" {
+		return serviceName
+	}
+	return methodName
 }
 
 // GetAllAppMeshPaths retrieves all the connections in the mesh

--- a/helpers/appmesh.go
+++ b/helpers/appmesh.go
@@ -122,12 +122,9 @@ func getAllAppMeshVirtualServices(meshName *string, svc AppMeshAPI) []*types.Vir
 	return servicelist
 }
 
-// GetAllAppMeshPaths retrieves all the connections in the mesh
-func GetAllAppMeshPaths(meshName *string, svc AppMeshAPI) []AppMeshVirtualService {
-	var result []AppMeshVirtualService
+// buildRoutesHolder processes route data and builds a map of router name to routes.
+func buildRoutesHolder(routes []*types.RouteData) map[string][]AppMeshVirtualServiceRoute {
 	routesholder := make(map[string][]AppMeshVirtualServiceRoute)
-	services := getAllAppMeshVirtualServices(meshName, svc)
-	routes := getAppMeshRouteDescriptions(meshName, svc)
 	for _, route := range routes {
 		for _, action := range route.Spec.HttpRoute.Action.WeightedTargets {
 			target := AppMeshVirtualServiceRoute{
@@ -146,6 +143,15 @@ func GetAllAppMeshPaths(meshName *string, svc AppMeshAPI) []AppMeshVirtualServic
 
 		}
 	}
+	return routesholder
+}
+
+// GetAllAppMeshPaths retrieves all the connections in the mesh
+func GetAllAppMeshPaths(meshName *string, svc AppMeshAPI) []AppMeshVirtualService {
+	var result []AppMeshVirtualService
+	services := getAllAppMeshVirtualServices(meshName, svc)
+	routes := getAppMeshRouteDescriptions(meshName, svc)
+	routesholder := buildRoutesHolder(routes)
 	for _, service := range services {
 		switch v := service.Spec.Provider.(type) {
 		case *types.VirtualServiceProviderMemberVirtualRouter:

--- a/helpers/appmesh_test.go
+++ b/helpers/appmesh_test.go
@@ -336,7 +336,6 @@ func TestBuildRoutesHolder_NilRouteSpec_NoPanic(t *testing.T) {
 		t.Errorf("Expected 0 routes for empty-router, got %d", len(result["empty-router"]))
 	}
 }
-}
 
 func TestGetAllAppMeshRoutes_ListRoutesError_NoPanic(t *testing.T) {
 	mock := &mockAppMeshClient{

--- a/helpers/appmesh_test.go
+++ b/helpers/appmesh_test.go
@@ -128,6 +128,216 @@ func TestGetAllAppMeshRoutes_ListVirtualRoutersError_NoPanic(t *testing.T) {
 	}
 }
 
+// Test that buildRoutesHolder correctly processes HTTP routes
+func TestBuildRoutesHolder_HttpRoute(t *testing.T) {
+	routes := []*types.RouteData{
+		{
+			VirtualRouterName: aws.String("http-router"),
+			Spec: &types.RouteSpec{
+				HttpRoute: &types.HttpRoute{
+					Action: &types.HttpRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("node-a"), Weight: 100},
+						},
+					},
+					Match: &types.HttpRouteMatch{
+						Prefix: aws.String("/api"),
+					},
+				},
+			},
+		},
+	}
+
+	result := buildRoutesHolder(routes)
+
+	if len(result["http-router"]) != 1 {
+		t.Fatalf("Expected 1 route for http-router, got %d", len(result["http-router"]))
+	}
+	r := result["http-router"][0]
+	if r.Path != "/api" {
+		t.Errorf("Expected Path '/api', got '%s'", r.Path)
+	}
+	if r.DestinationNode != "node-a" {
+		t.Errorf("Expected DestinationNode 'node-a', got '%s'", r.DestinationNode)
+	}
+	if r.Weight != 100 {
+		t.Errorf("Expected Weight 100, got %d", r.Weight)
+	}
+}
+
+// Regression test: GRPC routes must not panic (bug T-345)
+func TestBuildRoutesHolder_GrpcRoute_NoPanic(t *testing.T) {
+	routes := []*types.RouteData{
+		{
+			VirtualRouterName: aws.String("grpc-router"),
+			Spec: &types.RouteSpec{
+				GrpcRoute: &types.GrpcRoute{
+					Action: &types.GrpcRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("grpc-node"), Weight: 50},
+						},
+					},
+					Match: &types.GrpcRouteMatch{
+						ServiceName: aws.String("my.grpc.Service"),
+						MethodName:  aws.String("DoStuff"),
+					},
+				},
+			},
+		},
+	}
+
+	result := buildRoutesHolder(routes)
+
+	if len(result["grpc-router"]) != 1 {
+		t.Fatalf("Expected 1 route for grpc-router, got %d", len(result["grpc-router"]))
+	}
+	r := result["grpc-router"][0]
+	if r.DestinationNode != "grpc-node" {
+		t.Errorf("Expected DestinationNode 'grpc-node', got '%s'", r.DestinationNode)
+	}
+	if r.Weight != 50 {
+		t.Errorf("Expected Weight 50, got %d", r.Weight)
+	}
+	if r.Path != "my.grpc.Service/DoStuff" {
+		t.Errorf("Expected Path 'my.grpc.Service/DoStuff', got '%s'", r.Path)
+	}
+}
+
+// Regression test: TCP routes must not panic (bug T-345)
+func TestBuildRoutesHolder_TcpRoute_NoPanic(t *testing.T) {
+	routes := []*types.RouteData{
+		{
+			VirtualRouterName: aws.String("tcp-router"),
+			Spec: &types.RouteSpec{
+				TcpRoute: &types.TcpRoute{
+					Action: &types.TcpRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("tcp-node"), Weight: 100},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := buildRoutesHolder(routes)
+
+	if len(result["tcp-router"]) != 1 {
+		t.Fatalf("Expected 1 route for tcp-router, got %d", len(result["tcp-router"]))
+	}
+	r := result["tcp-router"][0]
+	if r.DestinationNode != "tcp-node" {
+		t.Errorf("Expected DestinationNode 'tcp-node', got '%s'", r.DestinationNode)
+	}
+}
+
+// Regression test: HTTP2 routes must not panic (bug T-345)
+func TestBuildRoutesHolder_Http2Route_NoPanic(t *testing.T) {
+	routes := []*types.RouteData{
+		{
+			VirtualRouterName: aws.String("http2-router"),
+			Spec: &types.RouteSpec{
+				Http2Route: &types.HttpRoute{
+					Action: &types.HttpRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("http2-node"), Weight: 75},
+						},
+					},
+					Match: &types.HttpRouteMatch{
+						Prefix: aws.String("/v2"),
+					},
+				},
+			},
+		},
+	}
+
+	result := buildRoutesHolder(routes)
+
+	if len(result["http2-router"]) != 1 {
+		t.Fatalf("Expected 1 route for http2-router, got %d", len(result["http2-router"]))
+	}
+	r := result["http2-router"][0]
+	if r.Path != "/v2" {
+		t.Errorf("Expected Path '/v2', got '%s'", r.Path)
+	}
+}
+
+// Regression test: mixed route types must all be processed (bug T-345)
+func TestBuildRoutesHolder_MixedRouteTypes(t *testing.T) {
+	routes := []*types.RouteData{
+		{
+			VirtualRouterName: aws.String("router-1"),
+			Spec: &types.RouteSpec{
+				HttpRoute: &types.HttpRoute{
+					Action: &types.HttpRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("http-node"), Weight: 100},
+						},
+					},
+					Match: &types.HttpRouteMatch{Prefix: aws.String("/http")},
+				},
+			},
+		},
+		{
+			VirtualRouterName: aws.String("router-2"),
+			Spec: &types.RouteSpec{
+				GrpcRoute: &types.GrpcRoute{
+					Action: &types.GrpcRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("grpc-node"), Weight: 100},
+						},
+					},
+					Match: &types.GrpcRouteMatch{ServiceName: aws.String("svc")},
+				},
+			},
+		},
+		{
+			VirtualRouterName: aws.String("router-3"),
+			Spec: &types.RouteSpec{
+				TcpRoute: &types.TcpRoute{
+					Action: &types.TcpRouteAction{
+						WeightedTargets: []types.WeightedTarget{
+							{VirtualNode: aws.String("tcp-node"), Weight: 100},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := buildRoutesHolder(routes)
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 routers in result, got %d", len(result))
+	}
+	if len(result["router-1"]) != 1 {
+		t.Errorf("Expected 1 route for router-1, got %d", len(result["router-1"]))
+	}
+	if len(result["router-2"]) != 1 {
+		t.Errorf("Expected 1 route for router-2, got %d", len(result["router-2"]))
+	}
+	if len(result["router-3"]) != 1 {
+		t.Errorf("Expected 1 route for router-3, got %d", len(result["router-3"]))
+	}
+}
+
+// Regression test: route with nil spec fields must not panic (bug T-345)
+func TestBuildRoutesHolder_NilRouteSpec_NoPanic(t *testing.T) {
+	routes := []*types.RouteData{
+		{
+			VirtualRouterName: aws.String("empty-router"),
+			Spec:              &types.RouteSpec{},
+		},
+	}
+
+	result := buildRoutesHolder(routes)
+
+	if len(result["empty-router"]) != 0 {
+		t.Errorf("Expected 0 routes for empty-router, got %d", len(result["empty-router"]))
+	}
+}
+}
+
 func TestGetAllAppMeshRoutes_ListRoutesError_NoPanic(t *testing.T) {
 	mock := &mockAppMeshClient{
 		listVirtualRoutersFunc: func(_ context.Context, _ *appmesh.ListVirtualRoutersInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualRoutersOutput, error) {

--- a/specs/bugfixes/non-http-appmesh-routes/report.md
+++ b/specs/bugfixes/non-http-appmesh-routes/report.md
@@ -1,0 +1,74 @@
+# Bugfix Report: non-http-appmesh-routes
+
+**Date:** 2026-03-13
+**Status:** Fixed
+
+## Description of the Issue
+
+`GetAllAppMeshPaths` in `helpers/appmesh.go` unconditionally dereferences `route.Spec.HttpRoute` when iterating over routes. AWS App Mesh supports four route types: HTTP, HTTP/2, gRPC, and TCP. When a route uses gRPC, TCP, or HTTP/2 (via `Http2Route`), the `HttpRoute` field is nil, causing a nil pointer dereference panic.
+
+**Reproduction steps:**
+1. Configure an App Mesh with a virtual router that has gRPC or TCP routes
+2. Run any awstools command that calls `GetAllAppMeshPaths` (e.g., appmesh connections/paths)
+3. Observe panic: `runtime error: invalid memory address or nil pointer dereference`
+
+**Impact:** Any mesh containing non-HTTP routes causes a crash, making the tool unusable for mixed-protocol meshes.
+
+## Investigation Summary
+
+- **Symptoms examined:** Nil pointer dereference at `route.Spec.HttpRoute.Action.WeightedTargets`
+- **Code inspected:** `helpers/appmesh.go` lines 108-130, AWS SDK types for `RouteSpec`
+- **Hypotheses tested:** Confirmed that `RouteSpec` has four optional route fields (`HttpRoute`, `Http2Route`, `GrpcRoute`, `TcpRoute`), all of which contain `WeightedTargets` in their action
+
+## Discovered Root Cause
+
+**Defect type:** Missing nil check / incomplete type handling
+
+**Why it occurred:** The original implementation only considered HTTP routes. When App Mesh added gRPC, TCP, and HTTP/2 route types, the code was not updated to handle them.
+
+**Contributing factors:** All route types share similar structure (Action with WeightedTargets) but are separate fields on `RouteSpec`, making it easy to assume only one exists.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/appmesh.go` - Extracted route processing into `buildRoutesHolder` function that branches on route type (HttpRoute, Http2Route, GrpcRoute, TcpRoute), with nil checks for each. Routes with no recognized type are skipped.
+
+**Approach rationale:** Handle all four route types since they all have WeightedTargets. For the Path field: HTTP/HTTP2 use Match.Prefix, gRPC uses ServiceName/MethodName, TCP uses empty string (no path concept).
+
+**Alternatives considered:**
+- Skip non-HTTP routes entirely — rejected because it loses useful routing information
+- Use a single interface-based approach — rejected because SDK types don't share a common interface
+
+## Regression Test
+
+**Test file:** `helpers/appmesh_test.go`
+**Test names:** `TestBuildRoutesHolder_GrpcRoute_NoPanic`, `TestBuildRoutesHolder_TcpRoute_NoPanic`, `TestBuildRoutesHolder_Http2Route_NoPanic`, `TestBuildRoutesHolder_MixedRouteTypes`, `TestBuildRoutesHolder_NilRouteSpec_NoPanic`
+
+**What it verifies:** Non-HTTP route types are processed without panic and produce correct routing entries.
+
+**Run command:** `go test ./helpers/ -run TestBuildRoutesHolder -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/appmesh.go` | Extract `buildRoutesHolder`, handle all route types with nil checks |
+| `helpers/appmesh_test.go` | Add regression tests for all route types |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When handling AWS SDK union-like structs with multiple optional fields, always check which field is populated
+- Add tests for each variant when processing polymorphic AWS resource types
+- Consider adding nil-safety helper functions for common AWS type patterns
+
+## Related
+
+- Transit ticket: T-345


### PR DESCRIPTION
## Bug

`GetAllAppMeshPaths` panics with a nil pointer dereference when processing gRPC, TCP, or HTTP/2 App Mesh routes because it unconditionally accesses `route.Spec.HttpRoute`.

## Root Cause

`RouteSpec` has four optional route type fields (`HttpRoute`, `Http2Route`, `GrpcRoute`, `TcpRoute`). The code only handled `HttpRoute`, causing a nil deref for any other type.

## Fix

- Extracted route processing into `buildRoutesHolder` function
- Added a `switch` that branches on which route type is populated
- HTTP/HTTP2: extract targets and path from `Match.Prefix`
- gRPC: extract targets and path from `ServiceName/MethodName`
- TCP: extract targets with empty path (TCP has no match path)
- Unknown/empty specs: skip gracefully
- Added `grpcMatchPath` helper for building gRPC match strings

## Tests

Added 6 regression tests covering HTTP, gRPC, TCP, HTTP/2, mixed, and empty route specs. Full test suite passes.

## Report

See `specs/bugfixes/non-http-appmesh-routes/report.md` for full investigation details.

Fixes T-345