### PR TITLE
Fix T-538: Profile generator ignores output file for conflict detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Profile generator now reads from `--output-file` for conflict detection, template validation, and profile generation instead of always reading the default AWS config file (T-538)
+
 ### Added
 
 - Makefile targets for code quality: `fmt`, `vet`, `modernize`, `check`, `security-scan`

--- a/helpers/profile_generator.go
+++ b/helpers/profile_generator.go
@@ -191,8 +191,8 @@ func (pg *ProfileGenerator) initializeConflictDetector() error {
 		return nil // Already initialized
 	}
 
-	// Load AWS config file
-	configFile, err := LoadAWSConfigFile("")
+	// Load AWS config file from output file path (falls back to default when empty)
+	configFile, err := LoadAWSConfigFile(pg.outputFile)
 	if err != nil {
 		return NewFileSystemError("failed to load AWS config file", err)
 	}
@@ -211,8 +211,8 @@ func (pg *ProfileGenerator) initializeConflictDetector() error {
 
 // ValidateTemplateProfile validates the template profile configuration
 func (pg *ProfileGenerator) ValidateTemplateProfile() (*TemplateProfile, error) {
-	// Load AWS config file
-	configFile, err := LoadAWSConfigFile("")
+	// Load AWS config file from output file path (falls back to default when empty)
+	configFile, err := LoadAWSConfigFile(pg.outputFile)
 	if err != nil {
 		return nil, NewFileSystemError("failed to load AWS config file", err)
 	}
@@ -276,8 +276,8 @@ func (pg *ProfileGenerator) GenerateProfiles(templateProfile *TemplateProfile, d
 		return nil, err
 	}
 
-	// Load existing profiles to detect conflicts
-	configFile, err := LoadAWSConfigFile("")
+	// Load existing profiles from output file to detect conflicts (falls back to default when empty)
+	configFile, err := LoadAWSConfigFile(pg.outputFile)
 	if err != nil {
 		return nil, NewFileSystemError("failed to load AWS config file", err)
 	}

--- a/helpers/profile_generator_test.go
+++ b/helpers/profile_generator_test.go
@@ -2670,6 +2670,196 @@ func TestProgressReporting(t *testing.T) {
 	}
 }
 
+// TestOutputFileUsedForConflictDetection verifies that when outputFile is set,
+// initializeConflictDetector reads from the output file rather than the default
+// config file. This is a regression test for T-538.
+func TestOutputFileUsedForConflictDetection(t *testing.T) {
+	// Create the "default" config file with NO conflicting profiles.
+	// Use a non-SSO profile so there's no SSO-based match.
+	defaultConfig := CreateTempConfigFile(t, `[profile some-unrelated-profile]
+region = us-west-2
+`)
+
+	// Create the output file with an existing SSO profile that WILL conflict
+	// via same-name detection.
+	outputDir := t.TempDir()
+	outputPath := filepath.Join(outputDir, "custom-config")
+	outputContent := `[profile test-account-PowerUserAccess]
+region = us-east-1
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = PowerUserAccess
+sso_session = test-session
+`
+	err := os.WriteFile(outputPath, []byte(outputContent), 0600)
+	require.NoError(t, err)
+
+	// Point AWS_CONFIG_FILE to the default config (no conflicting profiles)
+	oldValue := os.Getenv("AWS_CONFIG_FILE")
+	defer func() {
+		if oldValue != "" {
+			os.Setenv("AWS_CONFIG_FILE", oldValue)
+		} else {
+			os.Unsetenv("AWS_CONFIG_FILE")
+		}
+	}()
+	os.Setenv("AWS_CONFIG_FILE", defaultConfig)
+
+	// Create generator with outputFile pointing to the file WITH conflicts
+	pg, err := NewProfileGenerator("template-profile", "{account_name}-{role_name}", false, outputPath, ConflictPrompt, aws.Config{})
+	require.NoError(t, err)
+
+	// Initialize conflict detector — should read from outputPath, not defaultConfig
+	err = pg.initializeConflictDetector()
+	require.NoError(t, err)
+	require.NotNil(t, pg.conflictDetector)
+
+	// Detect conflicts with a role whose generated name matches a profile in the output file
+	conflicts, err := pg.conflictDetector.DetectConflicts([]DiscoveredRole{
+		{
+			AccountID:         "123456789012",
+			AccountName:       "test-account",
+			PermissionSetName: "PowerUserAccess",
+			RoleName:          "PowerUserAccess",
+		},
+	})
+	require.NoError(t, err)
+
+	// Should detect a conflict because the output file has "test-account-PowerUserAccess"
+	// If the bug is present (reading default config), this would find zero conflicts
+	assert.NotEmpty(t, conflicts, "conflict detector should read from output file, not default config")
+}
+
+// TestOutputFileUsedForValidateTemplateProfile verifies that when outputFile is set,
+// ValidateTemplateProfile reads from the output file rather than the default config.
+// This is a regression test for T-538.
+func TestOutputFileUsedForValidateTemplateProfile(t *testing.T) {
+	// Create the "default" config file with NO template profile
+	defaultConfig := CreateTempConfigFile(t, `[profile unrelated-profile]
+region = us-west-2
+`)
+
+	// Create the output file that HAS the template profile
+	outputDir := t.TempDir()
+	outputPath := filepath.Join(outputDir, "custom-config")
+	outputContent := `[profile my-sso-template]
+region = us-east-1
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = PowerUserAccess
+sso_session = test-session
+`
+	err := os.WriteFile(outputPath, []byte(outputContent), 0600)
+	require.NoError(t, err)
+
+	// Point AWS_CONFIG_FILE to default config (no template profile)
+	oldValue := os.Getenv("AWS_CONFIG_FILE")
+	defer func() {
+		if oldValue != "" {
+			os.Setenv("AWS_CONFIG_FILE", oldValue)
+		} else {
+			os.Unsetenv("AWS_CONFIG_FILE")
+		}
+	}()
+	os.Setenv("AWS_CONFIG_FILE", defaultConfig)
+
+	// Create generator with outputFile pointing to the file WITH template
+	pg, err := NewProfileGenerator("my-sso-template", "{account_name}-{role_name}", false, outputPath, ConflictPrompt, aws.Config{})
+	require.NoError(t, err)
+
+	// ValidateTemplateProfile should find the template in outputPath
+	// If the bug is present, this would fail with "template profile not found"
+	tp, err := pg.ValidateTemplateProfile()
+	assert.NoError(t, err, "ValidateTemplateProfile should read from output file, not default config")
+	if tp != nil {
+		assert.Equal(t, "my-sso-template", tp.Name)
+	}
+}
+
+// TestOutputFileUsedForGenerateProfiles verifies that when outputFile is set,
+// GenerateProfiles reads existing profiles from the output file for conflict
+// resolution rather than the default config. This is a regression test for T-538.
+func TestOutputFileUsedForGenerateProfiles(t *testing.T) {
+	// Create the "default" config file — no conflicting profiles here
+	defaultConfig := CreateTempConfigFile(t, `[profile template-profile]
+region = us-east-1
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = PowerUserAccess
+sso_session = test-session
+`)
+
+	// Create the output file with a profile name that would collide
+	outputDir := t.TempDir()
+	outputPath := filepath.Join(outputDir, "custom-config")
+	outputContent := `[profile template-profile]
+region = us-east-1
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = PowerUserAccess
+sso_session = test-session
+
+[profile test-account-PowerUserAccess]
+region = us-east-1
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_session = test-session
+`
+	err := os.WriteFile(outputPath, []byte(outputContent), 0600)
+	require.NoError(t, err)
+
+	// Point AWS_CONFIG_FILE to default config
+	oldValue := os.Getenv("AWS_CONFIG_FILE")
+	defer func() {
+		if oldValue != "" {
+			os.Setenv("AWS_CONFIG_FILE", oldValue)
+		} else {
+			os.Unsetenv("AWS_CONFIG_FILE")
+		}
+	}()
+	os.Setenv("AWS_CONFIG_FILE", defaultConfig)
+
+	templateProfile := &TemplateProfile{
+		Name:        "template-profile",
+		Region:      "us-east-1",
+		SSOStartURL: "https://example.awsapps.com/start",
+		SSORegion:   "us-east-1",
+		SSOSession:  "test-session",
+		IsSSO:       true,
+	}
+
+	discoveredRoles := []DiscoveredRole{
+		{
+			AccountID:         "123456789012",
+			AccountName:       "test-account",
+			AccountAlias:      "test-alias",
+			PermissionSetName: "PowerUserAccess",
+			RoleName:          "PowerUserAccess",
+		},
+	}
+
+	// Create generator with outputFile
+	pg, err := NewProfileGenerator("template-profile", "{account_name}-{role_name}", false, outputPath, ConflictPrompt, aws.Config{})
+	require.NoError(t, err)
+
+	// GenerateProfiles should detect the name collision in the output file
+	// and generate a suffixed name (e.g., "test-account-PowerUserAccess-1")
+	profiles, err := pg.GenerateProfiles(templateProfile, discoveredRoles)
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+
+	// The profile name should be different from "test-account-PowerUserAccess"
+	// because that name already exists in the output file.
+	// If the bug is present, it would read the default config (no collision)
+	// and return "test-account-PowerUserAccess" without a suffix.
+	assert.NotEqual(t, "test-account-PowerUserAccess", profiles[0].Name,
+		"GenerateProfiles should detect name collisions in the output file, not default config")
+}
+
 // Helper function for testing
 func contains(slice []string, item string) bool {
 	return slices.Contains(slice, item)

--- a/specs/bugfixes/output-file-conflict-detection/report.md
+++ b/specs/bugfixes/output-file-conflict-detection/report.md
@@ -60,9 +60,9 @@ When `--output-file` is specified for the profile generator, three methods (`Val
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
 
 **Manual verification:**
 - Confirmed `AppendToConfig` already uses `pg.outputFile` correctly, establishing the intended pattern

--- a/specs/bugfixes/output-file-conflict-detection/report.md
+++ b/specs/bugfixes/output-file-conflict-detection/report.md
@@ -1,0 +1,78 @@
+# Bugfix Report: Profile Generator Ignores Output File for Conflict Detection
+
+**Date:** 2026-03-20
+**Status:** Fixed
+
+## Description of the Issue
+
+When `--output-file` is specified for the profile generator, three methods (`ValidateTemplateProfile`, `GenerateProfiles`, and `initializeConflictDetector`) still read the default AWS config file (via `AWS_CONFIG_FILE` env var or `~/.aws/config`) instead of the specified output file. This causes conflict detection to run against the wrong file, potentially missing conflicts that exist in the actual output file or reporting false conflicts from the default config.
+
+**Reproduction steps:**
+1. Create an output file at a custom path with existing profiles
+2. Run `awstools sso profile-generator --template my-profile --output-file /path/to/custom-config`
+3. Observe that conflict detection checks the default AWS config file instead of the custom output file
+
+**Impact:** Users writing to a custom output file may silently overwrite existing profiles in that file, or receive incorrect conflict reports based on profiles in their default config that are irrelevant to the output file.
+
+## Investigation Summary
+
+- **Symptoms examined:** `LoadAWSConfigFile("")` called with empty string in three methods despite `pg.outputFile` being available
+- **Code inspected:** `helpers/profile_generator.go` — `initializeConflictDetector()` (line 195), `ValidateTemplateProfile()` (line 215), `GenerateProfiles()` (line 280)
+- **Hypotheses tested:** Confirmed that `AppendToConfig()` already correctly uses `pg.outputFile`, establishing the intended pattern
+
+## Discovered Root Cause
+
+**Defect type:** Hardcoded argument error
+
+**Why it occurred:** The three methods were written to call `LoadAWSConfigFile("")` (empty string), which falls back to the default config file resolution. The `outputFile` field was added to `ProfileGenerator` but these call sites were not updated to use it.
+
+**Contributing factors:** The `AppendToConfig` method was correctly implemented with `pg.outputFile`, but this pattern was not applied consistently to the other three methods that also need to read the same file being written to.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/profile_generator.go:195` - Changed `LoadAWSConfigFile("")` to `LoadAWSConfigFile(pg.outputFile)` in `initializeConflictDetector()`
+- `helpers/profile_generator.go:215` - Changed `LoadAWSConfigFile("")` to `LoadAWSConfigFile(pg.outputFile)` in `ValidateTemplateProfile()`
+- `helpers/profile_generator.go:280` - Changed `LoadAWSConfigFile("")` to `LoadAWSConfigFile(pg.outputFile)` in `GenerateProfiles()`
+
+**Approach rationale:** When `pg.outputFile` is empty, `LoadAWSConfigFile("")` falls back to the default config file anyway, so this change is fully backward-compatible. When `pg.outputFile` is set, all methods now consistently read from the same file that `AppendToConfig` writes to.
+
+**Alternatives considered:**
+- Adding a separate source file parameter for template validation — rejected because the output file should be self-consistent (contain the template if it contains profiles)
+- Caching the loaded config across methods — out of scope for this bugfix; the current approach matches the existing pattern
+
+## Regression Test
+
+**Test file:** `helpers/profile_generator_test.go`
+**Test names:** `TestOutputFileUsedForConflictDetection`, `TestOutputFileUsedForValidateTemplateProfile`, `TestOutputFileUsedForGenerateProfiles`
+
+**What it verifies:** Each test creates a default config and a separate output file with different content, then verifies the respective method reads from the output file (not the default config).
+
+**Run command:** `go test ./helpers/ -run "TestOutputFileUsedFor" -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/profile_generator.go` | Pass `pg.outputFile` instead of `""` to `LoadAWSConfigFile` in three methods |
+| `helpers/profile_generator_test.go` | Add three regression tests verifying output file is used |
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- Confirmed `AppendToConfig` already uses `pg.outputFile` correctly, establishing the intended pattern
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding a field to a struct that affects file path resolution, audit all call sites that resolve that path
+- Consider adding a helper method on `ProfileGenerator` that encapsulates config file loading (e.g., `pg.loadConfigFile()`) to centralize the file path logic
+
+## Related
+
+- Transit ticket: T-538


### PR DESCRIPTION
## Summary

- Fixed three methods in `ProfileGenerator` that called `LoadAWSConfigFile("")` instead of `LoadAWSConfigFile(pg.outputFile)`, causing conflict detection, template validation, and profile generation to always read the default AWS config file even when `--output-file` was specified
- Added three regression tests that verify each method reads from the output file when set
- The fix is backward-compatible: when `outputFile` is empty, `LoadAWSConfigFile` falls back to the default config resolution

## Test plan

- [x] Three new regression tests pass (`TestOutputFileUsedForConflictDetection`, `TestOutputFileUsedForValidateTemplateProfile`, `TestOutputFileUsedForGenerateProfiles`)
- [x] Full test suite passes (`go test ./...`)
- [x] Linting and formatting pass (`make test`)