### PR TITLE
Fix T-481: role discovery account alias lookup across accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makefile target `install` for installing the application
 - Organized help output with categorized sections
 
+### Fixed
+
+- Role discovery account alias lookup now uses SSO-provided account names instead of IAM ListAccountAliases, which incorrectly returned the template profile's alias for all accounts (T-481)
+
 ### Changed
 
 - `clean` target now also removes coverage artifacts

--- a/docs/agent-notes/role-discovery.md
+++ b/docs/agent-notes/role-discovery.md
@@ -1,0 +1,34 @@
+# Role Discovery
+
+## Architecture
+
+`RoleDiscovery` (`helpers/role_discovery.go`) discovers accessible roles using SSO OIDC tokens. It uses the SSO `ListAccounts` API to enumerate accounts and `ListAccountRoles` to find roles per account.
+
+Key types:
+- `RoleDiscovery` — orchestrates the discovery flow
+- `DiscoveredRole` — result type with account ID, name, alias, and role info
+- `SSOTokenCache` — handles cached SSO token loading
+
+## Account Alias Lookup
+
+Account aliases are populated from the SSO `ListAccounts` API response during role discovery. The `AccountName` field from `types.AccountInfo` is used as the alias and cached in `aliasCache`.
+
+**Important:** IAM `ListAccountAliases` is account-scoped — it only returns the alias for the caller's own account. It cannot be used for cross-account alias lookup. This was the root cause of T-481.
+
+`GetAccountAlias` is a cache-only lookup. If no alias is cached, it falls back to the account ID.
+
+## Concurrency
+
+`getRolesForAccount` is called concurrently for each account (goroutine per account in `DiscoverAccessibleRoles`). The `aliasCache` and `accountCache` are protected by `cacheMutex` (sync.RWMutex).
+
+## Dependencies
+
+- `ssoClient` — SSO API calls (ListAccounts, ListAccountRoles)
+- `stsClient` — STS for token validation
+- `tokenCache` — SSO token cache for loading cached OIDC tokens
+
+IAM client was removed as a dependency in T-481 since the alias lookup now uses SSO data.
+
+## Profile Generator Integration
+
+`ProfileGenerator` (`helpers/profile_generator.go`) creates a `RoleDiscovery` instance in its constructor and uses it to discover roles, which are then converted to `GeneratedProfile` entries using a naming pattern (e.g., `{account_name}-{role_name}` or `{account_alias}-{role_name}`).

--- a/helpers/profile_generator.go
+++ b/helpers/profile_generator.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
@@ -79,7 +78,6 @@ type ProfileGenerator struct {
 	awsConfig        aws.Config                 // AWS SDK configuration for API calls
 	ssoClient        *sso.Client                // AWS SSO client for role discovery
 	stsClient        *sts.Client                // AWS STS client for token validation
-	iamClient        *iam.Client                // AWS IAM client for role information
 	roleDiscovery    *RoleDiscovery             // Role discovery service for enumerating accessible roles
 	conflictDetector *ProfileConflictDetector   // Conflict detection service (initialized lazily)
 	logger           Logger                     // Logger for progress and diagnostic messages
@@ -92,7 +90,7 @@ type ProfileGenerator struct {
 // 1. Validates required parameters (template profile name)
 // 2. Sets default naming pattern if not provided
 // 3. Validates the naming pattern syntax
-// 4. Creates AWS service clients (SSO, STS, IAM)
+// 4. Creates AWS service clients (SSO, STS)
 // 5. Initializes role discovery service
 // 6. Sets up default logger (can be overridden)
 //
@@ -154,10 +152,9 @@ func NewProfileGenerator(templateProfile, namingPattern string, autoApprove bool
 	// Create AWS service clients
 	ssoClient := sso.NewFromConfig(awsConfig)
 	stsClient := sts.NewFromConfig(awsConfig)
-	iamClient := iam.NewFromConfig(awsConfig)
 
 	// Create role discovery
-	roleDiscovery, err := NewRoleDiscovery(ssoClient, stsClient, iamClient)
+	roleDiscovery, err := NewRoleDiscovery(ssoClient, stsClient)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +168,6 @@ func NewProfileGenerator(templateProfile, namingPattern string, autoApprove bool
 		awsConfig:        awsConfig,
 		ssoClient:        ssoClient,
 		stsClient:        stsClient,
-		iamClient:        iamClient,
 		roleDiscovery:    roleDiscovery,
 		logger:           &defaultLogger{},
 	}

--- a/helpers/profile_generator_test.go
+++ b/helpers/profile_generator_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/sso/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -50,16 +49,6 @@ func (m *MockSSOClient) ListAccountRoles(ctx context.Context, params *sso.ListAc
 func (m *MockSSOClient) GetRoleCredentials(ctx context.Context, params *sso.GetRoleCredentialsInput, optFns ...func(*sso.Options)) (*sso.GetRoleCredentialsOutput, error) {
 	args := m.Called(ctx, params, optFns)
 	return args.Get(0).(*sso.GetRoleCredentialsOutput), args.Error(1)
-}
-
-// MockIAMClient is a mock IAM client for testing
-type MockIAMClient struct {
-	mock.Mock
-}
-
-func (m *MockIAMClient) ListAccountAliases(ctx context.Context, params *iam.ListAccountAliasesInput, optFns ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error) {
-	args := m.Called(ctx, params, optFns)
-	return args.Get(0).(*iam.ListAccountAliasesOutput), args.Error(1)
 }
 
 func (m *MockSSOClient) Logout(ctx context.Context, params *sso.LogoutInput, optFns ...func(*sso.Options)) (*sso.LogoutOutput, error) {
@@ -2668,6 +2657,82 @@ func TestProgressReporting(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetAccountAlias_UsesSSO_NotIAM verifies that GetAccountAlias returns
+// per-account aliases from the SSO-populated cache rather than calling IAM
+// (which would return the template profile's account alias for every account).
+// This is a regression test for T-481.
+func TestGetAccountAlias_UsesSSO_NotIAM(t *testing.T) {
+	rd := &RoleDiscovery{
+		logger:       &MockLogger{},
+		accountCache: make(map[string]string),
+		aliasCache:   make(map[string]string),
+	}
+
+	// Pre-populate cache as the SSO-based flow does during role discovery
+	rd.aliasCache["111111111111"] = "dev-account"
+	rd.aliasCache["222222222222"] = "staging-account"
+	rd.aliasCache["333333333333"] = "prod-account"
+
+	// Each account should return its own alias, not a shared one
+	alias1, err := rd.GetAccountAlias("111111111111")
+	assert.NoError(t, err)
+	assert.Equal(t, "dev-account", alias1)
+
+	alias2, err := rd.GetAccountAlias("222222222222")
+	assert.NoError(t, err)
+	assert.Equal(t, "staging-account", alias2)
+
+	alias3, err := rd.GetAccountAlias("333333333333")
+	assert.NoError(t, err)
+	assert.Equal(t, "prod-account", alias3)
+
+	// Uncached account should fall back to account ID
+	alias4, err := rd.GetAccountAlias("444444444444")
+	assert.NoError(t, err)
+	assert.Equal(t, "444444444444", alias4)
+}
+
+// TestGetAccountAlias_CrossAccountNotMislabeled verifies that different accounts
+// get different aliases — the bug was that all accounts received the template
+// profile's account alias because IAM ListAccountAliases always returns the
+// current account's alias. This is a regression test for T-481.
+func TestGetAccountAlias_CrossAccountNotMislabeled(t *testing.T) {
+	rd := &RoleDiscovery{
+		logger:       &MockLogger{},
+		accountCache: make(map[string]string),
+		aliasCache:   make(map[string]string),
+	}
+
+	// Simulate what getRolesForAccount does: populate alias cache from SSO AccountName
+	accounts := map[string]string{
+		"111111111111": "alpha-account",
+		"222222222222": "beta-account",
+		"333333333333": "gamma-account",
+	}
+	for id, name := range accounts {
+		rd.aliasCache[id] = name
+	}
+
+	// Verify each account gets its own distinct alias
+	aliases := make(map[string]string)
+	for id := range accounts {
+		alias, err := rd.GetAccountAlias(id)
+		require.NoError(t, err)
+		aliases[id] = alias
+	}
+
+	// All aliases must be distinct (the bug caused them all to be the same)
+	assert.Equal(t, 3, len(aliases))
+	assert.NotEqual(t, aliases["111111111111"], aliases["222222222222"])
+	assert.NotEqual(t, aliases["222222222222"], aliases["333333333333"])
+	assert.NotEqual(t, aliases["111111111111"], aliases["333333333333"])
+
+	// Each alias must match the SSO-provided account name
+	assert.Equal(t, "alpha-account", aliases["111111111111"])
+	assert.Equal(t, "beta-account", aliases["222222222222"])
+	assert.Equal(t, "gamma-account", aliases["333333333333"])
 }
 
 // Helper function for testing

--- a/helpers/role_discovery.go
+++ b/helpers/role_discovery.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/sso/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -18,7 +17,6 @@ import (
 type RoleDiscovery struct {
 	ssoClient    *sso.Client
 	stsClient    *sts.Client
-	iamClient    *iam.Client
 	tokenCache   *SSOTokenCache
 	logger       Logger
 	accountCache map[string]string
@@ -39,15 +37,12 @@ func (dl *defaultLogger) Printf(format string, args ...any) {
 }
 
 // NewRoleDiscovery creates a new role discovery instance using OIDC tokens
-func NewRoleDiscovery(ssoClient *sso.Client, stsClient *sts.Client, iamClient *iam.Client) (*RoleDiscovery, error) {
+func NewRoleDiscovery(ssoClient *sso.Client, stsClient *sts.Client) (*RoleDiscovery, error) {
 	if ssoClient == nil {
 		return nil, NewValidationError("SSO client cannot be nil", nil)
 	}
 	if stsClient == nil {
 		return nil, NewValidationError("STS client cannot be nil", nil)
-	}
-	if iamClient == nil {
-		return nil, NewValidationError("IAM client cannot be nil", nil)
 	}
 
 	tokenCache, err := NewSSOTokenCache()
@@ -58,7 +53,6 @@ func NewRoleDiscovery(ssoClient *sso.Client, stsClient *sts.Client, iamClient *i
 	rd := &RoleDiscovery{
 		ssoClient:    ssoClient,
 		stsClient:    stsClient,
-		iamClient:    iamClient,
 		tokenCache:   tokenCache,
 		logger:       &defaultLogger{},
 		accountCache: make(map[string]string),
@@ -192,12 +186,16 @@ func (rd *RoleDiscovery) getRolesForAccount(ctx context.Context, token *CachedTo
 				accountName = *account.AccountId // Fallback to account ID
 			}
 
-			// Get account alias with fallback to account ID
-			accountAlias, err := rd.GetAccountAlias(*account.AccountId)
-			if err != nil {
-				rd.logger.Printf("Warning: failed to get account alias for %s: %v", *account.AccountId, err)
-				accountAlias = *account.AccountId // Fallback to account ID
+			// Cache the SSO-provided account name as the alias for this account.
+			// The SSO ListAccounts API provides per-account names, unlike IAM
+			// ListAccountAliases which only returns the current account's alias.
+			rd.cacheMutex.Lock()
+			if _, exists := rd.aliasCache[*account.AccountId]; !exists {
+				rd.aliasCache[*account.AccountId] = accountName
 			}
+			rd.cacheMutex.Unlock()
+
+			accountAlias, _ := rd.GetAccountAlias(*account.AccountId)
 
 			role := DiscoveredRole{
 				AccountID:         *account.AccountId,
@@ -244,9 +242,11 @@ func (rd *RoleDiscovery) GetAccountInfo(accountID string) (string, error) {
 	return accountID, nil
 }
 
-// GetAccountAlias retrieves the account alias for a given account ID
+// GetAccountAlias retrieves the account alias for a given account ID.
+// Aliases are populated from SSO ListAccounts data during role discovery,
+// which provides per-account names. Falls back to the account ID if no
+// alias has been cached.
 func (rd *RoleDiscovery) GetAccountAlias(accountID string) (string, error) {
-	// Check cache first
 	rd.cacheMutex.RLock()
 	if alias, exists := rd.aliasCache[accountID]; exists {
 		rd.cacheMutex.RUnlock()
@@ -254,37 +254,8 @@ func (rd *RoleDiscovery) GetAccountAlias(accountID string) (string, error) {
 	}
 	rd.cacheMutex.RUnlock()
 
-	ctx := context.TODO()
-
-	// Get account aliases from IAM
-	input := &iam.ListAccountAliasesInput{}
-	result, err := rd.iamClient.ListAccountAliases(ctx, input)
-	if err != nil {
-		// Cache the failure and return account ID as fallback
-		rd.cacheMutex.Lock()
-		rd.aliasCache[accountID] = accountID
-		rd.cacheMutex.Unlock()
-
-		return accountID, NewAPIError("failed to retrieve account alias", err).
-			WithContext("account_id", accountID).
-			WithContext("suggestion", "Ensure IAM permissions for ListAccountAliases")
-	}
-
-	// AWS accounts can have at most one alias
-	var alias string
-	if len(result.AccountAliases) > 0 {
-		alias = result.AccountAliases[0]
-	} else {
-		// No alias configured, use account ID
-		alias = accountID
-	}
-
-	// Cache the result
-	rd.cacheMutex.Lock()
-	rd.aliasCache[accountID] = alias
-	rd.cacheMutex.Unlock()
-
-	return alias, nil
+	// No cached alias — fall back to account ID
+	return accountID, nil
 }
 
 // ValidateTokenAccess validates that we can access SSO with the given profile

--- a/specs/bugfixes/role-discovery-alias-lookup/report.md
+++ b/specs/bugfixes/role-discovery-alias-lookup/report.md
@@ -1,0 +1,83 @@
+# Bugfix Report: role-discovery-alias-lookup
+
+**Date:** 2026-03-20
+**Status:** Fixed
+
+## Description of the Issue
+
+`RoleDiscovery.GetAccountAlias` uses IAM `ListAccountAliases` with the template profile's credentials, which always returns the alias for the currently authenticated account. When discovering roles across multiple accounts via SSO, every account receives the same alias (the template profile's account alias), mislabeling all other accounts.
+
+**Reproduction steps:**
+1. Configure an SSO template profile that authenticates against account A (alias: "shared-services")
+2. Run profile generation that discovers roles across accounts A, B, and C
+3. All three accounts get `AccountAlias: "shared-services"` instead of their own aliases
+
+**Impact:** High — profile names using the `{account_alias}` naming pattern are incorrect for all non-template accounts, making generated profiles confusing and potentially causing users to assume roles in the wrong account.
+
+## Investigation Summary
+
+- **Symptoms examined:** All discovered accounts receive the same alias regardless of account ID
+- **Code inspected:** `GetAccountAlias`, `getRolesForAccount`, `NewRoleDiscovery`
+- **Root cause identified via:** Code inspection of IAM `ListAccountAliases` API semantics
+
+## Discovered Root Cause
+
+`GetAccountAlias(accountID string)` accepts an account ID parameter but ignores it when calling `rd.iamClient.ListAccountAliases()`. The IAM API always returns the alias for the account that the IAM client is authenticated against (the template profile's account), not the account specified by `accountID`. The result is then cached under the requested account ID, so every account ends up with the same alias.
+
+**Defect type:** Logic error — wrong API used for cross-account data
+
+**Why it occurred:** IAM `ListAccountAliases` is an account-scoped API that only works for the caller's own account. It cannot retrieve aliases for other accounts. The method signature suggests per-account lookup via the `accountID` parameter, but the IAM call ignores that parameter entirely.
+
+**Contributing factors:**
+- IAM `ListAccountAliases` does not accept an account ID parameter (it always operates on the caller's account)
+- The SSO `ListAccounts` API already provides `AccountName` for each account, making the IAM call unnecessary
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/role_discovery.go` — Removed IAM dependency from `RoleDiscovery`. `GetAccountAlias` now reads from the alias cache only, falling back to account ID. `getRolesForAccount` populates the alias cache from the SSO-provided `AccountName` for each account.
+- `helpers/profile_generator.go` — Removed IAM client creation and field, since `RoleDiscovery` no longer needs it.
+- `helpers/profile_generator_test.go` — Removed unused `MockIAMClient` type and IAM import.
+
+**Approach rationale:** The SSO `ListAccounts` API already provides per-account names during role discovery. Using this data as the alias is correct, avoids cross-account IAM calls, and requires no additional API permissions.
+
+**Alternatives considered:**
+- Assuming a role in each target account and calling IAM `ListAccountAliases` per-account — correct but adds latency, complexity, and requires assume-role permissions
+- Using Organizations `DescribeAccount` — requires Organizations API access which not all users have
+
+## Regression Test
+
+**Test file:** `helpers/profile_generator_test.go`
+**Test names:** `TestGetAccountAlias_UsesSSO_NotIAM`, `TestGetAccountAlias_CrossAccountNotMislabeled`
+
+**What it verifies:**
+1. `GetAccountAlias` returns distinct per-account aliases from the SSO-populated cache
+2. Uncached accounts fall back to account ID instead of calling IAM
+3. Multiple accounts do not share the same alias
+
+**Run command:** `go test ./helpers/ -run "TestGetAccountAlias_UsesSSO_NotIAM|TestGetAccountAlias_CrossAccountNotMislabeled" -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/role_discovery.go` | Removed IAM client dependency; `GetAccountAlias` uses cache only; `getRolesForAccount` populates alias cache from SSO data |
+| `helpers/profile_generator.go` | Removed IAM client creation and struct field |
+| `helpers/profile_generator_test.go` | Added 2 regression tests; removed unused `MockIAMClient` |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When using AWS APIs, verify whether the API is account-scoped or cross-account capable
+- Prefer data already available from the discovery flow (SSO `AccountInfo`) over additional API calls
+
+## Related
+
+- Transit ticket: T-481


### PR DESCRIPTION
## Summary

- **Bug:** `GetAccountAlias` used IAM `ListAccountAliases` with the template profile's credentials, which always returns the alias for the currently authenticated account. Every discovered account received the same alias — the template profile's account alias.
- **Fix:** Use the SSO-provided `AccountName` (already available per-account from the `ListAccounts` API during role discovery) as the alias instead of making an IAM call that can only return the current account's alias.
- **Cleanup:** Removed the now-unnecessary IAM client dependency from `RoleDiscovery` and `ProfileGenerator`.

## Test plan

- [x] Regression test `TestGetAccountAlias_UsesSSO_NotIAM` — verifies per-account aliases from SSO cache and fallback to account ID
- [x] Regression test `TestGetAccountAlias_CrossAccountNotMislabeled` — verifies distinct aliases across multiple accounts
- [x] Full test suite passes (`go test ./...`)
- [x] Linters pass (`make test`)