### PR TITLE
[feat]: add code quality and development Makefile targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Makefile targets for code quality: `fmt`, `vet`, `modernize`, `check`, `security-scan`
+- Makefile targets for testing: `test-verbose`, `test-coverage`
+- Makefile targets for dependency management: `deps-tidy`, `deps-update`
+- Makefile target `install` for installing the application
+- Organized help output with categorized sections
+
+### Changed
+
+- `clean` target now also removes coverage artifacts
+- Formatting fix in `helpers/organizations_test.go`
+
 ## [1.2.0] - 2025-01-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Declare all phony targets
-.PHONY: all build deps test local clean compile shapes go-functions help
+.PHONY: all build test test-verbose test-coverage lint fmt vet modernize check \
+	clean compile install deps-tidy deps-update security-scan \
+	shapes go-functions help
 
 # Default target
 all: build
@@ -7,14 +9,33 @@ all: build
 # Help target
 help:
 	@echo "Available targets:"
-	@echo "  all         - Build the project (same as build)"
-	@echo "  build       - Run tests, clean, and compile"
-	@echo "  test        - Run tests"
-	@echo "  lint        - Run linters"
-	@echo "  clean       - Clean build artifacts"
-	@echo "  compile     - Compile the binary"
-	@echo "  shapes      - Convert draw.io shapes"
-	@echo "  go-functions - List all Go functions in the project"
+	@echo ""
+	@echo "Build targets:"
+	@echo "  build                 - Run tests, clean, and compile"
+	@echo "  compile               - Compile the binary"
+	@echo "  install               - Install the application"
+	@echo "  clean                 - Clean build artifacts and coverage files"
+	@echo ""
+	@echo "Testing targets:"
+	@echo "  test                  - Run Go unit tests"
+	@echo "  test-verbose          - Run tests with verbose output and coverage"
+	@echo "  test-coverage         - Generate test coverage report (HTML)"
+	@echo ""
+	@echo "Code quality targets:"
+	@echo "  fmt                   - Format Go code"
+	@echo "  vet                   - Run go vet for static analysis"
+	@echo "  lint                  - Run linter (requires golangci-lint)"
+	@echo "  modernize             - Update code to modern Go patterns (requires modernize)"
+	@echo "  check                 - Run full validation suite (fmt, vet, lint, test)"
+	@echo "  security-scan         - Run security analysis (requires gosec)"
+	@echo ""
+	@echo "Dependency management:"
+	@echo "  deps-tidy             - Clean up go.mod and go.sum"
+	@echo "  deps-update           - Update dependencies to latest versions"
+	@echo ""
+	@echo "Development utilities:"
+	@echo "  go-functions          - List all Go functions in the project"
+	@echo "  shapes                - Convert draw.io shapes"
 
 # Build targets
 build: test clean compile
@@ -22,18 +43,55 @@ build: test clean compile
 compile:
 	CGO_ENABLED=0 go build -ldflags "-w -s" -buildvcs=false
 
-# Testing and linting
+install:
+	go install .
+
+# Testing
 test:
 	@echo "Running tests..."
 	CGO_ENABLED=0 go test ./...
+
+test-verbose:
+	CGO_ENABLED=0 go test -v -cover ./...
+
+test-coverage:
+	CGO_ENABLED=0 go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report generated at coverage.html"
+
+# Code quality
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
 
 lint:
 	@echo "Running linters..."
 	golangci-lint run --timeout 5m
 
+modernize:
+	@which modernize > /dev/null || (echo "modernize not installed. Run: go install github.com/gaissmai/modernize@latest" && exit 1)
+	modernize -fix -test ./...
+
+check: fmt vet lint test
+
+security-scan:
+	@which gosec > /dev/null || (echo "gosec not installed. Run: go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest" && exit 1)
+	gosec ./...
+
+# Dependency management
+deps-tidy:
+	go mod tidy
+
+deps-update:
+	go get -u ./...
+	go mod tidy
+
 # Utility targets
 clean:
 	go clean
+	rm -f coverage.out coverage.html
 
 go-functions:
 	@echo "Finding all functions in the project..."

--- a/helpers/organizations_test.go
+++ b/helpers/organizations_test.go
@@ -36,7 +36,6 @@ func (m *mockOrganizationsClient) DescribeAccount(ctx context.Context, params *o
 	return m.DescribeAccountFunc(ctx, params, optFns...)
 }
 
-
 func TestOrganizationEntry_Struct(t *testing.T) {
 	entry := OrganizationEntry{
 		ID:       "r-1234567890",


### PR DESCRIPTION
Add targets from the fog project's Makefile that improve the development
workflow: fmt, vet, modernize, check, security-scan, test-verbose,
test-coverage, deps-tidy, deps-update, and install. Organize help output
into categorized sections for easier discovery.
