### PR TITLE
fix: handle nil SSO account/role pointers in role discovery (T-607)

### DIFF
--- a/helpers/role_discovery.go
+++ b/helpers/role_discovery.go
@@ -160,6 +160,17 @@ func (rd *RoleDiscovery) getAccountsFromToken(ctx context.Context, token *Cached
 
 // getRolesForAccount retrieves roles for a specific account
 func (rd *RoleDiscovery) getRolesForAccount(ctx context.Context, token *CachedToken, account types.AccountInfo) ([]DiscoveredRole, error) {
+	// Skip accounts with nil AccountId — required for API calls
+	if account.AccountId == nil {
+		return nil, nil
+	}
+
+	accountID := aws.ToString(account.AccountId)
+	accountName := aws.ToString(account.AccountName)
+	if accountName == "" {
+		accountName = accountID
+	}
+
 	var roles []DiscoveredRole
 	maxResults := int32(100)
 	var nextToken *string
@@ -175,41 +186,42 @@ func (rd *RoleDiscovery) getRolesForAccount(ctx context.Context, token *CachedTo
 		result, err := rd.ssoClient.ListAccountRoles(ctx, input)
 		if err != nil {
 			return nil, NewAPIError("failed to list account roles", err).
-				WithContext("account_id", *account.AccountId).
-				WithContext("account_name", *account.AccountName).
+				WithContext("account_id", accountID).
+				WithContext("account_name", accountName).
 				WithContext("suggestion", "Run 'aws sso login' to refresh authentication")
 		}
 
 		// Create discovered roles from the response
 		for _, roleInfo := range result.RoleList {
-			accountName := *account.AccountName
-			if accountName == "" {
-				accountName = *account.AccountId // Fallback to account ID
+			// Skip roles with nil RoleName — required field
+			if roleInfo.RoleName == nil {
+				continue
 			}
+			roleName := aws.ToString(roleInfo.RoleName)
 
 			// Cache the SSO-provided account name as the alias for this account.
 			// The SSO ListAccounts API provides per-account names, unlike IAM
 			// ListAccountAliases which only returns the current account's alias.
 			rd.cacheMutex.Lock()
-			if _, exists := rd.aliasCache[*account.AccountId]; !exists {
-				rd.aliasCache[*account.AccountId] = accountName
+			if _, exists := rd.aliasCache[accountID]; !exists {
+				rd.aliasCache[accountID] = accountName
 			}
 			rd.cacheMutex.Unlock()
 
-			accountAlias, _ := rd.GetAccountAlias(*account.AccountId)
+			accountAlias, _ := rd.GetAccountAlias(accountID)
 
 			role := DiscoveredRole{
-				AccountID:         *account.AccountId,
+				AccountID:         accountID,
 				AccountName:       accountName,
 				AccountAlias:      accountAlias,
-				PermissionSetName: *roleInfo.RoleName,
-				RoleName:          *roleInfo.RoleName,
+				PermissionSetName: roleName,
+				RoleName:          roleName,
 			}
 
 			if err := role.Validate(); err != nil {
 				return nil, NewValidationError("invalid discovered role", err).
-					WithContext("account_id", *account.AccountId).
-					WithContext("role_name", *roleInfo.RoleName)
+					WithContext("account_id", accountID).
+					WithContext("role_name", roleName)
 			}
 
 			roles = append(roles, role)

--- a/helpers/sso.go
+++ b/helpers/sso.go
@@ -86,9 +86,13 @@ func getSSOInstance(svc SSOAdminAPI) (SSOInstance, error) {
 	if len(instances.Instances) > 1 {
 		return SSOInstance{}, fmt.Errorf("found multiple SSO instances, expected exactly one")
 	}
+	inst := instances.Instances[0]
+	if inst.IdentityStoreId == nil || inst.InstanceArn == nil {
+		return SSOInstance{}, fmt.Errorf("SSO instance has nil IdentityStoreId or InstanceArn")
+	}
 	ssoInstance := SSOInstance{
-		IdentityStoreID: aws.ToString(instances.Instances[0].IdentityStoreId),
-		Arn:             aws.ToString(instances.Instances[0].InstanceArn),
+		IdentityStoreID: aws.ToString(inst.IdentityStoreId),
+		Arn:             aws.ToString(inst.InstanceArn),
 	}
 	return ssoInstance, nil
 }
@@ -137,19 +141,18 @@ func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, sv
 	if err != nil {
 		return SSOPermissionSet{}, fmt.Errorf("failed to describe permission set %s: %w", permissionsetarn, err)
 	}
-	var createdAt time.Time
-	if permissionsetdescription.PermissionSet.CreatedDate != nil {
-		createdAt = *permissionsetdescription.PermissionSet.CreatedDate
-	}
+	ps := permissionsetdescription.PermissionSet
 	permissionset := SSOPermissionSet{
 		Arn:             permissionsetarn,
-		Name:            aws.ToString(permissionsetdescription.PermissionSet.Name),
-		CreatedAt:       createdAt,
-		SessionDuration: aws.ToString(permissionsetdescription.PermissionSet.SessionDuration),
+		Name:            aws.ToString(ps.Name),
+		SessionDuration: aws.ToString(ps.SessionDuration),
 		Instance:        instance,
 	}
-	if permissionsetdescription.PermissionSet.Description != nil {
-		permissionset.Description = *permissionsetdescription.PermissionSet.Description
+	if ps.CreatedDate != nil {
+		permissionset.CreatedAt = *ps.CreatedDate
+	}
+	if ps.Description != nil {
+		permissionset.Description = *ps.Description
 	}
 	// Get accounts
 	if err := permissionset.addAccountInfo(svc); err != nil {
@@ -171,6 +174,9 @@ func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, sv
 			return SSOPermissionSet{}, fmt.Errorf("failed to list managed policies for permission set %s: %w", permissionsetarn, err)
 		}
 		for _, managedpolicy := range managedpolicies.AttachedManagedPolicies {
+			if managedpolicy.Arn == nil || managedpolicy.Name == nil {
+				continue
+			}
 			policy := SSOPolicy{
 				Arn:  aws.ToString(managedpolicy.Arn),
 				Name: aws.ToString(managedpolicy.Name),
@@ -234,6 +240,9 @@ func (permissionset *SSOPermissionSet) addAccountInfo(svc SSOAdminAPI) error {
 				return fmt.Errorf("failed to list account assignments for account %s, permission set %s: %w", accountnr, permissionset.Arn, err)
 			}
 			for _, assignmentraw := range accountassignments.AccountAssignments {
+				if assignmentraw.PrincipalId == nil {
+					continue
+				}
 				assignment := SSOAccountAssignment{
 					PrincipalType: string(assignmentraw.PrincipalType),
 					PrincipalID:   aws.ToString(assignmentraw.PrincipalId),


### PR DESCRIPTION
Adds nil guards in helpers/role_discovery.go and helpers/sso.go for SSO account/role pointer fields, skipping malformed entries instead of panicking.