### PR TITLE
fix: handle invalid instance IDs in ENI name batch lookup (T-623)

### DIFF
--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -2,9 +2,12 @@ package helpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"net"
 	"os"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -12,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 )
 
 // ENI and service type constants
@@ -1413,41 +1417,102 @@ func (cache *ENILookupCache) batchFetchVPCEndpoints(svc *ec2.Client, vpcIDs map[
 	}
 }
 
+// instanceIDPattern matches valid EC2 instance IDs (i- followed by 8 or 17 hex chars).
+var instanceIDPattern = regexp.MustCompile(`^i-[0-9a-f]{8}([0-9a-f]{9})?$`)
+
+// isValidInstanceID returns true if the ID matches the EC2 instance ID format.
+func isValidInstanceID(id string) bool {
+	return instanceIDPattern.MatchString(id)
+}
+
+// isInstanceIDError returns true if the error is an InvalidInstanceID API error.
+func isInstanceIDError(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.ErrorCode()
+		return code == "InvalidInstanceID.NotFound" || code == "InvalidInstanceID.Malformed"
+	}
+	return false
+}
+
 // batchFetchInstanceNames fetches all instance names for the given instances
 func (cache *ENILookupCache) batchFetchInstanceNames(svc *ec2.Client, instanceIDs map[string]bool) {
 	if len(instanceIDs) == 0 {
 		return
 	}
 
-	// Convert instance IDs to slice for API call
+	// Pre-filter: only keep validly-formatted instance IDs
 	instanceIDList := make([]string, 0, len(instanceIDs))
 	for instanceID := range instanceIDs {
-		instanceIDList = append(instanceIDList, instanceID)
+		if isValidInstanceID(instanceID) {
+			instanceIDList = append(instanceIDList, instanceID)
+		} else {
+			log.Printf("Skipping invalid instance ID format: %s", instanceID)
+		}
+	}
+	if len(instanceIDList) == 0 {
+		return
 	}
 
 	// Fetch all instances in batches (DescribeInstances filter limit)
 	const batchSize = 100
 	for i := 0; i < len(instanceIDList); i += batchSize {
 		end := min(i+batchSize, len(instanceIDList))
+		batch := instanceIDList[i:end]
 
+		cache.describeInstanceBatch(svc, batch)
+	}
+}
+
+// describeInstanceBatch fetches instance names for a single batch.
+// On InvalidInstanceID errors it falls back to individual lookups.
+func (cache *ENILookupCache) describeInstanceBatch(svc *ec2.Client, ids []string) {
+	params := &ec2.DescribeInstancesInput{
+		InstanceIds: ids,
+	}
+
+	paginator := ec2.NewDescribeInstancesPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			if isInstanceIDError(err) {
+				log.Printf("Some instance IDs not found in batch, falling back to individual lookups")
+				cache.describeInstancesIndividually(svc, ids)
+				return
+			}
+			log.Printf("Error describing instances: %v", err)
+			return
+		}
+		cache.extractInstanceNames(page)
+	}
+}
+
+// describeInstancesIndividually looks up each instance ID one at a time,
+// gracefully skipping any that return errors.
+func (cache *ENILookupCache) describeInstancesIndividually(svc *ec2.Client, ids []string) {
+	for _, id := range ids {
 		params := &ec2.DescribeInstancesInput{
-			InstanceIds: instanceIDList[i:end],
+			InstanceIds: []string{id},
 		}
 
 		paginator := ec2.NewDescribeInstancesPaginator(svc, params)
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(context.TODO())
 			if err != nil {
-				// If an instance doesn't exist, continue with others
+				log.Printf("Skipping instance %s: %v", id, err)
 				break
 			}
+			cache.extractInstanceNames(page)
+		}
+	}
+}
 
-			for _, reservation := range page.Reservations {
-				for _, instance := range reservation.Instances {
-					if instance.InstanceId != nil {
-						cache.InstanceNames[*instance.InstanceId] = getNameFromTags(instance.Tags)
-					}
-				}
+// extractInstanceNames populates the cache from a DescribeInstances response.
+func (cache *ENILookupCache) extractInstanceNames(resp *ec2.DescribeInstancesOutput) {
+	for _, reservation := range resp.Reservations {
+		for _, instance := range reservation.Instances {
+			if instance.InstanceId != nil {
+				cache.InstanceNames[*instance.InstanceId] = getNameFromTags(instance.Tags)
 			}
 		}
 	}

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -1576,6 +1576,33 @@ func TestGetSubnetRouteTable_NoMatchReturnsNil(t *testing.T) {
 	}
 }
 
+func TestIsValidInstanceID(t *testing.T) {
+	tests := []struct {
+		id    string
+		valid bool
+	}{
+		{"i-1234567890abcdef0", true},   // 17-char hex (modern format)
+		{"i-12345678", true},            // 8-char hex (legacy format)
+		{"i-abcdef1234567890a", true},   // 17-char hex
+		{"i-abcdef12", true},            // 8-char hex
+		{"", false},                     // empty
+		{"i-", false},                   // prefix only
+		{"i-123", false},                // too short
+		{"i-1234567890abcdef0a", false}, // too long
+		{"i-ABCDEF12", false},           // uppercase not valid
+		{"i-1234567g", false},           // non-hex character
+		{"vol-12345678", false},         // wrong prefix
+		{"not-an-id", false},            // totally wrong
+	}
+
+	for _, tt := range tests {
+		got := isValidInstanceID(tt.id)
+		if got != tt.valid {
+			t.Errorf("isValidInstanceID(%q) = %v, want %v", tt.id, got, tt.valid)
+		}
+	}
+}
+
 func TestIsPublicSubnet_UsesCorrectVPCMainRouteTable(t *testing.T) {
 	// vpc-111 has a public main route table (with igw)
 	// vpc-222 has a private main route table (no igw)


### PR DESCRIPTION
Adds instance ID validation, error detection for InvalidInstanceID errors, and graceful per-ID fallback in batch lookup.