### PR TITLE
fix: paginate Organizations ListChildren in findChildren (T-547)

### DIFF
--- a/helpers/organizations.go
+++ b/helpers/organizations.go
@@ -64,36 +64,48 @@ func (entry *OrganizationEntry) findChildren(svc OrganizationsAPI) ([]Organizati
 		ParentId:  aws.String(entry.ID),
 		ChildType: types.ChildType(types.TargetTypeOrganizationalUnit),
 	}
-	ouchildren, err := svc.ListChildren(context.TODO(), ouinput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list OU children of %s: %w", entry.ID, err)
-	}
-	for _, child := range ouchildren.Children {
-		ouchild, err := formatChild(child, svc)
+	for {
+		ouchildren, err := svc.ListChildren(context.TODO(), ouinput)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list OU children of %s: %w", entry.ID, err)
 		}
-		ouchildChildren, err := ouchild.findChildren(svc)
-		if err != nil {
-			return nil, err
+		for _, child := range ouchildren.Children {
+			ouchild, err := formatChild(child, svc)
+			if err != nil {
+				return nil, err
+			}
+			ouchildChildren, err := ouchild.findChildren(svc)
+			if err != nil {
+				return nil, err
+			}
+			ouchild.Children = ouchildChildren
+			children = append(children, ouchild)
 		}
-		ouchild.Children = ouchildChildren
-		children = append(children, ouchild)
+		if ouchildren.NextToken == nil {
+			break
+		}
+		ouinput.NextToken = ouchildren.NextToken
 	}
 	accountinput := &organizations.ListChildrenInput{
 		ParentId:  aws.String(entry.ID),
 		ChildType: types.ChildType(types.TargetTypeAccount),
 	}
-	accountchildren, err := svc.ListChildren(context.TODO(), accountinput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list account children of %s: %w", entry.ID, err)
-	}
-	for _, child := range accountchildren.Children {
-		accountchild, err := formatChild(child, svc)
+	for {
+		accountchildren, err := svc.ListChildren(context.TODO(), accountinput)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list account children of %s: %w", entry.ID, err)
 		}
-		children = append(children, accountchild)
+		for _, child := range accountchildren.Children {
+			accountchild, err := formatChild(child, svc)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, accountchild)
+		}
+		if accountchildren.NextToken == nil {
+			break
+		}
+		accountinput.NextToken = accountchildren.NextToken
 	}
 	return children, nil
 }

--- a/helpers/organizations_test.go
+++ b/helpers/organizations_test.go
@@ -255,6 +255,113 @@ func TestGetFullOrganization_Success(t *testing.T) {
 	assert.Equal(t, "Main Account", org.Children[1].Name)
 }
 
+// Regression tests for T-547: ListChildren pagination must collect all pages
+
+func TestFindChildren_PaginatesOUChildren(t *testing.T) {
+	ouCallCount := 0
+	mock := &mockOrganizationsClient{
+		ListChildrenFunc: func(_ context.Context, params *organizations.ListChildrenInput, _ ...func(*organizations.Options)) (*organizations.ListChildrenOutput, error) {
+			// Only paginate OU children for the root; child OUs have no children
+			if *params.ParentId == "r-root" && params.ChildType == orgtypes.ChildType(orgtypes.TargetTypeOrganizationalUnit) {
+				ouCallCount++
+				if params.NextToken == nil {
+					return &organizations.ListChildrenOutput{
+						Children: []orgtypes.Child{
+							{Id: aws.String("ou-page1"), Type: orgtypes.ChildType(orgtypes.TargetTypeOrganizationalUnit)},
+						},
+						NextToken: aws.String("token-page2"),
+					}, nil
+				}
+				if *params.NextToken == "token-page2" {
+					return &organizations.ListChildrenOutput{
+						Children: []orgtypes.Child{
+							{Id: aws.String("ou-page2"), Type: orgtypes.ChildType(orgtypes.TargetTypeOrganizationalUnit)},
+						},
+					}, nil
+				}
+			}
+			return &organizations.ListChildrenOutput{Children: []orgtypes.Child{}}, nil
+		},
+		DescribeOrganizationalUnitFunc: func(_ context.Context, params *organizations.DescribeOrganizationalUnitInput, _ ...func(*organizations.Options)) (*organizations.DescribeOrganizationalUnitOutput, error) {
+			return &organizations.DescribeOrganizationalUnitOutput{
+				OrganizationalUnit: &orgtypes.OrganizationalUnit{
+					Id:   params.OrganizationalUnitId,
+					Arn:  aws.String("arn:aws:organizations::123456789012:ou/" + *params.OrganizationalUnitId),
+					Name: aws.String("OU-" + *params.OrganizationalUnitId),
+				},
+			}, nil
+		},
+		DescribeAccountFunc: func(_ context.Context, params *organizations.DescribeAccountInput, _ ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error) {
+			return &organizations.DescribeAccountOutput{
+				Account: &orgtypes.Account{
+					Id:   params.AccountId,
+					Arn:  aws.String("arn:aws:organizations::123456789012:account/" + *params.AccountId),
+					Name: aws.String("Acct-" + *params.AccountId),
+				},
+			}, nil
+		},
+	}
+	entry := &OrganizationEntry{ID: "r-root"}
+
+	children, err := entry.findChildren(mock)
+	require.NoError(t, err)
+
+	// Must have collected OUs from both pages
+	ouChildren := 0
+	for _, c := range children {
+		if c.Type == string(orgtypes.TargetTypeOrganizationalUnit) {
+			ouChildren++
+		}
+	}
+	assert.Equal(t, 2, ouChildren, "should collect OU children from all pages")
+	assert.GreaterOrEqual(t, ouCallCount, 2, "should have called ListChildren at least twice for OUs")
+}
+
+func TestFindChildren_PaginatesAccountChildren(t *testing.T) {
+	callCount := 0
+	mock := &mockOrganizationsClient{
+		ListChildrenFunc: func(_ context.Context, params *organizations.ListChildrenInput, _ ...func(*organizations.Options)) (*organizations.ListChildrenOutput, error) {
+			if params.ChildType == orgtypes.ChildType(orgtypes.TargetTypeOrganizationalUnit) {
+				return &organizations.ListChildrenOutput{Children: []orgtypes.Child{}}, nil
+			}
+			// Account children: paginated across two pages
+			callCount++
+			if params.NextToken == nil {
+				return &organizations.ListChildrenOutput{
+					Children: []orgtypes.Child{
+						{Id: aws.String("111111111111"), Type: orgtypes.ChildType(orgtypes.TargetTypeAccount)},
+					},
+					NextToken: aws.String("acct-page2"),
+				}, nil
+			}
+			if *params.NextToken == "acct-page2" {
+				return &organizations.ListChildrenOutput{
+					Children: []orgtypes.Child{
+						{Id: aws.String("222222222222"), Type: orgtypes.ChildType(orgtypes.TargetTypeAccount)},
+					},
+				}, nil
+			}
+			return &organizations.ListChildrenOutput{Children: []orgtypes.Child{}}, nil
+		},
+		DescribeAccountFunc: func(_ context.Context, params *organizations.DescribeAccountInput, _ ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error) {
+			return &organizations.DescribeAccountOutput{
+				Account: &orgtypes.Account{
+					Id:   params.AccountId,
+					Arn:  aws.String("arn:aws:organizations::123456789012:account/" + *params.AccountId),
+					Name: aws.String("Acct-" + *params.AccountId),
+				},
+			}, nil
+		},
+	}
+	entry := &OrganizationEntry{ID: "r-root"}
+
+	children, err := entry.findChildren(mock)
+	require.NoError(t, err)
+
+	assert.Len(t, children, 2, "should collect accounts from all pages")
+	assert.GreaterOrEqual(t, callCount, 2, "should have called ListChildren at least twice for accounts")
+}
+
 func TestFindChildren_DescribeOUErrorDuringTraversal_ReturnsError(t *testing.T) {
 	mock := &mockOrganizationsClient{
 		ListChildrenFunc: func(_ context.Context, params *organizations.ListChildrenInput, _ ...func(*organizations.Options)) (*organizations.ListChildrenOutput, error) {


### PR DESCRIPTION
Adds pagination loop on NextToken for both ListChildren calls in findChildren, ensuring all child OUs and accounts are returned.