### PR TITLE
Fix T-668: Paginate VPC Route Table Listing Helper

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -24,3 +24,15 @@ All callers must pass the subnet's VPC ID. The VPC ID is available from:
 
 - `types.RouteTable` has a `VpcId` field — always use it when filtering by VPC
 - `DescribeRouteTables` without filters returns route tables across all VPCs
+- `DescribeRouteTables` is paginated (default page size 100). Always walk
+  `ec2.NewDescribeRouteTablesPaginator`; a single `DescribeRouteTables` call
+  truncates results in large accounts. `GetAllVPCRouteTables`, `retrieveRouteTables`,
+  and `addAllRouteTableNames` all follow the paginator pattern.
+
+## Testing Pattern
+
+`GetAllVPCRouteTables` takes `*ec2.Client` so callers don't have to change, but
+the pagination logic lives in the unexported `getAllVPCRouteTables` which takes
+the narrower `ec2.DescribeRouteTablesAPIClient` interface. Unit tests mock that
+interface (see `helpers/vpc_routetable_pagination_test.go`) — this is the same
+split used for the IAM pagination tests.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -314,28 +314,40 @@ type VPCRoute struct {
 	DestinationTarget string
 }
 
-// GetAllVPCRouteTables returns all the Routetables in the account and region
+// GetAllVPCRouteTables returns all the Routetables in the account and region.
+// It paginates through every page of DescribeRouteTables so accounts with more
+// route tables than fit in a single response are fully enumerated.
 func GetAllVPCRouteTables(svc *ec2.Client) []VPCRouteTable {
+	return getAllVPCRouteTables(svc)
+}
+
+// getAllVPCRouteTables implements GetAllVPCRouteTables against the minimal
+// DescribeRouteTablesAPIClient interface so the pagination logic can be unit
+// tested without a real *ec2.Client.
+func getAllVPCRouteTables(svc ec2.DescribeRouteTablesAPIClient) []VPCRouteTable {
 	var result []VPCRouteTable
-	resp, err := svc.DescribeRouteTables(context.TODO(), &ec2.DescribeRouteTablesInput{})
-	if err != nil {
-		panic(err)
-	}
-	for _, routetable := range resp.RouteTables {
-		var subnets []string
-		for _, assocs := range routetable.Associations {
-			if assocs.SubnetId != nil {
-				subnets = append(subnets, *assocs.SubnetId)
+	paginator := ec2.NewDescribeRouteTablesPaginator(svc, &ec2.DescribeRouteTablesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, routetable := range page.RouteTables {
+			var subnets []string
+			for _, assocs := range routetable.Associations {
+				if assocs.SubnetId != nil {
+					subnets = append(subnets, *assocs.SubnetId)
+				}
 			}
+			table := VPCRouteTable{
+				Vpc: VPCHolder{ID: aws.ToString(routetable.VpcId),
+					AccountID: aws.ToString(routetable.OwnerId)},
+				ID:      aws.ToString(routetable.RouteTableId),
+				Routes:  parseVPCRoutes(routetable.Routes),
+				Subnets: subnets,
+			}
+			result = append(result, table)
 		}
-		table := VPCRouteTable{
-			Vpc: VPCHolder{ID: aws.ToString(routetable.VpcId),
-				AccountID: aws.ToString(routetable.OwnerId)},
-			ID:      aws.ToString(routetable.RouteTableId),
-			Routes:  parseVPCRoutes(routetable.Routes),
-			Subnets: subnets,
-		}
-		result = append(result, table)
 	}
 	return result
 }

--- a/helpers/vpc_routetable_pagination_test.go
+++ b/helpers/vpc_routetable_pagination_test.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// mockDescribeRouteTablesClient simulates DescribeRouteTables pagination by
+// splitting a pre-configured slice of route tables across multiple pages
+// based on the NextToken. It satisfies ec2.DescribeRouteTablesAPIClient.
+type mockDescribeRouteTablesClient struct {
+	routeTables []types.RouteTable
+	pageSize    int
+	callCount   int
+}
+
+func (m *mockDescribeRouteTablesClient) DescribeRouteTables(_ context.Context, input *ec2.DescribeRouteTablesInput, _ ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	m.callCount++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(m.routeTables) {
+		end = len(m.routeTables)
+	}
+	output := &ec2.DescribeRouteTablesOutput{
+		RouteTables: m.routeTables[start:end],
+	}
+	if end < len(m.routeTables) {
+		next := fmt.Sprintf("%d", end)
+		output.NextToken = &next
+	}
+	return output, nil
+}
+
+// makeRouteTables builds n dummy route tables with unique IDs.
+func makeRouteTables(n int) []types.RouteTable {
+	tables := make([]types.RouteTable, n)
+	for i := range n {
+		id := fmt.Sprintf("rtb-%08d", i)
+		vpc := fmt.Sprintf("vpc-%08d", i)
+		tables[i] = types.RouteTable{
+			RouteTableId: aws.String(id),
+			VpcId:        aws.String(vpc),
+			OwnerId:      aws.String("123456789012"),
+		}
+	}
+	return tables
+}
+
+// TestGetAllVPCRouteTables_Pagination verifies that GetAllVPCRouteTables
+// retrieves every route table across multiple pages. Before the fix it
+// only returned the contents of the first page.
+func TestGetAllVPCRouteTables_Pagination(t *testing.T) {
+	totalTables := 5
+	mock := &mockDescribeRouteTablesClient{
+		routeTables: makeRouteTables(totalTables),
+		pageSize:    2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := getAllVPCRouteTables(mock)
+
+	if len(result) != totalTables {
+		t.Errorf("getAllVPCRouteTables() returned %d route tables, want %d (pagination bug: only first page returned)", len(result), totalTables)
+	}
+
+	if mock.callCount < 3 {
+		t.Errorf("expected at least 3 DescribeRouteTables calls for %d tables at page size %d, got %d", totalTables, mock.pageSize, mock.callCount)
+	}
+
+	for i, rt := range result {
+		expectedID := fmt.Sprintf("rtb-%08d", i)
+		if rt.ID != expectedID {
+			t.Errorf("result[%d].ID = %q, want %q", i, rt.ID, expectedID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `helpers.GetAllVPCRouteTables` made a single `DescribeRouteTables` call and returned only the first page, causing `awstools vpc routes` to silently drop route tables in accounts with more than ~100 of them.
- Replaced the single call with `ec2.NewDescribeRouteTablesPaginator`, mirroring the pattern already used by `addAllRouteTableNames` and `retrieveRouteTables` in the same file.
- Added a regression test that splits 5 route tables across 3 pages and verifies all are returned.

## Root Cause

The helper predated the project's shift to paginator-based iteration. Sibling helpers in `helpers/ec2.go` were migrated; this one was missed. Because it accepted a concrete `*ec2.Client`, no test could catch the truncation.

## Fix

- Extracted an unexported `getAllVPCRouteTables` that takes `ec2.DescribeRouteTablesAPIClient` and walks every page via the paginator.
- Kept the exported `GetAllVPCRouteTables(svc *ec2.Client)` signature so callers are untouched; it now delegates to the unexported helper.
- Added `helpers/vpc_routetable_pagination_test.go` with a mock `DescribeRouteTablesAPIClient` implementation (same pattern as `helpers/iam_pagination_test.go`).
- Updated `docs/agent-notes/ec2-helpers.md` with the pagination contract and testing pattern.

## Test plan

- [x] `go test ./helpers/ -run TestGetAllVPCRouteTables_Pagination`
- [x] `go test ./...`
- [x] `make lint`
- [x] `go vet ./...`
- [ ] Manual smoke test against an account with >100 route tables (not run locally)

Fixes T-668.