### PR TITLE
Fix T-498: Handle Pagination in IAM Listing Helpers

### DIFF
--- a/docs/agent-notes/iam-helpers.md
+++ b/docs/agent-notes/iam-helpers.md
@@ -1,0 +1,35 @@
+# IAM Helpers
+
+## Architecture
+
+IAM helper functions live in three files:
+- `helpers/iam.go` — User/group listing, policy retrieval, account info
+- `helpers/iamroles.go` — Role listing, role policy retrieval, policy document caching
+- `helpers/iamresources.go` — Type definitions (IAMUser, IAMGroup, IAMRole, etc.), interface definitions, access key checks
+
+## IAMClient Interface
+
+An `IAMClient` interface is defined in `helpers/iam.go` covering all IAM SDK methods used by the helpers package. Functions accept this interface rather than `*iam.Client` directly, which enables unit testing with mocks. The concrete `*iam.Client` satisfies the interface.
+
+## Pagination
+
+All IAM list operations use AWS SDK v2 built-in paginators (e.g., `iam.NewListUsersPaginator`). This was added because AWS IAM list APIs return at most 100 items per page by default.
+
+Affected functions: `getUserList`, `GetPoliciesMap`, `GetUserPoliciesMapForUser`, `GetGroupPoliciesMapForGroup`, `GetAttachedPoliciesMapForUser`, `GetAttachedPoliciesMapForGroup`, `GetGroupNameSliceForUser`, `getAllUsersInGroup`, `GetGroupDetails`, `GetRoleDetails`, `getInlinePoliciesForRole`, `getAttachedPoliciesForRole`.
+
+## Caching
+
+- `cachedUsers` (package-level var) — caches the full user list from `getUserList()`. Must be reset to `nil` in tests.
+- `cachedIAMPolicyDocuments` (package-level map) — caches IAM policy documents by name to avoid re-fetching.
+
+## Testing
+
+- `helpers/iam_pagination_test.go` — Contains `mockIAMClient` that implements the `IAMClient` interface with configurable page sizes. Tests verify pagination by setting `pageSize: 2` with 5 items (forces 3 pages).
+- `helpers/iam_test.go` — Unit tests for IAMUser/IAMGroup methods, pure data tests (no AWS calls).
+- `helpers/iamroles_test.go` — Tests for role type detection, policy names, caching.
+
+## Call Sites
+
+- `cmd/iamuserlist.go` — Calls `GetUserDetails`, `GetGroupDetails`, `HasAccessKeys`, `GetLastAccessKeyDate`
+- `cmd/iamrolelist.go` — Calls `GetRolesAndPolicies`
+- `cmd/names.go` — Calls `GetAccountAlias`

--- a/helpers/iam.go
+++ b/helpers/iam.go
@@ -13,20 +13,48 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
+// IAMClient defines the subset of IAM client methods used by the helpers
+// package. The concrete *iam.Client satisfies this interface.
+type IAMClient interface {
+	ListUsers(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error)
+	ListGroups(ctx context.Context, params *iam.ListGroupsInput, optFns ...func(*iam.Options)) (*iam.ListGroupsOutput, error)
+	ListPolicies(ctx context.Context, params *iam.ListPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListPoliciesOutput, error)
+	ListUserPolicies(ctx context.Context, params *iam.ListUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListUserPoliciesOutput, error)
+	ListGroupPolicies(ctx context.Context, params *iam.ListGroupPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListGroupPoliciesOutput, error)
+	ListAttachedUserPolicies(ctx context.Context, params *iam.ListAttachedUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error)
+	ListAttachedGroupPolicies(ctx context.Context, params *iam.ListAttachedGroupPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedGroupPoliciesOutput, error)
+	ListGroupsForUser(ctx context.Context, params *iam.ListGroupsForUserInput, optFns ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error)
+	ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	ListRolePolicies(ctx context.Context, params *iam.ListRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
+	ListAttachedRolePolicies(ctx context.Context, params *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+	ListAccessKeys(ctx context.Context, params *iam.ListAccessKeysInput, optFns ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
+	ListAccountAliases(ctx context.Context, params *iam.ListAccountAliasesInput, optFns ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error)
+	GetUserPolicy(ctx context.Context, params *iam.GetUserPolicyInput, optFns ...func(*iam.Options)) (*iam.GetUserPolicyOutput, error)
+	GetGroupPolicy(ctx context.Context, params *iam.GetGroupPolicyInput, optFns ...func(*iam.Options)) (*iam.GetGroupPolicyOutput, error)
+	GetGroup(ctx context.Context, params *iam.GetGroupInput, optFns ...func(*iam.Options)) (*iam.GetGroupOutput, error)
+	GetPolicy(ctx context.Context, params *iam.GetPolicyInput, optFns ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+	GetPolicyVersion(ctx context.Context, params *iam.GetPolicyVersionInput, optFns ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
+	GetRolePolicy(ctx context.Context, params *iam.GetRolePolicyInput, optFns ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error)
+	GetAccountSummary(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error)
+	GetAccessKeyLastUsed(ctx context.Context, params *iam.GetAccessKeyLastUsedInput, optFns ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error)
+}
+
 var cachedUsers []types.User
 
 // GetPoliciesMap retrieves a map of policies with the policy name as the key
 // and the actual policy object as the value
-func GetPoliciesMap(svc *iam.Client) map[string]types.Policy {
+func GetPoliciesMap(svc IAMClient) map[string]types.Policy {
 	result := make(map[string]types.Policy)
 
-	params := &iam.ListPoliciesInput{}
-	resp, err := svc.ListPolicies(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	for _, policy := range resp.Policies {
-		result[*policy.PolicyName] = policy
+	paginator := iam.NewListPoliciesPaginator(svc, &iam.ListPoliciesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, policy := range page.Policies {
+			result[*policy.PolicyName] = policy
+		}
 	}
 	return result
 }
@@ -34,17 +62,18 @@ func GetPoliciesMap(svc *iam.Client) map[string]types.Policy {
 // GetUserPoliciesMapForUser retrieves a map of policies for the provided IAM
 // username where the key is the name of the policy and the value is the actual
 // json policy document
-func GetUserPoliciesMapForUser(username *string, svc *iam.Client) map[string]string {
+func GetUserPoliciesMapForUser(username *string, svc IAMClient) map[string]string {
 	result := make(map[string]string)
-	params := &iam.ListUserPoliciesInput{
+
+	paginator := iam.NewListUserPoliciesPaginator(svc, &iam.ListUserPoliciesInput{
 		UserName: username,
-	}
-	resp, err := svc.ListUserPolicies(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	if len(resp.PolicyNames) > 0 {
-		for _, policyname := range resp.PolicyNames {
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, policyname := range page.PolicyNames {
 			params := &iam.GetUserPolicyInput{
 				PolicyName: aws.String(policyname),
 				UserName:   username,
@@ -66,17 +95,18 @@ func GetUserPoliciesMapForUser(username *string, svc *iam.Client) map[string]str
 // GetGroupPoliciesMapForGroup retrieves a map of policies for the provided IAM
 // groupname where the key is the name of the policy and the value is the actual
 // json policy document
-func GetGroupPoliciesMapForGroup(groupname *string, svc *iam.Client) map[string]string {
+func GetGroupPoliciesMapForGroup(groupname *string, svc IAMClient) map[string]string {
 	result := make(map[string]string)
-	params := &iam.ListGroupPoliciesInput{
+
+	paginator := iam.NewListGroupPoliciesPaginator(svc, &iam.ListGroupPoliciesInput{
 		GroupName: groupname,
-	}
-	resp, err := svc.ListGroupPolicies(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	if len(resp.PolicyNames) > 0 {
-		for _, policyname := range resp.PolicyNames {
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, policyname := range page.PolicyNames {
 			params := &iam.GetGroupPolicyInput{
 				PolicyName: aws.String(policyname),
 				GroupName:  groupname,
@@ -98,7 +128,7 @@ func GetGroupPoliciesMapForGroup(groupname *string, svc *iam.Client) map[string]
 // GetGroupPoliciesMapForGroups retrieves all of the policies for the provided
 // slice of groups, where the key is the name of the policy and the value is the
 // json policy document
-func GetGroupPoliciesMapForGroups(groups []string, svc *iam.Client) map[string]string {
+func GetGroupPoliciesMapForGroups(groups []string, svc IAMClient) map[string]string {
 	result := make(map[string]string)
 	for _, group := range groups {
 		groupmap := GetGroupPoliciesMapForGroup(&group, svc)
@@ -110,17 +140,18 @@ func GetGroupPoliciesMapForGroups(groups []string, svc *iam.Client) map[string]s
 // GetAttachedPoliciesMapForUser retrieves a map of attached policies for the
 // provided IAM username where the key is the name of the policy and the value
 // is the actual json policy document
-func GetAttachedPoliciesMapForUser(username *string, svc *iam.Client) map[string]string {
+func GetAttachedPoliciesMapForUser(username *string, svc IAMClient) map[string]string {
 	result := make(map[string]string)
-	params := &iam.ListAttachedUserPoliciesInput{
+
+	paginator := iam.NewListAttachedUserPoliciesPaginator(svc, &iam.ListAttachedUserPoliciesInput{
 		UserName: username,
-	}
-	resp, err := svc.ListAttachedUserPolicies(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	if len(resp.AttachedPolicies) > 0 {
-		for _, policy := range resp.AttachedPolicies {
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, policy := range page.AttachedPolicies {
 			result[*policy.PolicyName] = getAttachedPolicy(policy.PolicyArn, svc)
 		}
 	}
@@ -130,17 +161,18 @@ func GetAttachedPoliciesMapForUser(username *string, svc *iam.Client) map[string
 // GetAttachedPoliciesMapForGroup retrieves a map of attached policies for the
 // provided IAM groupname where the key is the name of the policy and the value
 // is the actual json policy document
-func GetAttachedPoliciesMapForGroup(groupname *string, svc *iam.Client) map[string]string {
+func GetAttachedPoliciesMapForGroup(groupname *string, svc IAMClient) map[string]string {
 	result := make(map[string]string)
-	params := &iam.ListAttachedGroupPoliciesInput{
+
+	paginator := iam.NewListAttachedGroupPoliciesPaginator(svc, &iam.ListAttachedGroupPoliciesInput{
 		GroupName: groupname,
-	}
-	resp, err := svc.ListAttachedGroupPolicies(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	if len(resp.AttachedPolicies) > 0 {
-		for _, policy := range resp.AttachedPolicies {
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, policy := range page.AttachedPolicies {
 			result[*policy.PolicyName] = getAttachedPolicy(policy.PolicyArn, svc)
 		}
 	}
@@ -150,7 +182,7 @@ func GetAttachedPoliciesMapForGroup(groupname *string, svc *iam.Client) map[stri
 // GetAttachedPoliciesMapForGroups retrieves a map of attached policies for the
 // slice of IAM groupnames where the key is the name of the policy and the value
 // is the actual json policy document
-func GetAttachedPoliciesMapForGroups(groups []string, svc *iam.Client) map[string]string {
+func GetAttachedPoliciesMapForGroups(groups []string, svc IAMClient) map[string]string {
 	result := make(map[string]string)
 	for _, group := range groups {
 		groupmap := GetAttachedPoliciesMapForGroup(&group, svc)
@@ -161,19 +193,19 @@ func GetAttachedPoliciesMapForGroups(groups []string, svc *iam.Client) map[strin
 
 // GetGroupNameSliceForUser retrieves a slice of all the groups the provided
 // IAM username belongs to
-func GetGroupNameSliceForUser(username *string, svc *iam.Client) []string {
-	params := &iam.ListGroupsForUserInput{
-		UserName: username,
-	}
-	resp, err := svc.ListGroupsForUser(context.TODO(), params)
+func GetGroupNameSliceForUser(username *string, svc IAMClient) []string {
+	var groups []string
 
-	if err != nil {
-		panic(err)
-	}
-	groups := make([]string, len(resp.Groups))
-	if len(resp.Groups) > 0 {
-		for counter, group := range resp.Groups {
-			groups[counter] = *group.GroupName
+	paginator := iam.NewListGroupsForUserPaginator(svc, &iam.ListGroupsForUserInput{
+		UserName: username,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, group := range page.Groups {
+			groups = append(groups, *group.GroupName)
 		}
 	}
 	return groups
@@ -181,7 +213,7 @@ func GetGroupNameSliceForUser(username *string, svc *iam.Client) []string {
 
 // GetAccountSummary retrieves the account summary map which contains high level
 // information about the root account
-func GetAccountSummary(svc *iam.Client) (map[string]int32, error) {
+func GetAccountSummary(svc IAMClient) (map[string]int32, error) {
 	input := &iam.GetAccountSummaryInput{}
 
 	result, err := svc.GetAccountSummary(context.TODO(), input)
@@ -195,20 +227,23 @@ func GetAccountSummary(svc *iam.Client) (map[string]int32, error) {
 	return result.SummaryMap, nil
 }
 
-func getUserList(svc *iam.Client) []types.User {
+func getUserList(svc IAMClient) []types.User {
 	if cachedUsers == nil {
-		resp, err := svc.ListUsers(context.TODO(), &iam.ListUsersInput{})
-		if err != nil {
-			panic(err)
+		paginator := iam.NewListUsersPaginator(svc, &iam.ListUsersInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(context.TODO())
+			if err != nil {
+				panic(err)
+			}
+			cachedUsers = append(cachedUsers, page.Users...)
 		}
-		cachedUsers = resp.Users
 	}
 	return cachedUsers
 }
 
 // GetUserDetails collects detailed information about a user, consisting mostly
 // of the groups and policies it follows.
-func GetUserDetails(svc *iam.Client) []IAMUser {
+func GetUserDetails(svc IAMClient) []IAMUser {
 	users := getUserList(svc)
 	c := make(chan IAMUser)
 	userlist := make([]IAMUser, len(users))
@@ -232,31 +267,41 @@ func GetUserDetails(svc *iam.Client) []IAMUser {
 	return userlist
 }
 
-func getAllUsersInGroup(groupname string, svc *iam.Client) []string {
-	input := iam.GetGroupInput{
+func getAllUsersInGroup(groupname string, svc IAMClient) []string {
+	var result []string
+
+	paginator := iam.NewGetGroupPaginator(svc, &iam.GetGroupInput{
 		GroupName: &groupname,
-	}
-	resp, err := svc.GetGroup(context.TODO(), &input)
-	if err != nil {
-		panic(err)
-	}
-	result := []string{}
-	for _, user := range resp.Users {
-		result = append(result, *user.UserName)
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, user := range page.Users {
+			result = append(result, *user.UserName)
+		}
 	}
 	return result
 }
 
 // GetGroupDetails collects detailed information about a group, consisting mostly
 // of the users and policies it follows.
-func GetGroupDetails(svc *iam.Client) []IAMGroup {
-	resp, err := svc.ListGroups(context.TODO(), &iam.ListGroupsInput{})
-	if err != nil {
-		panic(err)
+func GetGroupDetails(svc IAMClient) []IAMGroup {
+	var allGroups []types.Group
+
+	paginator := iam.NewListGroupsPaginator(svc, &iam.ListGroupsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		allGroups = append(allGroups, page.Groups...)
 	}
+
 	c := make(chan IAMGroup)
-	grouplist := make([]IAMGroup, len(resp.Groups))
-	for _, group := range resp.Groups {
+	grouplist := make([]IAMGroup, len(allGroups))
+	for _, group := range allGroups {
 		go func(group types.Group) {
 			groupStruct := IAMGroup{
 				Name:  *group.GroupName,
@@ -268,7 +313,7 @@ func GetGroupDetails(svc *iam.Client) []IAMGroup {
 			c <- groupStruct
 		}(group)
 	}
-	for i := 0; i < len(resp.Groups); i++ {
+	for i := 0; i < len(allGroups); i++ {
 		grouplist[i] = <-c
 	}
 	return grouplist
@@ -301,7 +346,7 @@ func GetAccountAlias(svc *iam.Client, stsSvc *sts.Client) map[string]string {
 	return alias
 }
 
-func getAttachedPolicy(policyArn *string, svc *iam.Client) string {
+func getAttachedPolicy(policyArn *string, svc IAMClient) string {
 	params := &iam.GetPolicyInput{
 		PolicyArn: policyArn,
 	}

--- a/helpers/iam_pagination_test.go
+++ b/helpers/iam_pagination_test.go
@@ -1,0 +1,591 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// mockIAMClient implements the IAMClient interface for testing.
+// It simulates paginated responses by splitting data across pages.
+type mockIAMClient struct {
+	users           []types.User
+	groups          []types.Group
+	policies        []types.Policy
+	userPolicies    map[string][]string               // username -> policy names
+	groupPolicies   map[string][]string               // groupname -> policy names
+	attachedUserPol map[string][]types.AttachedPolicy // username -> attached policies
+	attachedGrpPol  map[string][]types.AttachedPolicy // groupname -> attached policies
+	groupsForUser   map[string][]types.Group          // username -> groups
+	usersInGroup    map[string][]types.User           // groupname -> users
+	pageSize        int                               // items per page for simulating truncation
+}
+
+// Ensure mockIAMClient satisfies IAMClient at compile time.
+var _ IAMClient = (*mockIAMClient)(nil)
+
+// ListUsers returns paginated user results. The mock uses Marker for pagination.
+func (m *mockIAMClient) ListUsers(_ context.Context, input *iam.ListUsersInput, _ ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(m.users) {
+		end = len(m.users)
+	}
+	output := &iam.ListUsersOutput{
+		Users:       m.users[start:end],
+		IsTruncated: end < len(m.users),
+	}
+	if end < len(m.users) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// ListGroups returns paginated group results.
+func (m *mockIAMClient) ListGroups(_ context.Context, input *iam.ListGroupsInput, _ ...func(*iam.Options)) (*iam.ListGroupsOutput, error) {
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(m.groups) {
+		end = len(m.groups)
+	}
+	output := &iam.ListGroupsOutput{
+		Groups:      m.groups[start:end],
+		IsTruncated: end < len(m.groups),
+	}
+	if end < len(m.groups) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// ListPolicies returns paginated policy results.
+func (m *mockIAMClient) ListPolicies(_ context.Context, input *iam.ListPoliciesInput, _ ...func(*iam.Options)) (*iam.ListPoliciesOutput, error) {
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(m.policies) {
+		end = len(m.policies)
+	}
+	output := &iam.ListPoliciesOutput{
+		Policies:    m.policies[start:end],
+		IsTruncated: end < len(m.policies),
+	}
+	if end < len(m.policies) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// ListUserPolicies returns paginated inline policy names for a user.
+func (m *mockIAMClient) ListUserPolicies(_ context.Context, input *iam.ListUserPoliciesInput, _ ...func(*iam.Options)) (*iam.ListUserPoliciesOutput, error) {
+	allPolicies := m.userPolicies[*input.UserName]
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(allPolicies) {
+		end = len(allPolicies)
+	}
+	output := &iam.ListUserPoliciesOutput{
+		PolicyNames: allPolicies[start:end],
+		IsTruncated: end < len(allPolicies),
+	}
+	if end < len(allPolicies) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// GetUserPolicy returns a user policy document.
+func (m *mockIAMClient) GetUserPolicy(_ context.Context, input *iam.GetUserPolicyInput, _ ...func(*iam.Options)) (*iam.GetUserPolicyOutput, error) {
+	doc := fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:Get*","Resource":"*"}]}`)
+	return &iam.GetUserPolicyOutput{
+		PolicyName:     input.PolicyName,
+		UserName:       input.UserName,
+		PolicyDocument: &doc,
+	}, nil
+}
+
+// ListGroupPolicies returns paginated inline policy names for a group.
+func (m *mockIAMClient) ListGroupPolicies(_ context.Context, input *iam.ListGroupPoliciesInput, _ ...func(*iam.Options)) (*iam.ListGroupPoliciesOutput, error) {
+	allPolicies := m.groupPolicies[*input.GroupName]
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(allPolicies) {
+		end = len(allPolicies)
+	}
+	output := &iam.ListGroupPoliciesOutput{
+		PolicyNames: allPolicies[start:end],
+		IsTruncated: end < len(allPolicies),
+	}
+	if end < len(allPolicies) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// GetGroupPolicy returns a group policy document.
+func (m *mockIAMClient) GetGroupPolicy(_ context.Context, input *iam.GetGroupPolicyInput, _ ...func(*iam.Options)) (*iam.GetGroupPolicyOutput, error) {
+	doc := fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:Get*","Resource":"*"}]}`)
+	return &iam.GetGroupPolicyOutput{
+		PolicyName:     input.PolicyName,
+		GroupName:      input.GroupName,
+		PolicyDocument: &doc,
+	}, nil
+}
+
+// ListAttachedUserPolicies returns paginated attached policies for a user.
+func (m *mockIAMClient) ListAttachedUserPolicies(_ context.Context, input *iam.ListAttachedUserPoliciesInput, _ ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error) {
+	allPolicies := m.attachedUserPol[*input.UserName]
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(allPolicies) {
+		end = len(allPolicies)
+	}
+	output := &iam.ListAttachedUserPoliciesOutput{
+		AttachedPolicies: allPolicies[start:end],
+		IsTruncated:      end < len(allPolicies),
+	}
+	if end < len(allPolicies) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// ListAttachedGroupPolicies returns paginated attached policies for a group.
+func (m *mockIAMClient) ListAttachedGroupPolicies(_ context.Context, input *iam.ListAttachedGroupPoliciesInput, _ ...func(*iam.Options)) (*iam.ListAttachedGroupPoliciesOutput, error) {
+	allPolicies := m.attachedGrpPol[*input.GroupName]
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(allPolicies) {
+		end = len(allPolicies)
+	}
+	output := &iam.ListAttachedGroupPoliciesOutput{
+		AttachedPolicies: allPolicies[start:end],
+		IsTruncated:      end < len(allPolicies),
+	}
+	if end < len(allPolicies) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// ListGroupsForUser returns paginated groups for a user.
+func (m *mockIAMClient) ListGroupsForUser(_ context.Context, input *iam.ListGroupsForUserInput, _ ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error) {
+	allGroups := m.groupsForUser[*input.UserName]
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(allGroups) {
+		end = len(allGroups)
+	}
+	output := &iam.ListGroupsForUserOutput{
+		Groups:      allGroups[start:end],
+		IsTruncated: end < len(allGroups),
+	}
+	if end < len(allGroups) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// GetGroup returns paginated users in a group.
+func (m *mockIAMClient) GetGroup(_ context.Context, input *iam.GetGroupInput, _ ...func(*iam.Options)) (*iam.GetGroupOutput, error) {
+	allUsers := m.usersInGroup[*input.GroupName]
+	start := 0
+	if input.Marker != nil {
+		fmt.Sscanf(*input.Marker, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(allUsers) {
+		end = len(allUsers)
+	}
+	output := &iam.GetGroupOutput{
+		Users:       allUsers[start:end],
+		IsTruncated: end < len(allUsers),
+		Group: &types.Group{
+			GroupName: input.GroupName,
+			GroupId:   aws.String("AGPA" + *input.GroupName),
+			Arn:       aws.String("arn:aws:iam::123456789012:group/" + *input.GroupName),
+			Path:      aws.String("/"),
+		},
+	}
+	if end < len(allUsers) {
+		marker := fmt.Sprintf("%d", end)
+		output.Marker = &marker
+	}
+	return output, nil
+}
+
+// GetPolicy returns a policy with a default version.
+func (m *mockIAMClient) GetPolicy(_ context.Context, input *iam.GetPolicyInput, _ ...func(*iam.Options)) (*iam.GetPolicyOutput, error) {
+	return &iam.GetPolicyOutput{
+		Policy: &types.Policy{
+			PolicyName:       aws.String("mock-policy"),
+			Arn:              input.PolicyArn,
+			DefaultVersionId: aws.String("v1"),
+		},
+	}, nil
+}
+
+// GetPolicyVersion returns a policy version document.
+func (m *mockIAMClient) GetPolicyVersion(_ context.Context, _ *iam.GetPolicyVersionInput, _ ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error) {
+	doc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`
+	return &iam.GetPolicyVersionOutput{
+		PolicyVersion: &types.PolicyVersion{
+			Document:  &doc,
+			VersionId: aws.String("v1"),
+		},
+	}, nil
+}
+
+// ListRoles stub for interface compliance.
+func (m *mockIAMClient) ListRoles(_ context.Context, input *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	return &iam.ListRolesOutput{}, nil
+}
+
+// ListRolePolicies stub for interface compliance.
+func (m *mockIAMClient) ListRolePolicies(_ context.Context, _ *iam.ListRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+	return &iam.ListRolePoliciesOutput{}, nil
+}
+
+// ListAttachedRolePolicies stub for interface compliance.
+func (m *mockIAMClient) ListAttachedRolePolicies(_ context.Context, _ *iam.ListAttachedRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+	return &iam.ListAttachedRolePoliciesOutput{}, nil
+}
+
+// ListAccessKeys stub for interface compliance.
+func (m *mockIAMClient) ListAccessKeys(_ context.Context, _ *iam.ListAccessKeysInput, _ ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+	return &iam.ListAccessKeysOutput{}, nil
+}
+
+// ListAccountAliases stub for interface compliance.
+func (m *mockIAMClient) ListAccountAliases(_ context.Context, _ *iam.ListAccountAliasesInput, _ ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error) {
+	return &iam.ListAccountAliasesOutput{}, nil
+}
+
+// GetRolePolicy stub for interface compliance.
+func (m *mockIAMClient) GetRolePolicy(_ context.Context, _ *iam.GetRolePolicyInput, _ ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error) {
+	return &iam.GetRolePolicyOutput{}, nil
+}
+
+// GetAccountSummary stub for interface compliance.
+func (m *mockIAMClient) GetAccountSummary(_ context.Context, _ *iam.GetAccountSummaryInput, _ ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error) {
+	return &iam.GetAccountSummaryOutput{SummaryMap: map[string]int32{}}, nil
+}
+
+// GetAccessKeyLastUsed stub for interface compliance.
+func (m *mockIAMClient) GetAccessKeyLastUsed(_ context.Context, _ *iam.GetAccessKeyLastUsedInput, _ ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error) {
+	return &iam.GetAccessKeyLastUsedOutput{}, nil
+}
+
+// makeUsers creates n test users.
+func makeUsers(n int) []types.User {
+	users := make([]types.User, n)
+	for i := range n {
+		name := fmt.Sprintf("user-%03d", i)
+		id := fmt.Sprintf("AIDA%012d", i)
+		users[i] = types.User{
+			UserName: &name,
+			UserId:   &id,
+			Arn:      aws.String(fmt.Sprintf("arn:aws:iam::123456789012:user/%s", name)),
+			Path:     aws.String("/"),
+		}
+	}
+	return users
+}
+
+// makeGroups creates n test groups.
+func makeGroups(n int) []types.Group {
+	groups := make([]types.Group, n)
+	for i := range n {
+		name := fmt.Sprintf("group-%03d", i)
+		id := fmt.Sprintf("AGPA%012d", i)
+		groups[i] = types.Group{
+			GroupName: &name,
+			GroupId:   &id,
+			Arn:       aws.String(fmt.Sprintf("arn:aws:iam::123456789012:group/%s", name)),
+			Path:      aws.String("/"),
+		}
+	}
+	return groups
+}
+
+// makePolicyNames creates n policy names.
+func makePolicyNames(n int, prefix string) []string {
+	names := make([]string, n)
+	for i := range n {
+		names[i] = fmt.Sprintf("%s-policy-%03d", prefix, i)
+	}
+	return names
+}
+
+// makeAttachedPolicies creates n attached policies.
+func makeAttachedPolicies(n int, prefix string) []types.AttachedPolicy {
+	policies := make([]types.AttachedPolicy, n)
+	for i := range n {
+		name := fmt.Sprintf("%s-attached-%03d", prefix, i)
+		arn := fmt.Sprintf("arn:aws:iam::123456789012:policy/%s", name)
+		policies[i] = types.AttachedPolicy{
+			PolicyName: &name,
+			PolicyArn:  &arn,
+		}
+	}
+	return policies
+}
+
+// TestGetUserList_Pagination verifies that getUserList retrieves all users
+// across multiple pages. Before the fix, only the first page was returned.
+func TestGetUserList_Pagination(t *testing.T) {
+	// Reset the cached users so we get a fresh call
+	cachedUsers = nil
+
+	totalUsers := 5
+	mock := &mockIAMClient{
+		users:    makeUsers(totalUsers),
+		pageSize: 2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := getUserList(mock)
+
+	if len(result) != totalUsers {
+		t.Errorf("getUserList() returned %d users, want %d (pagination bug: only first page returned)", len(result), totalUsers)
+	}
+
+	// Verify all users are present
+	for i, user := range result {
+		expected := fmt.Sprintf("user-%03d", i)
+		if *user.UserName != expected {
+			t.Errorf("getUserList()[%d].UserName = %s, want %s", i, *user.UserName, expected)
+		}
+	}
+
+	// Clean up cache
+	cachedUsers = nil
+}
+
+// TestGetGroupNameSliceForUser_Pagination verifies that all groups for a user
+// are returned across multiple pages.
+func TestGetGroupNameSliceForUser_Pagination(t *testing.T) {
+	totalGroups := 5
+	groups := makeGroups(totalGroups)
+
+	mock := &mockIAMClient{
+		groupsForUser: map[string][]types.Group{
+			"test-user": groups,
+		},
+		pageSize: 2,
+	}
+
+	username := "test-user"
+	result := GetGroupNameSliceForUser(&username, mock)
+
+	if len(result) != totalGroups {
+		t.Errorf("GetGroupNameSliceForUser() returned %d groups, want %d (pagination bug)", len(result), totalGroups)
+	}
+
+	for i, name := range result {
+		expected := fmt.Sprintf("group-%03d", i)
+		if name != expected {
+			t.Errorf("GetGroupNameSliceForUser()[%d] = %s, want %s", i, name, expected)
+		}
+	}
+}
+
+// TestGetAllUsersInGroup_Pagination verifies that all users in a group
+// are returned across multiple pages.
+func TestGetAllUsersInGroup_Pagination(t *testing.T) {
+	totalUsers := 5
+	users := makeUsers(totalUsers)
+
+	mock := &mockIAMClient{
+		usersInGroup: map[string][]types.User{
+			"test-group": users,
+		},
+		pageSize: 2,
+	}
+
+	result := getAllUsersInGroup("test-group", mock)
+
+	if len(result) != totalUsers {
+		t.Errorf("getAllUsersInGroup() returned %d users, want %d (pagination bug)", len(result), totalUsers)
+	}
+}
+
+// TestGetUserPoliciesMapForUser_Pagination verifies that all inline policies
+// for a user are returned across multiple pages.
+func TestGetUserPoliciesMapForUser_Pagination(t *testing.T) {
+	totalPolicies := 5
+	policyNames := makePolicyNames(totalPolicies, "user-inline")
+
+	mock := &mockIAMClient{
+		userPolicies: map[string][]string{
+			"test-user": policyNames,
+		},
+		pageSize: 2,
+	}
+
+	username := "test-user"
+	result := GetUserPoliciesMapForUser(&username, mock)
+
+	if len(result) != totalPolicies {
+		t.Errorf("GetUserPoliciesMapForUser() returned %d policies, want %d (pagination bug)", len(result), totalPolicies)
+	}
+}
+
+// TestGetGroupPoliciesMapForGroup_Pagination verifies that all inline policies
+// for a group are returned across multiple pages.
+func TestGetGroupPoliciesMapForGroup_Pagination(t *testing.T) {
+	totalPolicies := 5
+	policyNames := makePolicyNames(totalPolicies, "group-inline")
+
+	mock := &mockIAMClient{
+		groupPolicies: map[string][]string{
+			"test-group": policyNames,
+		},
+		pageSize: 2,
+	}
+
+	groupname := "test-group"
+	result := GetGroupPoliciesMapForGroup(&groupname, mock)
+
+	if len(result) != totalPolicies {
+		t.Errorf("GetGroupPoliciesMapForGroup() returned %d policies, want %d (pagination bug)", len(result), totalPolicies)
+	}
+}
+
+// TestGetAttachedPoliciesMapForUser_Pagination verifies that all attached
+// policies for a user are returned across multiple pages.
+func TestGetAttachedPoliciesMapForUser_Pagination(t *testing.T) {
+	totalPolicies := 5
+	policies := makeAttachedPolicies(totalPolicies, "user")
+
+	mock := &mockIAMClient{
+		attachedUserPol: map[string][]types.AttachedPolicy{
+			"test-user": policies,
+		},
+		pageSize: 2,
+	}
+
+	username := "test-user"
+	result := GetAttachedPoliciesMapForUser(&username, mock)
+
+	if len(result) != totalPolicies {
+		t.Errorf("GetAttachedPoliciesMapForUser() returned %d policies, want %d (pagination bug)", len(result), totalPolicies)
+	}
+}
+
+// TestGetAttachedPoliciesMapForGroup_Pagination verifies that all attached
+// policies for a group are returned across multiple pages.
+func TestGetAttachedPoliciesMapForGroup_Pagination(t *testing.T) {
+	totalPolicies := 5
+	policies := makeAttachedPolicies(totalPolicies, "group")
+
+	mock := &mockIAMClient{
+		attachedGrpPol: map[string][]types.AttachedPolicy{
+			"test-group": policies,
+		},
+		pageSize: 2,
+	}
+
+	groupname := "test-group"
+	result := GetAttachedPoliciesMapForGroup(&groupname, mock)
+
+	if len(result) != totalPolicies {
+		t.Errorf("GetAttachedPoliciesMapForGroup() returned %d policies, want %d (pagination bug)", len(result), totalPolicies)
+	}
+}
+
+// TestGetPoliciesMap_Pagination verifies that all policies are returned
+// across multiple pages.
+func TestGetPoliciesMap_Pagination(t *testing.T) {
+	totalPolicies := 5
+	policies := make([]types.Policy, totalPolicies)
+	for i := range totalPolicies {
+		name := fmt.Sprintf("policy-%03d", i)
+		arn := fmt.Sprintf("arn:aws:iam::123456789012:policy/%s", name)
+		policies[i] = types.Policy{
+			PolicyName: &name,
+			Arn:        &arn,
+		}
+	}
+
+	mock := &mockIAMClient{
+		policies: policies,
+		pageSize: 2,
+	}
+
+	result := GetPoliciesMap(mock)
+
+	if len(result) != totalPolicies {
+		t.Errorf("GetPoliciesMap() returned %d policies, want %d (pagination bug)", len(result), totalPolicies)
+	}
+}

--- a/helpers/iamresources.go
+++ b/helpers/iamresources.go
@@ -179,7 +179,7 @@ func (user IAMUser) GetInheritedPolicies() map[string]string {
 }
 
 // HasAccessKeys checks if a user has access keys
-func (user IAMUser) HasAccessKeys(svc *iam.Client) bool {
+func (user IAMUser) HasAccessKeys(svc IAMClient) bool {
 	input := &iam.ListAccessKeysInput{
 		UserName: aws.String(user.Name),
 	}
@@ -192,7 +192,7 @@ func (user IAMUser) HasAccessKeys(svc *iam.Client) bool {
 }
 
 // GetLastAccessKeyDate returns the last date an access key was used
-func (user IAMUser) GetLastAccessKeyDate(svc *iam.Client) time.Time {
+func (user IAMUser) GetLastAccessKeyDate(svc IAMClient) time.Time {
 	input := &iam.ListAccessKeysInput{
 		UserName: aws.String(user.Name),
 	}

--- a/helpers/iamroles.go
+++ b/helpers/iamroles.go
@@ -14,7 +14,7 @@ import (
 var cachedIAMPolicyDocuments = make(map[string]*IAMPolicyDocument)
 
 // GetRolesAndPolicies returns all the roles and and their attached policies
-func GetRolesAndPolicies(verbose bool, svc *iam.Client) ([]IAMRole, map[string]IAMPolicyDocument) {
+func GetRolesAndPolicies(verbose bool, svc IAMClient) ([]IAMRole, map[string]IAMPolicyDocument) {
 	roles := GetRoleDetails(verbose, svc)
 	policies := make(map[string]IAMPolicyDocument)
 	for _, role := range roles {
@@ -30,42 +30,46 @@ func GetRolesAndPolicies(verbose bool, svc *iam.Client) ([]IAMRole, map[string]I
 }
 
 // GetRoleDetails returns the list of roles in the account
-func GetRoleDetails(verbose bool, svc *iam.Client) []IAMRole {
+func GetRoleDetails(verbose bool, svc IAMClient) []IAMRole {
 	result := []IAMRole{}
-	resp, err := svc.ListRoles(context.TODO(), &iam.ListRolesInput{})
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	for _, role := range resp.Roles {
-		policydocument := IAMPolicyDocument{Type: IAMPolicyTypeAssumeRole}
-		decodeddocument, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
+
+	paginator := iam.NewListRolesPaginator(svc, &iam.ListRolesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
 		if err != nil {
-			panic(err)
+			log.Fatal(err.Error())
 		}
-		err = json.Unmarshal([]byte(decodeddocument), &policydocument)
-		if err != nil {
-			panic(err)
+		for _, role := range page.Roles {
+			policydocument := IAMPolicyDocument{Type: IAMPolicyTypeAssumeRole}
+			decodeddocument, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
+			if err != nil {
+				panic(err)
+			}
+			err = json.Unmarshal([]byte(decodeddocument), &policydocument)
+			if err != nil {
+				panic(err)
+			}
+			inlinepolicies := getInlinePoliciesForRole(*role.RoleName, verbose, svc)
+			attachedpolicies := getAttachedPoliciesForRole(*role.RoleName, verbose, svc)
+			rolestruct := IAMRole{
+				Name:             *role.RoleName,
+				ID:               *role.RoleId,
+				AssumeRolePolicy: policydocument,
+				Path:             *role.Path,
+				Role:             &role,
+				InlinePolicies:   inlinepolicies,
+				AttachedPolicies: attachedpolicies,
+				Type:             getRoleType(role),
+				Verbose:          verbose,
+			}
+			for _, policy := range rolestruct.InlinePolicies {
+				policy.AddRole(&rolestruct)
+			}
+			for _, policy := range rolestruct.AttachedPolicies {
+				policy.AddRole(&rolestruct)
+			}
+			result = append(result, rolestruct)
 		}
-		inlinepolicies := getInlinePoliciesForRole(*role.RoleName, verbose, svc)
-		attachedpolicies := getAttachedPoliciesForRole(*role.RoleName, verbose, svc)
-		rolestruct := IAMRole{
-			Name:             *role.RoleName,
-			ID:               *role.RoleId,
-			AssumeRolePolicy: policydocument,
-			Path:             *role.Path,
-			Role:             &role,
-			InlinePolicies:   inlinepolicies,
-			AttachedPolicies: attachedpolicies,
-			Type:             getRoleType(role),
-			Verbose:          verbose,
-		}
-		for _, policy := range rolestruct.InlinePolicies {
-			policy.AddRole(&rolestruct)
-		}
-		for _, policy := range rolestruct.AttachedPolicies {
-			policy.AddRole(&rolestruct)
-		}
-		result = append(result, rolestruct)
 	}
 	return result
 }
@@ -81,75 +85,81 @@ func getRoleType(role types.Role) string {
 	return IAMRoleTypeUserDefined
 }
 
-func getInlinePoliciesForRole(rolename string, verbose bool, svc *iam.Client) map[string]*IAMPolicyDocument {
-	input := &iam.ListRolePoliciesInput{RoleName: &rolename}
-	resp, err := svc.ListRolePolicies(context.TODO(), input)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
+func getInlinePoliciesForRole(rolename string, verbose bool, svc IAMClient) map[string]*IAMPolicyDocument {
 	policies := make(map[string]*IAMPolicyDocument)
-	for _, policy := range resp.PolicyNames {
-		policyname := rolename + policy
-		if _, ok := cachedIAMPolicyDocuments[policyname]; !ok {
-			policydocument := IAMPolicyDocument{
-				Name: policy,
-				Type: IAMPolicyTypeInline,
-			}
-			if verbose {
-				detailinput := &iam.GetRolePolicyInput{
-					RoleName:   &rolename,
-					PolicyName: &policy,
-				}
-				detailresp, err := svc.GetRolePolicy(context.TODO(), detailinput)
-				if err != nil {
-					log.Fatal(err.Error())
-				}
 
-				decodeddocument, err := url.QueryUnescape(*detailresp.PolicyDocument)
-				if err != nil {
-					panic(err)
-				}
-				err = json.Unmarshal([]byte(decodeddocument), &policydocument)
-				if err != nil {
-					panic(err)
-				}
-			}
-			cachedIAMPolicyDocuments[policyname] = &policydocument
+	paginator := iam.NewListRolePoliciesPaginator(svc, &iam.ListRolePoliciesInput{RoleName: &rolename})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			log.Fatal(err.Error())
 		}
-		policies[policyname] = cachedIAMPolicyDocuments[policyname]
+		for _, policy := range page.PolicyNames {
+			policyname := rolename + policy
+			if _, ok := cachedIAMPolicyDocuments[policyname]; !ok {
+				policydocument := IAMPolicyDocument{
+					Name: policy,
+					Type: IAMPolicyTypeInline,
+				}
+				if verbose {
+					detailinput := &iam.GetRolePolicyInput{
+						RoleName:   &rolename,
+						PolicyName: &policy,
+					}
+					detailresp, err := svc.GetRolePolicy(context.TODO(), detailinput)
+					if err != nil {
+						log.Fatal(err.Error())
+					}
+
+					decodeddocument, err := url.QueryUnescape(*detailresp.PolicyDocument)
+					if err != nil {
+						panic(err)
+					}
+					err = json.Unmarshal([]byte(decodeddocument), &policydocument)
+					if err != nil {
+						panic(err)
+					}
+				}
+				cachedIAMPolicyDocuments[policyname] = &policydocument
+			}
+			policies[policyname] = cachedIAMPolicyDocuments[policyname]
+		}
 	}
 	return policies
 }
 
 // getAttachedPoliciesForRole(rolename string, svc *iam.IAM) map[string]
-func getAttachedPoliciesForRole(rolename string, verbose bool, svc *iam.Client) map[string]*IAMPolicyDocument {
-	input := &iam.ListAttachedRolePoliciesInput{RoleName: &rolename}
-	resp, err := svc.ListAttachedRolePolicies(context.TODO(), input)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
+func getAttachedPoliciesForRole(rolename string, verbose bool, svc IAMClient) map[string]*IAMPolicyDocument {
 	policies := make(map[string]*IAMPolicyDocument)
-	for _, policy := range resp.AttachedPolicies {
-		policyname := *policy.PolicyName
-		if _, ok := cachedIAMPolicyDocuments[policyname]; !ok {
-			policydocument := IAMPolicyDocument{
-				Type: IAMPolicyTypeAttached,
-				Name: policyname,
-			}
-			if verbose {
-				policystring := getAttachedPolicy(policy.PolicyArn, svc)
-				decodeddocument, err := url.QueryUnescape(policystring)
-				if err != nil {
-					panic(err)
-				}
-				err = json.Unmarshal([]byte(decodeddocument), &policydocument)
-				if err != nil {
-					panic(err)
-				}
-			}
-			cachedIAMPolicyDocuments[policyname] = &policydocument
+
+	paginator := iam.NewListAttachedRolePoliciesPaginator(svc, &iam.ListAttachedRolePoliciesInput{RoleName: &rolename})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			log.Fatal(err.Error())
 		}
-		policies[policyname] = cachedIAMPolicyDocuments[policyname]
+		for _, policy := range page.AttachedPolicies {
+			policyname := *policy.PolicyName
+			if _, ok := cachedIAMPolicyDocuments[policyname]; !ok {
+				policydocument := IAMPolicyDocument{
+					Type: IAMPolicyTypeAttached,
+					Name: policyname,
+				}
+				if verbose {
+					policystring := getAttachedPolicy(policy.PolicyArn, svc)
+					decodeddocument, err := url.QueryUnescape(policystring)
+					if err != nil {
+						panic(err)
+					}
+					err = json.Unmarshal([]byte(decodeddocument), &policydocument)
+					if err != nil {
+						panic(err)
+					}
+				}
+				cachedIAMPolicyDocuments[policyname] = &policydocument
+			}
+			policies[policyname] = cachedIAMPolicyDocuments[policyname]
+		}
 	}
 	return policies
 }

--- a/specs/bugfixes/iam-listing-pagination/report.md
+++ b/specs/bugfixes/iam-listing-pagination/report.md
@@ -1,0 +1,83 @@
+# Bugfix Report: IAM Listing Pagination
+
+**Date:** 2026-03-20
+**Status:** Fixed
+
+## Description of the Issue
+
+IAM helper functions in `helpers/iam.go` and `helpers/iamroles.go` made single-page API calls without processing pagination markers. AWS IAM list APIs return at most 100 items per page by default. Accounts exceeding this limit would silently receive incomplete data.
+
+**Reproduction steps:**
+1. Have an AWS account with more than 100 IAM users, groups, roles, or policies
+2. Run `awstools iam userlist` or `awstools iam rolelist`
+3. Observe that only the first 100 items are returned
+
+**Impact:** Any account with more than 100 IAM resources of a given type would get incomplete results from the userlist and rolelist commands. This affects all downstream operations that depend on complete IAM data.
+
+## Investigation Summary
+
+Examined all IAM API call sites in `helpers/iam.go` and `helpers/iamroles.go` and identified that none of the list/get-group operations handled pagination.
+
+- **Symptoms examined:** Single API call per list operation, no pagination loop
+- **Code inspected:** `helpers/iam.go`, `helpers/iamroles.go`, `helpers/iamresources.go`
+- **Hypotheses tested:** Confirmed that AWS SDK v2 provides built-in paginators for all affected APIs
+
+## Discovered Root Cause
+
+Every IAM list helper made exactly one API call and used only the items from that single response page.
+
+**Defect type:** Missing pagination handling
+
+**Why it occurred:** The original implementation was likely written against small test accounts where results fit in a single page, so the truncation was never observed.
+
+**Contributing factors:** AWS IAM APIs default to 100 items per page. The SDK does not warn when responses are truncated.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/iam.go` - Introduced `IAMClient` interface; replaced all single-call list operations with SDK paginator loops
+- `helpers/iamroles.go` - Replaced single-call list operations with SDK paginator loops; updated function signatures to use `IAMClient` interface
+- `helpers/iamresources.go` - Updated `HasAccessKeys` and `GetLastAccessKeyDate` to accept `IAMClient` interface
+
+**Approach rationale:** AWS SDK v2 provides built-in paginators (`NewListUsersPaginator`, `NewListGroupsPaginator`, etc.) that handle the `IsTruncated`/`Marker` protocol correctly. Using these is the idiomatic approach and avoids manual marker management.
+
+**Alternatives considered:**
+- Manual `IsTruncated`/`Marker` loop - Rejected because the SDK paginators already encapsulate this logic correctly and are less error-prone
+- Increasing `MaxItems` parameter - Rejected because this only raises the limit, it does not eliminate it
+
+## Regression Test
+
+**Test file:** `helpers/iam_pagination_test.go`
+**Test names:** `TestGetUserList_Pagination`, `TestGetGroupNameSliceForUser_Pagination`, `TestGetAllUsersInGroup_Pagination`, `TestGetUserPoliciesMapForUser_Pagination`, `TestGetGroupPoliciesMapForGroup_Pagination`, `TestGetAttachedPoliciesMapForUser_Pagination`, `TestGetAttachedPoliciesMapForGroup_Pagination`, `TestGetPoliciesMap_Pagination`
+
+**What it verifies:** Each test creates a mock IAM client with 5 items and a page size of 2, forcing 3 pages. The test asserts that all 5 items are returned, which would fail if only the first page was read.
+
+**Run command:** `go test ./helpers/ -run Pagination -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/iam.go` | Added `IAMClient` interface; replaced single API calls with paginator loops for 8 functions |
+| `helpers/iamroles.go` | Replaced single API calls with paginator loops for 3 functions; updated signatures to `IAMClient` |
+| `helpers/iamresources.go` | Updated 2 method signatures from `*iam.Client` to `IAMClient` |
+| `helpers/iam_pagination_test.go` | New file with mock IAMClient and 8 pagination regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] go vet passes
+- [x] make test passes
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When calling AWS list APIs, always use the SDK paginator type if available
+- Add pagination tests for any new AWS list API integrations
+- The `IAMClient` interface enables unit testing of IAM helpers without live AWS access
+
+## Related
+
+- Transit ticket: T-498


### PR DESCRIPTION
## Summary

- IAM listing helpers (`getUserList`, `GetGroupDetails`, `GetPoliciesMap`, `GetUserPoliciesMapForUser`, `GetGroupPoliciesMapForGroup`, `GetAttachedPoliciesMapForUser`, `GetAttachedPoliciesMapForGroup`, `GetGroupNameSliceForUser`, `getAllUsersInGroup`, `GetRoleDetails`, `getInlinePoliciesForRole`, `getAttachedPoliciesForRole`) made single-page API calls without pagination, returning at most 100 items
- Replaced all single-call list operations with AWS SDK v2 built-in paginators
- Introduced `IAMClient` interface to enable unit testing without live AWS access

## Test plan

- [x] 8 pagination regression tests verify multi-page retrieval (page size 2, 5 items = 3 pages)
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet` passes
- [x] `make test` passes
- [ ] Manual verification with an AWS account containing >100 IAM users/roles