### PR TITLE
fix: redirect ip-finder informational messages to stderr (T-600)

### DIFF
--- a/cmd/vpcipfinder.go
+++ b/cmd/vpcipfinder.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/ArjenSchwarz/awstools/config"
 	"github.com/ArjenSchwarz/awstools/helpers"
@@ -57,12 +58,12 @@ func findIPAddress(_ *cobra.Command, args []string) {
 
 func formatIPFinderOutput(result helpers.IPFinderResult) {
 	if !result.Found {
-		fmt.Printf("IP address %s not found in any ENI in the current region\n", result.IPAddress)
-		fmt.Printf("\nTroubleshooting suggestions:\n")
-		fmt.Printf("  - Verify the IP address is correct\n")
-		fmt.Printf("  - Check if the IP is in a different AWS region using --region flag\n")
-		fmt.Printf("  - Ensure you have the necessary permissions to describe network interfaces\n")
-		fmt.Printf("  - Consider that the IP might be associated with a different AWS account\n")
+		fmt.Fprintf(os.Stderr, "IP address %s not found in any ENI in the current region\n", result.IPAddress)
+		fmt.Fprintf(os.Stderr, "\nTroubleshooting suggestions:\n")
+		fmt.Fprintf(os.Stderr, "  - Verify the IP address is correct\n")
+		fmt.Fprintf(os.Stderr, "  - Check if the IP is in a different AWS region using --region flag\n")
+		fmt.Fprintf(os.Stderr, "  - Ensure you have the necessary permissions to describe network interfaces\n")
+		fmt.Fprintf(os.Stderr, "  - Consider that the IP might be associated with a different AWS account\n")
 		return
 	}
 

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -1570,7 +1571,7 @@ func FindIPAddressDetails(svc *ec2.Client, ipAddress string) IPFinderResult {
 	if len(enis) > 1 {
 		// Log warning about multiple matches - following awstools pattern of using panic for warnings
 		// This is a rare scenario but can happen in some edge cases
-		fmt.Printf("Warning: Multiple ENIs found with IP %s. Returning details for first ENI (%s)\n",
+		fmt.Fprintf(os.Stderr, "Warning: Multiple ENIs found with IP %s. Returning details for first ENI (%s)\n",
 			ipAddress, aws.ToString(enis[0].NetworkInterfaceId))
 	}
 


### PR DESCRIPTION
Changes 6 fmt.Printf calls to fmt.Fprintf(os.Stderr, ...) in cmd/vpcipfinder.go and helpers/ec2.go, keeping stdout clean for structured output.