### PR TITLE
fix: guard ENI pointer dereferences in vpc enis output (T-587)

### DIFF
--- a/cmd/vpcenis.go
+++ b/cmd/vpcenis.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ArjenSchwarz/awstools/config"
 	"github.com/ArjenSchwarz/awstools/helpers"
 	format "github.com/ArjenSchwarz/go-output"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/spf13/cobra"
 )
@@ -39,7 +40,7 @@ func enis(_ *cobra.Command, _ []string) {
 		output.Settings.SeparateTables = true
 		groups := splitBySubnet(interfaces)
 		for subnet, group := range groups {
-			printENIs(group, names, fmt.Sprintf("%s - %s: %s", resultTitle, getNameAndIDFromMap(*group[0].VpcId, names), getNameAndIDFromMap(subnet, names)), true)
+			printENIs(group, names, fmt.Sprintf("%s - %s: %s", resultTitle, getNameAndIDFromMap(aws.ToString(group[0].VpcId), names), getNameAndIDFromMap(subnet, names)), true)
 		}
 	} else {
 		printENIs(interfaces, names, resultTitle, false)
@@ -62,18 +63,20 @@ func printENIs(interfaces []types.NetworkInterface, names map[string]string, res
 	for _, netinterface := range interfaces {
 		content := make(map[string]any)
 		iparray := make([]string, 0)
-		if netinterface.Association != nil {
+		if netinterface.Association != nil && netinterface.Association.PublicIp != nil {
 			iparray = append(iparray, *netinterface.Association.PublicIp)
 		}
 		for _, ips := range netinterface.PrivateIpAddresses {
-			iparray = append(iparray, *ips.PrivateIpAddress)
+			if ips.PrivateIpAddress != nil {
+				iparray = append(iparray, *ips.PrivateIpAddress)
+			}
 		}
-		content["ENI"] = *netinterface.NetworkInterfaceId
+		content["ENI"] = aws.ToString(netinterface.NetworkInterfaceId)
 		content["Type"] = netinterface.InterfaceType
 		content["Attachment"] = getNameAndIDFromMap(getAttachment(netinterface), names)
 		content["IPs"] = iparray
-		content["VPC"] = getNameAndIDFromMap(*netinterface.VpcId, names)
-		content["Subnet"] = getNameAndIDFromMap(*netinterface.SubnetId, names)
+		content["VPC"] = getNameAndIDFromMap(aws.ToString(netinterface.VpcId), names)
+		content["Subnet"] = getNameAndIDFromMap(aws.ToString(netinterface.SubnetId), names)
 		output.AddContents(content)
 	}
 	output.AddToBuffer()
@@ -82,7 +85,8 @@ func printENIs(interfaces []types.NetworkInterface, names map[string]string, res
 func splitBySubnet(interfaces []types.NetworkInterface) map[string][]types.NetworkInterface {
 	result := make(map[string][]types.NetworkInterface)
 	for _, netinterface := range interfaces {
-		result[*netinterface.SubnetId] = append(result[*netinterface.SubnetId], netinterface)
+		subnetID := aws.ToString(netinterface.SubnetId)
+		result[subnetID] = append(result[subnetID], netinterface)
 	}
 	return result
 }
@@ -98,14 +102,14 @@ func getAttachment(netinterface types.NetworkInterface) string {
 	if netinterface.InterfaceType == types.NetworkInterfaceTypeNatGateway || netinterface.InterfaceType == "nat_gateway" {
 		natgw := helpers.GetNatGatewayFromNetworkInterface(netinterface, awsConfig.Ec2Client())
 		if natgw != nil {
-			return *natgw.NatGatewayId
+			return aws.ToString(natgw.NatGatewayId)
 		}
 		return ""
 	}
 	if netinterface.InterfaceType == types.NetworkInterfaceTypeVpcEndpoint {
 		endpoint := helpers.GetVPCEndpointFromNetworkInterface(netinterface, awsConfig.Ec2Client())
 		if endpoint != nil {
-			return fmt.Sprintf("%s (%s)", *endpoint.ServiceName, *endpoint.VpcEndpointId)
+			return fmt.Sprintf("%s (%s)", aws.ToString(endpoint.ServiceName), aws.ToString(endpoint.VpcEndpointId))
 		}
 		return ""
 	}

--- a/cmd/vpcipfinder.go
+++ b/cmd/vpcipfinder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ArjenSchwarz/awstools/config"
 	"github.com/ArjenSchwarz/awstools/helpers"
 	format "github.com/ArjenSchwarz/go-output"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/spf13/cobra"
 )
 
@@ -95,9 +96,14 @@ func formatIPFinderOutput(result helpers.IPFinderResult) {
 		subnetDisplay = result.Subnet.ID
 	}
 
+	var eniID string
+	if result.ENI != nil {
+		eniID = aws.ToString(result.ENI.NetworkInterfaceId)
+	}
+
 	outputData := []map[string]any{
 		{"Field": "IP Address", "Value": result.IPAddress},
-		{"Field": "ENI ID", "Value": *result.ENI.NetworkInterfaceId},
+		{"Field": "ENI ID", "Value": eniID},
 		{"Field": "Resource Type", "Value": result.ResourceType},
 		{"Field": "Resource Name", "Value": resourceName},
 		{"Field": "Resource ID", "Value": result.ResourceID},

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -1039,7 +1039,7 @@ func mapNetworkInterfacesToIPs(networkInterfaces []types.NetworkInterface, subne
 // Uses cache to avoid repeated API calls
 func getENIUsageTypeOptimized(eni types.NetworkInterface, cache *ENILookupCache) string {
 	// Check if it's a VPC endpoint first (highest priority)
-	if _, exists := cache.EndpointsByENI[*eni.NetworkInterfaceId]; exists {
+	if _, exists := cache.EndpointsByENI[aws.ToString(eni.NetworkInterfaceId)]; exists {
 		return vpcEndpointType
 	}
 
@@ -1116,11 +1116,11 @@ func getENIUsageTypeOptimized(eni types.NetworkInterface, cache *ENILookupCache)
 // Uses cache to avoid repeated API calls
 func getENIAttachmentDetailsOptimized(eni types.NetworkInterface, cache *ENILookupCache) string {
 	// Priority 1: Check if it's a VPC endpoint (following JS script logic)
-	if endpoint, exists := cache.EndpointsByENI[*eni.NetworkInterfaceId]; exists {
+	if endpoint, exists := cache.EndpointsByENI[aws.ToString(eni.NetworkInterfaceId)]; exists {
 		// Extract service name (last part after dots, like 's3', 'ec2')
-		serviceParts := strings.Split(*endpoint.ServiceName, ".")
+		serviceParts := strings.Split(aws.ToString(endpoint.ServiceName), ".")
 		shortServiceName := serviceParts[len(serviceParts)-1]
-		return *endpoint.VpcEndpointId + " (" + shortServiceName + ")"
+		return aws.ToString(endpoint.VpcEndpointId) + " (" + shortServiceName + ")"
 	}
 
 	// Priority 2: Handle EC2 instances
@@ -1144,12 +1144,13 @@ func getENIAttachmentDetailsOptimized(eni types.NetworkInterface, cache *ENILook
 			return "Unknown Transit Gateway"
 
 		case types.NetworkInterfaceTypeNatGateway:
-			if natgw, exists := cache.NATGatewaysByENI[*eni.NetworkInterfaceId]; exists {
+			if natgw, exists := cache.NATGatewaysByENI[aws.ToString(eni.NetworkInterfaceId)]; exists {
 				natName := getNameFromTags(natgw.Tags)
-				if natName != "" && natName != *natgw.NatGatewayId {
-					return *natgw.NatGatewayId + " (" + natName + ")"
+				natgwID := aws.ToString(natgw.NatGatewayId)
+				if natName != "" && natName != natgwID {
+					return natgwID + " (" + natName + ")"
 				}
-				return *natgw.NatGatewayId
+				return natgwID
 			}
 			return "Unknown NAT Gateway"
 
@@ -1536,7 +1537,7 @@ func FindIPAddressDetails(svc *ec2.Client, ipAddress string) IPFinderResult {
 		// Log warning about multiple matches - following awstools pattern of using panic for warnings
 		// This is a rare scenario but can happen in some edge cases
 		fmt.Printf("Warning: Multiple ENIs found with IP %s. Returning details for first ENI (%s)\n",
-			ipAddress, *enis[0].NetworkInterfaceId)
+			ipAddress, aws.ToString(enis[0].NetworkInterfaceId))
 	}
 
 	// Process the first matching ENI
@@ -1619,13 +1620,13 @@ func getResourceNameAndID(eni types.NetworkInterface, cache *ENILookupCache) (st
 	}
 
 	// Handle VPC endpoints
-	if endpoint, exists := cache.EndpointsByENI[*eni.NetworkInterfaceId]; exists {
-		return attachmentDetails, *endpoint.VpcEndpointId
+	if endpoint, exists := cache.EndpointsByENI[aws.ToString(eni.NetworkInterfaceId)]; exists {
+		return attachmentDetails, aws.ToString(endpoint.VpcEndpointId)
 	}
 
 	// Handle NAT gateways
-	if natgw, exists := cache.NATGatewaysByENI[*eni.NetworkInterfaceId]; exists {
-		return attachmentDetails, *natgw.NatGatewayId
+	if natgw, exists := cache.NATGatewaysByENI[aws.ToString(eni.NetworkInterfaceId)]; exists {
+		return attachmentDetails, aws.ToString(natgw.NatGatewayId)
 	}
 
 	// Default to attachment details


### PR DESCRIPTION
Replaces unsafe *pointer dereferences with aws.ToString() and nil checks across ENI output formatting in cmd/vpcenis.go, cmd/vpcipfinder.go, and helpers/ec2.go.