### PR TITLE
Fix T-671: Guard IsLatestInstanceFamily against empty input

### DIFF
--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -558,6 +558,12 @@ func GetBlackholeRoutesForTransitGatewayRouteTable(routetableID string, svc *ec2
 // test family is running in the latest instance family.
 // TODO: Automate this to work properly
 func IsLatestInstanceFamily(instanceFamily string) bool {
+	// Guard against empty or malformed input. A valid EC2 instance family
+	// identifier needs at least one family letter followed by one version
+	// character (e.g. "t2"). Anything shorter is treated as unknown.
+	if len(instanceFamily) < 2 {
+		return false
+	}
 	family := instanceFamily[0:1]
 	version := instanceFamily[1:]
 	switch family {

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -188,10 +188,31 @@ func TestIsLatestInstanceFamily(t *testing.T) {
 			instanceFamily: "invalid",
 			expected:       false,
 		},
+		// Malformed / short input — must not panic (regression tests for T-671)
+		{
+			name:           "empty string returns false without panic",
+			instanceFamily: "",
+			expected:       false,
+		},
+		{
+			name:           "single character returns false without panic",
+			instanceFamily: "c",
+			expected:       false,
+		},
+		{
+			name:           "single unknown character returns false without panic",
+			instanceFamily: "z",
+			expected:       false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("IsLatestInstanceFamily(%q) panicked: %v", tt.instanceFamily, r)
+				}
+			}()
 			result := IsLatestInstanceFamily(tt.instanceFamily)
 			if result != tt.expected {
 				t.Errorf("IsLatestInstanceFamily(%q) = %v, want %v", tt.instanceFamily, result, tt.expected)


### PR DESCRIPTION
## Summary
- `helpers.IsLatestInstanceFamily` sliced `instanceFamily[0:1]` without checking length, so any caller passing an empty string triggered a runtime panic (`slice bounds out of range [:1] with length 0`).
- Added a length guard that returns `false` when the input is shorter than two characters, which matches the existing behaviour for unknown families.
- Added regression tests for empty and single-character inputs with a `recover()` guard in the subtest so any future regression shows up as a clear test failure rather than a crashing test binary.

## Root Cause
The function assumed callers always passed well-formed EC2 family identifiers like `t2`. No input validation was performed before the `[0:1]` / `[1:]` slice expressions.

## Test plan
- [x] `go test -run TestIsLatestInstanceFamily ./helpers/` (new cases cover empty / one-char input)
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go fmt ./...`

Closes T-671.