### PR TITLE
Fix T-690: Normalize S3 GetBucketLocation EU Value

### DIFF
--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -32,6 +32,22 @@ type S3Bucket struct {
 	VersioningMFAEnabled           bool
 }
 
+// normalizeBucketLocation converts the LocationConstraint returned by
+// S3's GetBucketLocation API into a canonical AWS region identifier.
+// S3 returns an empty constraint for buckets in us-east-1 and the
+// legacy value "EU" for buckets originally created in eu-west-1; both
+// need to be mapped to their standard region IDs.
+func normalizeBucketLocation(constraint types.BucketLocationConstraint) string {
+	switch constraint {
+	case "":
+		return "us-east-1"
+	case "EU":
+		return "eu-west-1"
+	default:
+		return string(constraint)
+	}
+}
+
 // resolveOwnerName safely extracts a display name from an S3 Owner,
 // falling back to the Owner ID or empty string when fields are nil.
 func resolveOwnerName(owner *types.Owner) string {
@@ -88,11 +104,11 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 		}
 
 		locationresp, err := svc.GetBucketLocation(context.TODO(), &s3.GetBucketLocationInput{Bucket: bucket.Name})
-		region := "us-east-1"
+		var region string
 		if err != nil {
 			region = "ERROR"
-		} else if locationresp.LocationConstraint != "" {
-			region = string(locationresp.LocationConstraint)
+		} else {
+			region = normalizeBucketLocation(locationresp.LocationConstraint)
 		}
 		bucketObject := S3Bucket{
 			Name:         *bucket.Name,

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -494,6 +494,53 @@ func TestHasOpenACLs_NilGranteeURI(t *testing.T) {
 	}
 }
 
+// TestNormalizeBucketLocation is a regression test for T-690.
+// S3's GetBucketLocation returns the legacy value "EU" for buckets originally
+// created in eu-west-1, and an empty LocationConstraint for us-east-1. Both
+// must be normalised to their canonical region IDs.
+func TestNormalizeBucketLocation(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		expected   string
+	}{
+		{
+			name:       "empty constraint maps to us-east-1",
+			constraint: "",
+			expected:   "us-east-1",
+		},
+		{
+			name:       "legacy EU constraint maps to eu-west-1",
+			constraint: "EU",
+			expected:   "eu-west-1",
+		},
+		{
+			name:       "standard region passes through unchanged",
+			constraint: "eu-west-1",
+			expected:   "eu-west-1",
+		},
+		{
+			name:       "us-west-2 passes through unchanged",
+			constraint: "us-west-2",
+			expected:   "us-west-2",
+		},
+		{
+			name:       "ap-southeast-2 passes through unchanged",
+			constraint: "ap-southeast-2",
+			expected:   "ap-southeast-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeBucketLocation(types.BucketLocationConstraint(tt.constraint))
+			if result != tt.expected {
+				t.Errorf("normalizeBucketLocation(%q) = %q, want %q", tt.constraint, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestS3Bucket_PublicAccessBlockConfiguration(t *testing.T) {
 	bucket := S3Bucket{
 		PublicAccessBlockConfiguration: types.PublicAccessBlockConfiguration{


### PR DESCRIPTION
## Summary

- Fixes T-690. The S3 GetBucketLocation API returns the legacy value `"EU"` for buckets originally created in `eu-west-1`, and an empty `LocationConstraint` for `us-east-1`. The existing code only handled the empty case, so reports listed the non-standard string `"EU"` for affected buckets.
- Adds a small `normalizeBucketLocation` helper in `helpers/s3.go` that maps `""` to `us-east-1`, `"EU"` to `eu-west-1`, and passes standard region IDs through unchanged.
- `GetBucketDetails` now routes the `LocationConstraint` through the helper.

## Test plan

- [x] New `TestNormalizeBucketLocation` regression test in `helpers/s3_test.go` covers empty, legacy `"EU"`, and standard region inputs (`go test ./helpers/ -run TestNormalizeBucketLocation -v`).
- [x] Full test suite passes (`go test ./...`).
- [x] Linting passes (`make lint`).