### PR TITLE
Fix T-510: Subnet route-table lookup for main route tables

### DIFF
--- a/cmd/vpcoverview.go
+++ b/cmd/vpcoverview.go
@@ -79,7 +79,7 @@ func vpcOverview(_ *cobra.Command, _ []string) {
 			subnetDisplay := getResourceDisplayName(subnet.ID, subnet.Tags)
 
 			// Get route table information for this subnet
-			routeTable := helpers.GetSubnetRouteTable(subnet.ID, routeTables)
+			routeTable := helpers.GetSubnetRouteTable(subnet.ID, subnet.VPCId, routeTables)
 			routeTableName, routes := helpers.FormatRouteTableInfo(routeTable)
 
 			content := make(map[string]any)

--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -1,0 +1,26 @@
+# EC2 Helpers
+
+## Route Table Lookup
+
+`GetSubnetRouteTable(subnetID, vpcID, routeTables)` in `helpers/ec2.go` resolves the route table for a subnet. It first checks for an explicit subnet association, then falls back to the VPC's main route table. The `vpcID` parameter is required to correctly scope the main route table fallback when multiple VPCs share the route table list.
+
+Callers:
+- `isPublicSubnet` (internal, used by `GetVPCUsageOverview`)
+- `getRouteTableInfo` (internal, used by `FindIPAddressDetails` / IP finder)
+- `cmd/vpcoverview.go` (VPC overview command)
+
+All callers must pass the subnet's VPC ID. The VPC ID is available from:
+- `*subnet.VpcId` (AWS SDK subnet type)
+- `subnet.VPCId` (SubnetUsageInfo struct)
+- `eni.VpcId` (ENI struct)
+
+## Key Types
+
+- `SubnetUsageInfo` — used by VPC overview, includes `VPCId` field
+- `IPFinderResult` — used by IP finder, includes VPC/Subnet/RouteTable info
+- `RouteTableInfo` — simplified route table data for output
+
+## AWS SDK Notes
+
+- `types.RouteTable` has a `VpcId` field — always use it when filtering by VPC
+- `DescribeRouteTables` without filters returns route tables across all VPCs

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -727,7 +727,7 @@ func GetVPCUsageOverview(svc *ec2.Client) VPCOverview {
 					VPCId:        *subnet.VpcId,
 					VPCName:      vpcInfo.Name,
 					Tags:         subnet.Tags,
-					IsPublic:     isPublicSubnet(*subnet.SubnetId, routeTables),
+					IsPublic:     isPublicSubnet(*subnet.SubnetId, *subnet.VpcId, routeTables),
 					TotalIPs:     totalIPs,
 					AvailableIPs: availableIPs,
 					UsedIPs:      usedIPs,
@@ -794,8 +794,10 @@ func retrieveRouteTables(svc *ec2.Client) []types.RouteTable {
 	return resp.RouteTables
 }
 
-// GetSubnetRouteTable finds the route table associated with a specific subnet
-func GetSubnetRouteTable(subnetID string, routeTables []types.RouteTable) *types.RouteTable {
+// GetSubnetRouteTable finds the route table associated with a specific subnet.
+// The vpcID parameter constrains the main route table fallback to the correct VPC,
+// preventing cross-VPC misassignment when multiple VPCs share the route table list.
+func GetSubnetRouteTable(subnetID string, vpcID string, routeTables []types.RouteTable) *types.RouteTable {
 	// First check for explicit subnet associations
 	for _, routeTable := range routeTables {
 		for _, association := range routeTable.Associations {
@@ -805,8 +807,11 @@ func GetSubnetRouteTable(subnetID string, routeTables []types.RouteTable) *types
 		}
 	}
 
-	// If no explicit association found, use the main route table
+	// If no explicit association found, use the main route table for this VPC
 	for _, routeTable := range routeTables {
+		if routeTable.VpcId == nil || *routeTable.VpcId != vpcID {
+			continue
+		}
 		for _, association := range routeTable.Associations {
 			if association.Main != nil && *association.Main {
 				return &routeTable
@@ -862,8 +867,8 @@ func FormatRouteTableInfo(routeTable *types.RouteTable) (string, []string) {
 }
 
 // isPublicSubnet determines if a subnet is public based on route table analysis
-func isPublicSubnet(subnetID string, routeTables []types.RouteTable) bool {
-	routeTable := GetSubnetRouteTable(subnetID, routeTables)
+func isPublicSubnet(subnetID string, vpcID string, routeTables []types.RouteTable) bool {
+	routeTable := GetSubnetRouteTable(subnetID, vpcID, routeTables)
 	if routeTable == nil {
 		return false
 	}
@@ -1552,7 +1557,7 @@ func FindIPAddressDetails(svc *ec2.Client, ipAddress string) IPFinderResult {
 	result.VPC = getVPCInfo(svc, aws.ToString(eni.VpcId))
 	result.Subnet = getSubnetInfo(svc, aws.ToString(eni.SubnetId))
 	result.SecurityGroups = getSecurityGroupInfo(svc, eni.Groups)
-	result.RouteTable = getRouteTableInfo(svc, aws.ToString(eni.SubnetId))
+	result.RouteTable = getRouteTableInfo(svc, aws.ToString(eni.SubnetId), aws.ToString(eni.VpcId))
 
 	return result
 }
@@ -1712,7 +1717,7 @@ func getSecurityGroupInfo(svc *ec2.Client, groups []types.GroupIdentifier) []Sec
 }
 
 // getRouteTableInfo retrieves route table information for a subnet
-func getRouteTableInfo(svc *ec2.Client, subnetID string) RouteTableInfo {
+func getRouteTableInfo(svc *ec2.Client, subnetID string, vpcID string) RouteTableInfo {
 	if subnetID == "" {
 		return RouteTableInfo{}
 	}
@@ -1721,7 +1726,7 @@ func getRouteTableInfo(svc *ec2.Client, subnetID string) RouteTableInfo {
 	routeTables := retrieveRouteTables(svc)
 
 	// Find the route table associated with this subnet
-	routeTable := GetSubnetRouteTable(subnetID, routeTables)
+	routeTable := GetSubnetRouteTable(subnetID, vpcID, routeTables)
 	if routeTable == nil {
 		return RouteTableInfo{
 			ID:     "No route table",

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -1355,3 +1355,118 @@ func BenchmarkENILookupCachePerformance(b *testing.B) {
 		}
 	})
 }
+
+func TestGetSubnetRouteTable_ExplicitAssociation(t *testing.T) {
+	routeTables := []types.RouteTable{
+		{
+			RouteTableId: aws.String("rtb-main-vpc1"),
+			VpcId:        aws.String("vpc-111"),
+			Associations: []types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+		},
+		{
+			RouteTableId: aws.String("rtb-explicit"),
+			VpcId:        aws.String("vpc-111"),
+			Associations: []types.RouteTableAssociation{
+				{SubnetId: aws.String("subnet-aaa")},
+			},
+		},
+	}
+
+	rt := GetSubnetRouteTable("subnet-aaa", "vpc-111", routeTables)
+	if rt == nil {
+		t.Fatal("expected route table, got nil")
+	}
+	if *rt.RouteTableId != "rtb-explicit" {
+		t.Errorf("expected rtb-explicit, got %s", *rt.RouteTableId)
+	}
+}
+
+func TestGetSubnetRouteTable_MainRouteTableMatchesVPC(t *testing.T) {
+	// Two VPCs, each with its own main route table.
+	// subnet-bbb belongs to vpc-222 and has no explicit association.
+	// The function must return vpc-222's main route table, not vpc-111's.
+	routeTables := []types.RouteTable{
+		{
+			RouteTableId: aws.String("rtb-main-vpc1"),
+			VpcId:        aws.String("vpc-111"),
+			Associations: []types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+		},
+		{
+			RouteTableId: aws.String("rtb-main-vpc2"),
+			VpcId:        aws.String("vpc-222"),
+			Associations: []types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+		},
+	}
+
+	rt := GetSubnetRouteTable("subnet-bbb", "vpc-222", routeTables)
+	if rt == nil {
+		t.Fatal("expected route table, got nil")
+	}
+	if *rt.RouteTableId != "rtb-main-vpc2" {
+		t.Errorf("expected rtb-main-vpc2 (vpc-222's main RT), got %s", *rt.RouteTableId)
+	}
+}
+
+func TestGetSubnetRouteTable_NoMatchReturnsNil(t *testing.T) {
+	routeTables := []types.RouteTable{
+		{
+			RouteTableId: aws.String("rtb-main-vpc1"),
+			VpcId:        aws.String("vpc-111"),
+			Associations: []types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+		},
+	}
+
+	// Subnet belongs to vpc-999 which has no route tables at all
+	rt := GetSubnetRouteTable("subnet-zzz", "vpc-999", routeTables)
+	if rt != nil {
+		t.Errorf("expected nil for unknown VPC, got %s", *rt.RouteTableId)
+	}
+}
+
+func TestIsPublicSubnet_UsesCorrectVPCMainRouteTable(t *testing.T) {
+	// vpc-111 has a public main route table (with igw)
+	// vpc-222 has a private main route table (no igw)
+	// subnet-private belongs to vpc-222 with no explicit association
+	// Without the VPC constraint, it would incorrectly pick vpc-111's main RT and report public
+	routeTables := []types.RouteTable{
+		{
+			RouteTableId: aws.String("rtb-main-vpc1"),
+			VpcId:        aws.String("vpc-111"),
+			Associations: []types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+			Routes: []types.Route{
+				{
+					DestinationCidrBlock: aws.String("0.0.0.0/0"),
+					GatewayId:            aws.String("igw-12345678"),
+				},
+			},
+		},
+		{
+			RouteTableId: aws.String("rtb-main-vpc2"),
+			VpcId:        aws.String("vpc-222"),
+			Associations: []types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+			Routes: []types.Route{
+				{
+					DestinationCidrBlock: aws.String("10.0.0.0/16"),
+					GatewayId:            aws.String("local"),
+				},
+			},
+		},
+	}
+
+	result := isPublicSubnet("subnet-private", "vpc-222", routeTables)
+	if result {
+		t.Error("subnet in vpc-222 should be private, but was classified as public (wrong main route table used)")
+	}
+}

--- a/specs/bugfixes/subnet-route-table-lookup/report.md
+++ b/specs/bugfixes/subnet-route-table-lookup/report.md
@@ -75,9 +75,9 @@ The fallback branch in `GetSubnetRouteTable` (lines 808-815) iterates all route 
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
 
 ## Prevention
 

--- a/specs/bugfixes/subnet-route-table-lookup/report.md
+++ b/specs/bugfixes/subnet-route-table-lookup/report.md
@@ -1,0 +1,91 @@
+# Bugfix Report: subnet-route-table-lookup
+
+**Date:** 2026-03-20
+**Status:** Fixed
+**Transit:** T-510
+
+## Description of the Issue
+
+`GetSubnetRouteTable` returns the wrong route table for subnets that have no explicit route table association. When falling back to a main route table, it picks the first main route table found across all VPCs rather than constraining the lookup to the subnet's own VPC. This causes incorrect public/private classification and wrong route table output in VPC overview and IP finder commands.
+
+**Reproduction steps:**
+1. Have two or more VPCs in the same region
+2. Have a subnet in VPC B with no explicit route table association (uses the VPC's default main route table)
+3. VPC A's main route table appears first in the DescribeRouteTables response
+4. Run `awstools vpc overview` or `awstools vpc ipfinder`
+5. The subnet in VPC B is assigned VPC A's main route table
+
+**Impact:** Any account with multiple VPCs where subnets rely on the default main route table will see incorrect route table assignments. This can misclassify private subnets as public (or vice versa) and display wrong routes in the output.
+
+## Investigation Summary
+
+- **Symptoms examined:** `GetSubnetRouteTable` fallback path iterates all route tables and returns the first one with `Main == true`, ignoring VPC boundaries
+- **Code inspected:** `helpers/ec2.go` (GetSubnetRouteTable, isPublicSubnet, getRouteTableInfo), `cmd/vpcoverview.go` (caller that has VPC context available)
+- **Hypotheses tested:** Confirmed that the `types.RouteTable` struct from the AWS SDK includes a `VpcId` field, so the information needed for correct filtering is already present in the data
+
+## Discovered Root Cause
+
+**Defect type:** Missing filter constraint
+
+The fallback branch in `GetSubnetRouteTable` (lines 808-815) iterates all route tables looking for any main route table without checking `routeTable.VpcId`. Each VPC has exactly one main route table, so the function should match only the main route table whose VPC ID matches the subnet's VPC.
+
+**Why it occurred:** The original implementation assumed the route tables list would only contain route tables from a single VPC, or that the first main route table encountered would always be the correct one.
+
+**Contributing factors:**
+- The function signature only accepted `subnetID` and had no way to know which VPC the subnet belongs to
+- No unit tests existed for this function to catch cross-VPC lookup errors
+- In single-VPC accounts, the bug is invisible
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/ec2.go` — Added `vpcID` parameter to `GetSubnetRouteTable` and `isPublicSubnet`; the main route table fallback now checks `routeTable.VpcId` matches the provided VPC ID
+- `helpers/ec2.go` — Updated `getRouteTableInfo` to accept and pass `vpcID`
+- `helpers/ec2.go` — Updated `isPublicSubnet` call in `GetVPCUsageOverview` to pass the VPC ID
+- `helpers/ec2.go` — Updated `getRouteTableInfo` call in `FindIPAddressDetails` to pass the VPC ID
+- `cmd/vpcoverview.go` — Updated `GetSubnetRouteTable` call to pass `subnet.VPCId`
+
+**Approach rationale:** Adding a `vpcID` parameter is the minimal change that fixes the root cause. The VPC ID is already available at every call site (from the VPC iteration context, from subnet structs, or from ENI data). No new API calls are needed.
+
+**Alternatives considered:**
+- Pre-filtering route tables per VPC before passing to the function — rejected because it would require refactoring all callers and adds unnecessary allocation
+- Building a subnet-to-VPC lookup map — rejected because the VPC ID is already known at each call site
+
+## Regression Test
+
+**Test file:** `helpers/ec2_test.go`
+**Test names:**
+- `TestGetSubnetRouteTable_ExplicitAssociation` — verifies explicit subnet association still works
+- `TestGetSubnetRouteTable_MainRouteTableMatchesVPC` — verifies main RT fallback selects the correct VPC's table
+- `TestGetSubnetRouteTable_NoMatchReturnsNil` — verifies nil is returned when no RT exists for the VPC
+- `TestIsPublicSubnet_UsesCorrectVPCMainRouteTable` — verifies public/private classification uses the correct VPC's main RT
+
+**What it verifies:** That the main route table fallback constrains results to the subnet's VPC, preventing cross-VPC misassignment.
+
+**Run command:** `go test ./helpers/ -run "TestGetSubnetRouteTable|TestIsPublicSubnet"`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/ec2.go` | Add `vpcID` parameter to `GetSubnetRouteTable`, `isPublicSubnet`, and `getRouteTableInfo`; filter main RT by VPC |
+| `helpers/ec2_test.go` | Add 4 regression tests |
+| `cmd/vpcoverview.go` | Pass VPC ID to `GetSubnetRouteTable` |
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When looking up VPC-scoped resources, always constrain queries by VPC ID
+- Add unit tests for functions that operate on collections of cross-VPC resources
+- Consider using typed VPC-scoped wrapper types to make VPC boundary violations a compile-time error
+
+## Related
+
+- Transit ticket: T-510


### PR DESCRIPTION
## Summary

- `GetSubnetRouteTable` returned the first main route table across all VPCs when a subnet had no explicit association, causing cross-VPC misassignment
- Added `vpcID` parameter to constrain the main route table fallback to the subnet's own VPC
- Updated all callers (`isPublicSubnet`, `getRouteTableInfo`, `cmd/vpcoverview.go`) to pass the VPC ID
- Added 4 regression tests covering explicit association, VPC-scoped main RT fallback, no-match nil return, and public/private classification

## Root Cause

The fallback path in `GetSubnetRouteTable` iterated all route tables and returned the first one with `Main == true`, without checking `routeTable.VpcId`. Each VPC has its own main route table, so with multiple VPCs the function could return the wrong VPC's main route table.

## Test plan

- [x] Regression tests pass (`TestGetSubnetRouteTable_*`, `TestIsPublicSubnet_*`)
- [x] Full test suite passes (`go test ./...`)
- [x] Linting passes (`make test`)

Report: `specs/bugfixes/subnet-route-table-lookup/report.md`