### PR TITLE
Fix T-479: Add Pagination for SSO Admin Listing Helpers

### DIFF
--- a/cmd/ssodangling.go
+++ b/cmd/ssodangling.go
@@ -24,7 +24,10 @@ func init() {
 func ssoDangling(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "Dangling Permission Sets"
-	ssoInstance := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	ssoInstance, err := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	if err != nil {
+		panic(err)
+	}
 	keys := []string{"PermissionSet", "Arn", "ManagedPolicies", "InlinePolicy"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle

--- a/cmd/ssolistpermissionsets.go
+++ b/cmd/ssolistpermissionsets.go
@@ -27,7 +27,10 @@ func init() {
 func ssoListPermissionSets(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "SSO Overview per permission set"
-	ssoInstance := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	ssoInstance, err := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	if err != nil {
+		panic(err)
+	}
 	keys := []string{permissionSetColumn, "AccountIDs", "Arn", "ManagedPolicies", "InlinePolicy"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle

--- a/cmd/ssooverviewaccount.go
+++ b/cmd/ssooverviewaccount.go
@@ -31,7 +31,10 @@ func init() {
 func ssoOverviewByAccount(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "SSO Overview per account"
-	ssoInstance := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	ssoInstance, err := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	if err != nil {
+		panic(err)
+	}
 	keys := []string{"AccountID", permissionSetColumn, "Principal"}
 	if settings.IsVerbose() {
 		keys = append(keys, "ManagedPolicies", "InlinePolicy")

--- a/cmd/ssooverviewpermissionset.go
+++ b/cmd/ssooverviewpermissionset.go
@@ -30,7 +30,10 @@ func init() {
 func ssoOverviewByPermissionSet(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "SSO Overview per permission set"
-	ssoInstance := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	ssoInstance, err := helpers.GetSSOAccountInstance(awsConfig.SsoClient())
+	if err != nil {
+		panic(err)
+	}
 	keys := []string{"PermissionSet", "AccountID", "Principal"}
 	if settings.IsVerbose() {
 		keys = append(keys, "ManagedPolicies", "InlinePolicy")

--- a/docs/agent-notes/sso-helpers.md
+++ b/docs/agent-notes/sso-helpers.md
@@ -1,0 +1,43 @@
+# SSO Helpers
+
+## Architecture
+
+The SSO helpers (`helpers/sso.go`) interact with AWS SSO Admin APIs to build a nested data model:
+
+```
+SSOInstance
+  -> []SSOPermissionSet
+       -> []SSOAccount (per permission set)
+            -> []SSOAccountAssignment
+       -> []SSOPolicy (managed policies)
+       -> InlinePolicy (string)
+  -> map[string]SSOAccount (aggregated across all permission sets)
+```
+
+## Key Design Decisions
+
+- **SSOAdminAPI interface**: Introduced in T-479 to enable mock-based testing. All SSO helper functions accept this interface rather than `*ssoadmin.Client`.
+- **Error returns (not panics)**: The helpers return errors. The cmd-layer callers currently use `panic(err)` to handle these, matching the pattern elsewhere in the cmd package.
+- **Manual pagination**: Uses `for { ... NextToken ... break }` loops, consistent with `helpers/role_discovery.go`.
+
+## Pagination
+
+Four listing APIs require pagination:
+1. `ListPermissionSets` — in `getPermissionSets()`
+2. `ListAccountsForProvisionedPermissionSet` — in `addAccountInfo()`
+3. `ListAccountAssignments` — in `addAccountInfo()` (nested per account)
+4. `ListManagedPoliciesInPermissionSet` — in `getPermissionSetDetails()`
+
+All use `MaxResults: 100` (AWS default max page size) and follow the NextToken pattern.
+
+## Testing
+
+Tests use a `mockSSOAdminClient` struct with function fields (same pattern as `mockOrganizationsClient` in `organizations_test.go`). The `newBasicMock()` helper returns a mock with sensible defaults — override individual function fields to test specific scenarios.
+
+## Callers
+
+Four cmd files call `GetSSOAccountInstance()`:
+- `cmd/ssolistpermissionsets.go`
+- `cmd/ssooverviewaccount.go`
+- `cmd/ssooverviewpermissionset.go`
+- `cmd/ssodangling.go`

--- a/helpers/sso.go
+++ b/helpers/sso.go
@@ -193,7 +193,7 @@ func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, sv
 
 func (permissionset *SSOPermissionSet) addAccountInfo(svc SSOAdminAPI) error {
 	maxresults := int32(100)
-	var allAccountIds []string
+	var allAccountIDs []string
 	var nextToken *string
 
 	for {
@@ -206,14 +206,14 @@ func (permissionset *SSOPermissionSet) addAccountInfo(svc SSOAdminAPI) error {
 		if err != nil {
 			return fmt.Errorf("failed to list accounts for permission set %s: %w", permissionset.Arn, err)
 		}
-		allAccountIds = append(allAccountIds, provisionedaccounts.AccountIds...)
+		allAccountIDs = append(allAccountIDs, provisionedaccounts.AccountIds...)
 		nextToken = provisionedaccounts.NextToken
 		if nextToken == nil {
 			break
 		}
 	}
 
-	for _, accountnr := range allAccountIds {
+	for _, accountnr := range allAccountIDs {
 		account := SSOAccount{
 			AccountID: accountnr,
 		}

--- a/helpers/sso.go
+++ b/helpers/sso.go
@@ -2,17 +2,34 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 )
 
+// SSOAdminAPI defines the subset of the SSO Admin client used by this package.
+type SSOAdminAPI interface {
+	ListInstances(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error)
+	ListPermissionSets(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error)
+	DescribePermissionSet(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error)
+	ListAccountsForProvisionedPermissionSet(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error)
+	ListAccountAssignments(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error)
+	ListManagedPoliciesInPermissionSet(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error)
+	GetInlinePolicyForPermissionSet(ctx context.Context, params *ssoadmin.GetInlinePolicyForPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.GetInlinePolicyForPermissionSetOutput, error)
+}
+
 // GetSSOAccountInstance retrieves the SSO Account Instance and all its data
-func GetSSOAccountInstance(svc *ssoadmin.Client) SSOInstance {
-	ssoInstance := getSSOInstance(svc)
-	ssoInstance.getPermissionSets(svc)
-	return ssoInstance
+func GetSSOAccountInstance(svc SSOAdminAPI) (SSOInstance, error) {
+	ssoInstance, err := getSSOInstance(svc)
+	if err != nil {
+		return SSOInstance{}, err
+	}
+	if _, err := ssoInstance.getPermissionSets(svc); err != nil {
+		return SSOInstance{}, err
+	}
+	return ssoInstance, nil
 }
 
 // SSOInstance is the top level representation of an SSO Instance
@@ -58,52 +75,67 @@ type SSOAccountAssignment struct {
 	PermissionSet *SSOPermissionSet
 }
 
-func getSSOInstance(svc *ssoadmin.Client) SSOInstance {
+func getSSOInstance(svc SSOAdminAPI) (SSOInstance, error) {
 	instances, err := svc.ListInstances(context.TODO(), &ssoadmin.ListInstancesInput{})
 	if err != nil {
-		panic(err)
+		return SSOInstance{}, fmt.Errorf("failed to list SSO instances: %w", err)
 	}
 	if len(instances.Instances) < 1 {
-		panic("Didn't find any SSO environments")
+		return SSOInstance{}, fmt.Errorf("no SSO instances found")
 	}
 	if len(instances.Instances) > 1 {
-		panic("Found multiple SSO environments. How did you manage that?")
+		return SSOInstance{}, fmt.Errorf("found multiple SSO instances, expected exactly one")
 	}
 	ssoInstance := SSOInstance{
 		IdentityStoreID: *instances.Instances[0].IdentityStoreId,
 		Arn:             *instances.Instances[0].InstanceArn,
 	}
-	return ssoInstance
+	return ssoInstance, nil
 }
 
-func (instance *SSOInstance) getPermissionSets(svc *ssoadmin.Client) []SSOPermissionSet {
+func (instance *SSOInstance) getPermissionSets(svc SSOAdminAPI) ([]SSOPermissionSet, error) {
 	maxresults := int32(100)
 	if instance.PermissionSets == nil {
-		permissions, err := svc.ListPermissionSets(context.TODO(), &ssoadmin.ListPermissionSetsInput{
-			InstanceArn: &instance.Arn,
-			MaxResults:  &maxresults,
-		})
-		if err != nil {
-			panic(err)
+		var allPermissionSetArns []string
+		var nextToken *string
+
+		for {
+			permissions, err := svc.ListPermissionSets(context.TODO(), &ssoadmin.ListPermissionSetsInput{
+				InstanceArn: &instance.Arn,
+				MaxResults:  &maxresults,
+				NextToken:   nextToken,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list permission sets: %w", err)
+			}
+			allPermissionSetArns = append(allPermissionSetArns, permissions.PermissionSets...)
+			nextToken = permissions.NextToken
+			if nextToken == nil {
+				break
+			}
 		}
+
 		permissionsets := []SSOPermissionSet{}
-		for _, permissionsetarn := range permissions.PermissionSets {
-			permissionset := instance.getPermissionSetDetails(permissionsetarn, svc)
+		for _, permissionsetarn := range allPermissionSetArns {
+			permissionset, err := instance.getPermissionSetDetails(permissionsetarn, svc)
+			if err != nil {
+				return nil, err
+			}
 			permissionsets = append(permissionsets, permissionset)
 		}
 		instance.PermissionSets = permissionsets
 	}
-	return instance.PermissionSets
+	return instance.PermissionSets, nil
 }
 
-func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, svc *ssoadmin.Client) SSOPermissionSet {
+func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, svc SSOAdminAPI) (SSOPermissionSet, error) {
 	// Get metadata
 	permissionsetdescription, err := svc.DescribePermissionSet(context.TODO(), &ssoadmin.DescribePermissionSetInput{
 		InstanceArn:      &instance.Arn,
 		PermissionSetArn: &permissionsetarn,
 	})
 	if err != nil {
-		panic(err)
+		return SSOPermissionSet{}, fmt.Errorf("failed to describe permission set %s: %w", permissionsetarn, err)
 	}
 	permissionset := SSOPermissionSet{
 		Arn:             permissionsetarn,
@@ -116,71 +148,103 @@ func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, sv
 		permissionset.Description = *permissionsetdescription.PermissionSet.Description
 	}
 	// Get accounts
-	permissionset.addAccountInfo(svc)
+	if err := permissionset.addAccountInfo(svc); err != nil {
+		return SSOPermissionSet{}, err
+	}
 	// Get managed policies
-	managedpolicies, err := svc.ListManagedPoliciesInPermissionSet(context.TODO(), &ssoadmin.ListManagedPoliciesInPermissionSetInput{
-		InstanceArn:      &instance.Arn,
-		PermissionSetArn: &permissionsetarn,
-	})
-	if err != nil {
-		panic(err)
-	}
-	policies := []SSOPolicy{}
-	for _, managedpolicy := range managedpolicies.AttachedManagedPolicies {
-		policy := SSOPolicy{
-			Arn:  *managedpolicy.Arn,
-			Name: *managedpolicy.Name,
+	maxresults := int32(100)
+	var allPolicies []SSOPolicy
+	var nextToken *string
+
+	for {
+		managedpolicies, err := svc.ListManagedPoliciesInPermissionSet(context.TODO(), &ssoadmin.ListManagedPoliciesInPermissionSetInput{
+			InstanceArn:      &instance.Arn,
+			PermissionSetArn: &permissionsetarn,
+			MaxResults:       &maxresults,
+			NextToken:        nextToken,
+		})
+		if err != nil {
+			return SSOPermissionSet{}, fmt.Errorf("failed to list managed policies for permission set %s: %w", permissionsetarn, err)
 		}
-		policies = append(policies, policy)
+		for _, managedpolicy := range managedpolicies.AttachedManagedPolicies {
+			policy := SSOPolicy{
+				Arn:  *managedpolicy.Arn,
+				Name: *managedpolicy.Name,
+			}
+			allPolicies = append(allPolicies, policy)
+		}
+		nextToken = managedpolicies.NextToken
+		if nextToken == nil {
+			break
+		}
 	}
-	permissionset.ManagedPolicies = policies
+	permissionset.ManagedPolicies = allPolicies
 	// Get Inline Policy
 	inlinepolicy, err := svc.GetInlinePolicyForPermissionSet(context.TODO(), &ssoadmin.GetInlinePolicyForPermissionSetInput{
 		InstanceArn:      &instance.Arn,
 		PermissionSetArn: &permissionsetarn,
 	})
 	if err != nil {
-		panic(err)
+		return SSOPermissionSet{}, fmt.Errorf("failed to get inline policy for permission set %s: %w", permissionsetarn, err)
 	}
 	permissionset.InlinePolicy = *inlinepolicy.InlinePolicy
-	return permissionset
+	return permissionset, nil
 }
 
-func (permissionset *SSOPermissionSet) addAccountInfo(svc *ssoadmin.Client) []SSOAccount {
+func (permissionset *SSOPermissionSet) addAccountInfo(svc SSOAdminAPI) error {
 	maxresults := int32(100)
-	provisionedaccounts, err := svc.ListAccountsForProvisionedPermissionSet(context.TODO(), &ssoadmin.ListAccountsForProvisionedPermissionSetInput{
-		InstanceArn:      &permissionset.Instance.Arn,
-		PermissionSetArn: &permissionset.Arn,
-		MaxResults:       &maxresults,
-	})
-	if err != nil {
-		panic(err)
+	var allAccountIds []string
+	var nextToken *string
+
+	for {
+		provisionedaccounts, err := svc.ListAccountsForProvisionedPermissionSet(context.TODO(), &ssoadmin.ListAccountsForProvisionedPermissionSetInput{
+			InstanceArn:      &permissionset.Instance.Arn,
+			PermissionSetArn: &permissionset.Arn,
+			MaxResults:       &maxresults,
+			NextToken:        nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list accounts for permission set %s: %w", permissionset.Arn, err)
+		}
+		allAccountIds = append(allAccountIds, provisionedaccounts.AccountIds...)
+		nextToken = provisionedaccounts.NextToken
+		if nextToken == nil {
+			break
+		}
 	}
-	accounts := []SSOAccount{}
-	for _, accountnr := range provisionedaccounts.AccountIds {
+
+	for _, accountnr := range allAccountIds {
 		account := SSOAccount{
 			AccountID: accountnr,
 		}
-		accountassignments, err := svc.ListAccountAssignments(context.TODO(), &ssoadmin.ListAccountAssignmentsInput{
-			InstanceArn:      &permissionset.Instance.Arn,
-			PermissionSetArn: &permissionset.Arn,
-			AccountId:        aws.String(accountnr),
-			MaxResults:       &maxresults,
-		})
-		if err != nil {
-			panic(err)
-		}
-		for _, assignmentraw := range accountassignments.AccountAssignments {
-			assignment := SSOAccountAssignment{
-				PrincipalType: string(assignmentraw.PrincipalType),
-				PrincipalID:   *assignmentraw.PrincipalId,
-				PermissionSet: permissionset,
+		var assignmentNextToken *string
+		for {
+			accountassignments, err := svc.ListAccountAssignments(context.TODO(), &ssoadmin.ListAccountAssignmentsInput{
+				InstanceArn:      &permissionset.Instance.Arn,
+				PermissionSetArn: &permissionset.Arn,
+				AccountId:        aws.String(accountnr),
+				MaxResults:       &maxresults,
+				NextToken:        assignmentNextToken,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list account assignments for account %s, permission set %s: %w", accountnr, permissionset.Arn, err)
 			}
-			account.addAssignmentToAccount(assignment)
+			for _, assignmentraw := range accountassignments.AccountAssignments {
+				assignment := SSOAccountAssignment{
+					PrincipalType: string(assignmentraw.PrincipalType),
+					PrincipalID:   *assignmentraw.PrincipalId,
+					PermissionSet: permissionset,
+				}
+				account.addAssignmentToAccount(assignment)
+			}
+			assignmentNextToken = accountassignments.NextToken
+			if assignmentNextToken == nil {
+				break
+			}
 		}
 		permissionset.addAccount(account)
 	}
-	return accounts
+	return nil
 }
 
 func (permissionset *SSOPermissionSet) addAccount(account SSOAccount) {

--- a/helpers/sso_test.go
+++ b/helpers/sso_test.go
@@ -1,9 +1,57 @@
 package helpers
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	ssotypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// mockSSOAdminClient implements SSOAdminAPI for testing.
+type mockSSOAdminClient struct {
+	ListInstancesFunc                           func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error)
+	ListPermissionSetsFunc                      func(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error)
+	DescribePermissionSetFunc                   func(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error)
+	ListAccountsForProvisionedPermissionSetFunc func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error)
+	ListAccountAssignmentsFunc                  func(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error)
+	ListManagedPoliciesInPermissionSetFunc      func(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error)
+	GetInlinePolicyForPermissionSetFunc         func(ctx context.Context, params *ssoadmin.GetInlinePolicyForPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.GetInlinePolicyForPermissionSetOutput, error)
+}
+
+func (m *mockSSOAdminClient) ListInstances(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+	return m.ListInstancesFunc(ctx, params, optFns...)
+}
+
+func (m *mockSSOAdminClient) ListPermissionSets(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error) {
+	return m.ListPermissionSetsFunc(ctx, params, optFns...)
+}
+
+func (m *mockSSOAdminClient) DescribePermissionSet(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error) {
+	return m.DescribePermissionSetFunc(ctx, params, optFns...)
+}
+
+func (m *mockSSOAdminClient) ListAccountsForProvisionedPermissionSet(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+	return m.ListAccountsForProvisionedPermissionSetFunc(ctx, params, optFns...)
+}
+
+func (m *mockSSOAdminClient) ListAccountAssignments(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error) {
+	return m.ListAccountAssignmentsFunc(ctx, params, optFns...)
+}
+
+func (m *mockSSOAdminClient) ListManagedPoliciesInPermissionSet(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error) {
+	return m.ListManagedPoliciesInPermissionSetFunc(ctx, params, optFns...)
+}
+
+func (m *mockSSOAdminClient) GetInlinePolicyForPermissionSet(ctx context.Context, params *ssoadmin.GetInlinePolicyForPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.GetInlinePolicyForPermissionSetOutput, error) {
+	return m.GetInlinePolicyForPermissionSetFunc(ctx, params, optFns...)
+}
 
 func TestSSOInstance_Struct(t *testing.T) {
 	instance := SSOInstance{
@@ -123,7 +171,432 @@ func TestSSOPermissionSet_WithManagedPolicies(t *testing.T) {
 	}
 }
 
-// Integration tests would require AWS SSO access
-func TestGetSSOAccountInstance_Integration(t *testing.T) {
-	t.Skip("Skipping integration test - requires SSO Admin client interface implementation")
+// Regression tests for T-479: pagination must collect all pages
+
+// newBasicMock returns a mock with common defaults set for a single permission set.
+// Callers override specific functions to test pagination scenarios.
+func newBasicMock() *mockSSOAdminClient {
+	createdDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &mockSSOAdminClient{
+		ListInstancesFunc: func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+			return &ssoadmin.ListInstancesOutput{
+				Instances: []ssotypes.InstanceMetadata{
+					{
+						IdentityStoreId: aws.String("d-1234567890"),
+						InstanceArn:     aws.String("arn:aws:sso:::instance/ssoins-abc"),
+					},
+				},
+			}, nil
+		},
+		ListPermissionSetsFunc: func(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error) {
+			return &ssoadmin.ListPermissionSetsOutput{
+				PermissionSets: []string{"arn:aws:sso:::permissionSet/ps-001"},
+			}, nil
+		},
+		DescribePermissionSetFunc: func(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error) {
+			return &ssoadmin.DescribePermissionSetOutput{
+				PermissionSet: &ssotypes.PermissionSet{
+					Name:            aws.String("TestPS"),
+					CreatedDate:     &createdDate,
+					SessionDuration: aws.String("PT1H"),
+				},
+			}, nil
+		},
+		ListAccountsForProvisionedPermissionSetFunc: func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+			return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+				AccountIds: []string{},
+			}, nil
+		},
+		ListAccountAssignmentsFunc: func(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error) {
+			return &ssoadmin.ListAccountAssignmentsOutput{
+				AccountAssignments: []ssotypes.AccountAssignment{},
+			}, nil
+		},
+		ListManagedPoliciesInPermissionSetFunc: func(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error) {
+			return &ssoadmin.ListManagedPoliciesInPermissionSetOutput{
+				AttachedManagedPolicies: []ssotypes.AttachedManagedPolicy{},
+			}, nil
+		},
+		GetInlinePolicyForPermissionSetFunc: func(ctx context.Context, params *ssoadmin.GetInlinePolicyForPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.GetInlinePolicyForPermissionSetOutput, error) {
+			return &ssoadmin.GetInlinePolicyForPermissionSetOutput{
+				InlinePolicy: aws.String(""),
+			}, nil
+		},
+	}
+}
+
+func TestListPermissionSets_Pagination(t *testing.T) {
+	mock := newBasicMock()
+	callCount := 0
+	mock.ListPermissionSetsFunc = func(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			assert.Nil(t, params.NextToken, "first call should not have NextToken")
+			return &ssoadmin.ListPermissionSetsOutput{
+				PermissionSets: []string{"arn:ps-001", "arn:ps-002"},
+				NextToken:      aws.String("page2"),
+			}, nil
+		case 2:
+			assert.Equal(t, "page2", *params.NextToken)
+			return &ssoadmin.ListPermissionSetsOutput{
+				PermissionSets: []string{"arn:ps-003"},
+				NextToken:      nil,
+			}, nil
+		default:
+			t.Fatal("ListPermissionSets called too many times")
+			return nil, nil
+		}
+	}
+
+	// DescribePermissionSet needs to handle three different ARNs
+	createdDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	mock.DescribePermissionSetFunc = func(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error) {
+		return &ssoadmin.DescribePermissionSetOutput{
+			PermissionSet: &ssotypes.PermissionSet{
+				Name:            aws.String("PS-" + *params.PermissionSetArn),
+				CreatedDate:     &createdDate,
+				SessionDuration: aws.String("PT1H"),
+			},
+		}, nil
+	}
+
+	instance, err := GetSSOAccountInstance(mock)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(instance.PermissionSets), "should collect permission sets across two pages")
+	assert.Equal(t, 2, callCount, "ListPermissionSets should be called twice")
+}
+
+func TestListAccountsForProvisionedPermissionSet_Pagination(t *testing.T) {
+	mock := newBasicMock()
+	accountCallCount := 0
+	mock.ListAccountsForProvisionedPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+		accountCallCount++
+		switch accountCallCount {
+		case 1:
+			assert.Nil(t, params.NextToken, "first call should not have NextToken")
+			return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+				AccountIds: []string{"111111111111", "222222222222"},
+				NextToken:  aws.String("page2"),
+			}, nil
+		case 2:
+			assert.Equal(t, "page2", *params.NextToken)
+			return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+				AccountIds: []string{"333333333333"},
+				NextToken:  nil,
+			}, nil
+		default:
+			t.Fatal("ListAccountsForProvisionedPermissionSet called too many times")
+			return nil, nil
+		}
+	}
+
+	instance, err := GetSSOAccountInstance(mock)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(instance.PermissionSets[0].Accounts), "should collect accounts across two pages")
+	assert.Equal(t, 2, accountCallCount, "ListAccountsForProvisionedPermissionSet should be called twice")
+}
+
+func TestListAccountAssignments_Pagination(t *testing.T) {
+	mock := newBasicMock()
+	// Return one account
+	mock.ListAccountsForProvisionedPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+		return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+			AccountIds: []string{"111111111111"},
+		}, nil
+	}
+
+	assignmentCallCount := 0
+	mock.ListAccountAssignmentsFunc = func(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error) {
+		assignmentCallCount++
+		switch assignmentCallCount {
+		case 1:
+			assert.Nil(t, params.NextToken, "first call should not have NextToken")
+			return &ssoadmin.ListAccountAssignmentsOutput{
+				AccountAssignments: []ssotypes.AccountAssignment{
+					{PrincipalType: ssotypes.PrincipalTypeUser, PrincipalId: aws.String("user-1")},
+					{PrincipalType: ssotypes.PrincipalTypeGroup, PrincipalId: aws.String("group-1")},
+				},
+				NextToken: aws.String("page2"),
+			}, nil
+		case 2:
+			assert.Equal(t, "page2", *params.NextToken)
+			return &ssoadmin.ListAccountAssignmentsOutput{
+				AccountAssignments: []ssotypes.AccountAssignment{
+					{PrincipalType: ssotypes.PrincipalTypeUser, PrincipalId: aws.String("user-2")},
+				},
+				NextToken: nil,
+			}, nil
+		default:
+			t.Fatal("ListAccountAssignments called too many times")
+			return nil, nil
+		}
+	}
+
+	instance, err := GetSSOAccountInstance(mock)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(instance.PermissionSets[0].Accounts))
+	assert.Equal(t, 3, len(instance.PermissionSets[0].Accounts[0].AccountAssignments),
+		"should collect assignments across two pages")
+	assert.Equal(t, 2, assignmentCallCount, "ListAccountAssignments should be called twice")
+}
+
+func TestListManagedPoliciesInPermissionSet_Pagination(t *testing.T) {
+	mock := newBasicMock()
+	policyCallCount := 0
+	mock.ListManagedPoliciesInPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error) {
+		policyCallCount++
+		switch policyCallCount {
+		case 1:
+			assert.Nil(t, params.NextToken, "first call should not have NextToken")
+			return &ssoadmin.ListManagedPoliciesInPermissionSetOutput{
+				AttachedManagedPolicies: []ssotypes.AttachedManagedPolicy{
+					{Arn: aws.String("arn:policy/1"), Name: aws.String("Policy1")},
+					{Arn: aws.String("arn:policy/2"), Name: aws.String("Policy2")},
+				},
+				NextToken: aws.String("page2"),
+			}, nil
+		case 2:
+			assert.Equal(t, "page2", *params.NextToken)
+			return &ssoadmin.ListManagedPoliciesInPermissionSetOutput{
+				AttachedManagedPolicies: []ssotypes.AttachedManagedPolicy{
+					{Arn: aws.String("arn:policy/3"), Name: aws.String("Policy3")},
+				},
+				NextToken: nil,
+			}, nil
+		default:
+			t.Fatal("ListManagedPoliciesInPermissionSet called too many times")
+			return nil, nil
+		}
+	}
+
+	instance, err := GetSSOAccountInstance(mock)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(instance.PermissionSets[0].ManagedPolicies),
+		"should collect managed policies across two pages")
+	assert.Equal(t, 2, policyCallCount, "ListManagedPoliciesInPermissionSet should be called twice")
+}
+
+// Error handling regression tests
+
+func TestGetSSOAccountInstance_ListInstancesError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListInstancesFunc = func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+		return nil, errors.New("access denied")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list SSO instances")
+}
+
+func TestGetSSOAccountInstance_NoInstances_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListInstancesFunc = func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+		return &ssoadmin.ListInstancesOutput{Instances: []ssotypes.InstanceMetadata{}}, nil
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SSO instances found")
+}
+
+func TestGetSSOAccountInstance_MultipleInstances_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListInstancesFunc = func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+		return &ssoadmin.ListInstancesOutput{
+			Instances: []ssotypes.InstanceMetadata{
+				{IdentityStoreId: aws.String("d-1"), InstanceArn: aws.String("arn:1")},
+				{IdentityStoreId: aws.String("d-2"), InstanceArn: aws.String("arn:2")},
+			},
+		}, nil
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "found multiple SSO instances")
+}
+
+func TestGetSSOAccountInstance_ListPermissionSetsError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListPermissionSetsFunc = func(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error) {
+		return nil, errors.New("throttled")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list permission sets")
+}
+
+func TestGetSSOAccountInstance_DescribePermissionSetError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.DescribePermissionSetFunc = func(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error) {
+		return nil, errors.New("not found")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to describe permission set")
+}
+
+func TestGetSSOAccountInstance_ListAccountsError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListAccountsForProvisionedPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+		return nil, errors.New("service error")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list accounts for permission set")
+}
+
+func TestGetSSOAccountInstance_ListAssignmentsError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListAccountsForProvisionedPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+		return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+			AccountIds: []string{"111111111111"},
+		}, nil
+	}
+	mock.ListAccountAssignmentsFunc = func(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error) {
+		return nil, errors.New("permission denied")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list account assignments")
+}
+
+func TestGetSSOAccountInstance_ListManagedPoliciesError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.ListManagedPoliciesInPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error) {
+		return nil, errors.New("internal error")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list managed policies")
+}
+
+func TestGetSSOAccountInstance_GetInlinePolicyError_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.GetInlinePolicyForPermissionSetFunc = func(ctx context.Context, params *ssoadmin.GetInlinePolicyForPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.GetInlinePolicyForPermissionSetOutput, error) {
+		return nil, errors.New("timeout")
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get inline policy")
+}
+
+// End-to-end test with pagination on all four listing APIs simultaneously
+
+func TestGetSSOAccountInstance_FullPagination(t *testing.T) {
+	createdDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Track call counts to verify pagination
+	listPSCalls := 0
+	listAccountsCalls := 0
+	listAssignmentCalls := 0
+	listPolicyCalls := 0
+
+	mock := &mockSSOAdminClient{
+		ListInstancesFunc: func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+			return &ssoadmin.ListInstancesOutput{
+				Instances: []ssotypes.InstanceMetadata{
+					{IdentityStoreId: aws.String("d-test"), InstanceArn: aws.String("arn:instance")},
+				},
+			}, nil
+		},
+		// Two pages of permission sets
+		ListPermissionSetsFunc: func(ctx context.Context, params *ssoadmin.ListPermissionSetsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListPermissionSetsOutput, error) {
+			listPSCalls++
+			if params.NextToken == nil {
+				return &ssoadmin.ListPermissionSetsOutput{
+					PermissionSets: []string{"arn:ps-1"},
+					NextToken:      aws.String("ps-page2"),
+				}, nil
+			}
+			return &ssoadmin.ListPermissionSetsOutput{
+				PermissionSets: []string{"arn:ps-2"},
+			}, nil
+		},
+		DescribePermissionSetFunc: func(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error) {
+			return &ssoadmin.DescribePermissionSetOutput{
+				PermissionSet: &ssotypes.PermissionSet{
+					Name:            params.PermissionSetArn,
+					CreatedDate:     &createdDate,
+					SessionDuration: aws.String("PT1H"),
+				},
+			}, nil
+		},
+		// Two pages of accounts per permission set
+		ListAccountsForProvisionedPermissionSetFunc: func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {
+			listAccountsCalls++
+			if params.NextToken == nil {
+				return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+					AccountIds: []string{"acct-1"},
+					NextToken:  aws.String("acct-page2"),
+				}, nil
+			}
+			return &ssoadmin.ListAccountsForProvisionedPermissionSetOutput{
+				AccountIds: []string{"acct-2"},
+			}, nil
+		},
+		// Two pages of assignments per account
+		ListAccountAssignmentsFunc: func(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error) {
+			listAssignmentCalls++
+			if params.NextToken == nil {
+				return &ssoadmin.ListAccountAssignmentsOutput{
+					AccountAssignments: []ssotypes.AccountAssignment{
+						{PrincipalType: ssotypes.PrincipalTypeUser, PrincipalId: aws.String(fmt.Sprintf("user-%s-1", *params.AccountId))},
+					},
+					NextToken: aws.String("assign-page2"),
+				}, nil
+			}
+			return &ssoadmin.ListAccountAssignmentsOutput{
+				AccountAssignments: []ssotypes.AccountAssignment{
+					{PrincipalType: ssotypes.PrincipalTypeGroup, PrincipalId: aws.String(fmt.Sprintf("group-%s-2", *params.AccountId))},
+				},
+			}, nil
+		},
+		// Two pages of managed policies per permission set
+		ListManagedPoliciesInPermissionSetFunc: func(ctx context.Context, params *ssoadmin.ListManagedPoliciesInPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListManagedPoliciesInPermissionSetOutput, error) {
+			listPolicyCalls++
+			if params.NextToken == nil {
+				return &ssoadmin.ListManagedPoliciesInPermissionSetOutput{
+					AttachedManagedPolicies: []ssotypes.AttachedManagedPolicy{
+						{Arn: aws.String("arn:policy/A"), Name: aws.String("PolicyA")},
+					},
+					NextToken: aws.String("policy-page2"),
+				}, nil
+			}
+			return &ssoadmin.ListManagedPoliciesInPermissionSetOutput{
+				AttachedManagedPolicies: []ssotypes.AttachedManagedPolicy{
+					{Arn: aws.String("arn:policy/B"), Name: aws.String("PolicyB")},
+				},
+			}, nil
+		},
+		GetInlinePolicyForPermissionSetFunc: func(ctx context.Context, params *ssoadmin.GetInlinePolicyForPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.GetInlinePolicyForPermissionSetOutput, error) {
+			return &ssoadmin.GetInlinePolicyForPermissionSetOutput{
+				InlinePolicy: aws.String(""),
+			}, nil
+		},
+	}
+
+	instance, err := GetSSOAccountInstance(mock)
+	require.NoError(t, err)
+
+	// 2 permission sets (from 2 pages)
+	assert.Equal(t, 2, len(instance.PermissionSets))
+
+	// Each permission set has 2 accounts (from 2 pages)
+	for _, ps := range instance.PermissionSets {
+		assert.Equal(t, 2, len(ps.Accounts), "permission set %s should have 2 accounts", ps.Name)
+
+		// Each account has 2 assignments (from 2 pages)
+		for _, acct := range ps.Accounts {
+			assert.Equal(t, 2, len(acct.AccountAssignments),
+				"account %s should have 2 assignments", acct.AccountID)
+		}
+
+		// Each permission set has 2 managed policies (from 2 pages)
+		assert.Equal(t, 2, len(ps.ManagedPolicies), "permission set %s should have 2 managed policies", ps.Name)
+	}
+
+	// Verify pagination was exercised
+	assert.Equal(t, 2, listPSCalls, "ListPermissionSets should be called twice")
+	assert.Equal(t, 4, listAccountsCalls, "ListAccountsForProvisionedPermissionSet should be called 4 times (2 PS x 2 pages)")
+	assert.Equal(t, 8, listAssignmentCalls, "ListAccountAssignments should be called 8 times (2 PS x 2 accounts x 2 pages)")
+	assert.Equal(t, 4, listPolicyCalls, "ListManagedPoliciesInPermissionSet should be called 4 times (2 PS x 2 pages)")
 }

--- a/specs/bugfixes/sso-admin-pagination/report.md
+++ b/specs/bugfixes/sso-admin-pagination/report.md
@@ -1,0 +1,84 @@
+# Bugfix Report: SSO Admin Pagination
+
+**Date:** 2026-03-20
+**Status:** Fixed
+
+## Description of the Issue
+
+The SSO Admin helper functions in `helpers/sso.go` made single API calls to four listing endpoints without handling the `NextToken` pagination field. When any of these APIs returned more than 100 results (the maximum page size), the additional items were silently dropped.
+
+**Reproduction steps:**
+1. Have an AWS SSO instance with more than 100 permission sets, or a permission set provisioned to more than 100 accounts, or more than 100 account assignments, or more than 100 managed policies on a permission set.
+2. Run any SSO command (e.g., `awstools sso list-permission-sets`).
+3. Observe that only the first 100 items are returned for the affected listing.
+
+**Impact:** Data truncation. Users with large SSO deployments would see incomplete results without any warning. This affects all four SSO commands: `list-permission-sets`, `by-account`, `by-permission-set`, and `dangling`.
+
+## Investigation Summary
+
+- **Symptoms examined:** API calls with `MaxResults: 100` and no `NextToken` handling.
+- **Code inspected:** `helpers/sso.go` — all four listing functions (`getPermissionSets`, `getPermissionSetDetails`, `addAccountInfo`).
+- **Hypotheses tested:** Confirmed that all four AWS SSO Admin listing APIs (`ListPermissionSets`, `ListAccountsForProvisionedPermissionSet`, `ListAccountAssignments`, `ListManagedPoliciesInPermissionSet`) return `NextToken` fields for pagination.
+
+## Discovered Root Cause
+
+All four SSO Admin listing calls made a single API request and used only the first page of results. The `NextToken` field in the response was never checked.
+
+**Defect type:** Missing pagination loop.
+
+**Why it occurred:** The original implementation assumed the results would fit in a single page. No pagination was implemented for any of the SSO Admin listing APIs.
+
+**Contributing factors:** The functions used `panic()` for error handling, which made them untestable with mock clients (no interface was defined), so this bug was never caught by tests.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/sso.go` — Introduced `SSOAdminAPI` interface. Added pagination loops (NextToken handling) to all four listing calls. Converted all `panic()` calls to proper error returns.
+- `cmd/ssolistpermissionsets.go` — Updated to handle error return from `GetSSOAccountInstance`.
+- `cmd/ssooverviewaccount.go` — Updated to handle error return from `GetSSOAccountInstance`.
+- `cmd/ssooverviewpermissionset.go` — Updated to handle error return from `GetSSOAccountInstance`.
+- `cmd/ssodangling.go` — Updated to handle error return from `GetSSOAccountInstance`.
+- `helpers/sso_test.go` — Added mock client, pagination regression tests for all four listing APIs, error handling tests, and a full end-to-end pagination test.
+
+**Approach rationale:** Follows the existing pagination pattern used in `helpers/role_discovery.go` and the interface/mock pattern used in `helpers/organizations.go`.
+
+**Alternatives considered:**
+- Using AWS SDK built-in paginators — rejected because the existing codebase uses manual pagination loops consistently, and the manual approach keeps the code uniform.
+
+## Regression Test
+
+**Test file:** `helpers/sso_test.go`
+**Test names:** `TestListPermissionSets_Pagination`, `TestListAccountsForProvisionedPermissionSet_Pagination`, `TestListAccountAssignments_Pagination`, `TestListManagedPoliciesInPermissionSet_Pagination`, `TestGetSSOAccountInstance_FullPagination`
+
+**What it verifies:** Each test configures a mock that returns results across two pages (with a NextToken on the first response). The tests assert that all items from both pages are collected and that the API is called the expected number of times.
+
+**Run command:** `go test ./helpers/ -run "TestList.*Pagination|TestGetSSOAccountInstance_Full"`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/sso.go` | Added `SSOAdminAPI` interface, pagination loops, error returns |
+| `helpers/sso_test.go` | Added mock client and pagination/error regression tests |
+| `cmd/ssolistpermissionsets.go` | Handle error return from `GetSSOAccountInstance` |
+| `cmd/ssooverviewaccount.go` | Handle error return from `GetSSOAccountInstance` |
+| `cmd/ssooverviewpermissionset.go` | Handle error return from `GetSSOAccountInstance` |
+| `cmd/ssodangling.go` | Handle error return from `GetSSOAccountInstance` |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass (`make test`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When using AWS SDK listing APIs, always implement pagination loops. Check for `NextToken` in every listing response.
+- Define interfaces for AWS service clients so helper functions can be tested with mocks.
+- Return errors instead of using `panic()` — this enables proper testing and graceful error handling.
+
+## Related
+
+- Transit ticket: T-479


### PR DESCRIPTION
## Summary

- Add pagination loops (NextToken handling) to all four SSO Admin listing APIs: `ListPermissionSets`, `ListAccountsForProvisionedPermissionSet`, `ListAccountAssignments`, and `ListManagedPoliciesInPermissionSet`
- Introduce `SSOAdminAPI` interface for testability, following the `OrganizationsAPI` pattern
- Convert `panic()` calls in SSO helpers to proper error returns

Previously, all four listing calls used a single API request with `MaxResults: 100` and ignored the `NextToken` response field, silently truncating results for environments with more than 100 items.

## Test plan

- [x] Pagination regression tests for each of the four listing APIs (mock returns two pages, test verifies all items collected)
- [x] End-to-end pagination test exercising all four APIs simultaneously
- [x] Error handling tests for every API call path
- [x] Full test suite passes (`make test`)