### PR TITLE
Fix T-658: Handle missing TGW route destination fields safely

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -24,3 +24,18 @@ All callers must pass the subnet's VPC ID. The VPC ID is available from:
 
 - `types.RouteTable` has a `VpcId` field — always use it when filtering by VPC
 - `DescribeRouteTables` without filters returns route tables across all VPCs
+
+## Transit Gateway Route Parsing
+
+`parseActiveRoute` and `parseBlackholeRoute` convert `types.TransitGatewayRoute`
+into the internal `TransitGatewayRoute` struct. The SDK type has two optional
+destination pointers — `DestinationCidrBlock` (IPv4 or IPv6 CIDR) and
+`PrefixListId` — and AWS populates only one. TGW routes do not have a separate
+IPv6 destination field; v6 CIDRs reuse `DestinationCidrBlock`.
+
+The helper `tgwRouteDestination(route)` encapsulates the fallback: CIDR first,
+then prefix list ID, then empty string. Never dereference the destination
+pointers directly — prefix-list routes will panic.
+
+Attachment fields `TransitGatewayAttachmentId` and `ResourceId` are also
+pointers; use `aws.ToString` rather than raw deref.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -505,25 +505,48 @@ func GetActiveRoutesForTransitGatewayRouteTable(routetableID string, svc *ec2.Cl
 	return result
 }
 
+// tgwRouteDestination returns a human-readable destination for a Transit Gateway
+// route. AWS populates either DestinationCidrBlock (for IPv4/IPv6 CIDR routes)
+// or PrefixListId (for prefix-list routes) — both are optional pointers, so we
+// fall back from one to the other and return an empty string if neither is set.
+func tgwRouteDestination(route types.TransitGatewayRoute) string {
+	if cidr := aws.ToString(route.DestinationCidrBlock); cidr != "" {
+		return cidr
+	}
+	return aws.ToString(route.PrefixListId)
+}
+
 // parseActiveRoute converts an AWS SDK TransitGatewayRoute into our TransitGatewayRoute type.
 func parseActiveRoute(route types.TransitGatewayRoute) TransitGatewayRoute {
 	tgwroute := TransitGatewayRoute{
 		State:     string(route.State),
-		CIDR:      *route.DestinationCidrBlock,
+		CIDR:      tgwRouteDestination(route),
 		RouteType: string(route.Type),
 	}
 	if len(route.TransitGatewayAttachments) > 0 {
-		resourceid := *route.TransitGatewayAttachments[0].ResourceId
+		attachment := route.TransitGatewayAttachments[0]
+		resourceid := aws.ToString(attachment.ResourceId)
 		// We don't care about the public IPs of the routes, so strip those off
-		if route.TransitGatewayAttachments[0].ResourceType == types.TransitGatewayAttachmentResourceTypeVpn {
+		if attachment.ResourceType == types.TransitGatewayAttachmentResourceTypeVpn {
 			resourceid = strings.Split(resourceid, "(")[0]
 		}
 		tgwroute.Attachment = TransitGatewayAttachment{
-			ID:         *route.TransitGatewayAttachments[0].TransitGatewayAttachmentId,
+			ID:         aws.ToString(attachment.TransitGatewayAttachmentId),
 			ResourceID: resourceid,
 		}
 	}
 	return tgwroute
+}
+
+// parseBlackholeRoute converts an AWS SDK blackhole TransitGatewayRoute into
+// our TransitGatewayRoute type. Blackhole routes have no useful attachment, so
+// only the destination and type are captured.
+func parseBlackholeRoute(route types.TransitGatewayRoute) TransitGatewayRoute {
+	return TransitGatewayRoute{
+		State:     string(route.State),
+		CIDR:      tgwRouteDestination(route),
+		RouteType: string(route.Type),
+	}
 }
 
 // GetBlackholeRoutesForTransitGatewayRouteTable returns all routes that are currently active for a Transit Gateway route table
@@ -544,12 +567,7 @@ func GetBlackholeRoutesForTransitGatewayRouteTable(routetableID string, svc *ec2
 		panic(err)
 	}
 	for _, route := range resp.Routes {
-		tgwroute := TransitGatewayRoute{
-			State:     string(route.State),
-			CIDR:      *route.DestinationCidrBlock,
-			RouteType: string(route.Type),
-		}
-		result = append(result, tgwroute)
+		result = append(result, parseBlackholeRoute(route))
 	}
 	return result
 }

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -609,6 +609,108 @@ func TestParseActiveRoute_VPNStripsPublicIP(t *testing.T) {
 	}
 }
 
+// TestParseActiveRoute_NilCIDRWithPrefixList verifies that parseActiveRoute does
+// not panic when AWS returns a TGW route without a DestinationCidrBlock (as
+// happens for prefix-list routes) and surfaces the prefix list ID instead. (T-658)
+func TestParseActiveRoute_NilCIDRWithPrefixList(t *testing.T) {
+	route := types.TransitGatewayRoute{
+		DestinationCidrBlock: nil,
+		PrefixListId:         aws.String("pl-12345678"),
+		State:                types.TransitGatewayRouteStateActive,
+		Type:                 types.TransitGatewayRouteTypeStatic,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parseActiveRoute panicked on nil DestinationCidrBlock: %v", r)
+		}
+	}()
+
+	result := parseActiveRoute(route)
+	if result.CIDR != "pl-12345678" {
+		t.Errorf("Expected CIDR to fall back to prefix list ID 'pl-12345678', got %q", result.CIDR)
+	}
+}
+
+// TestParseActiveRoute_NilCIDRNoPrefixList verifies that parseActiveRoute does
+// not panic when both DestinationCidrBlock and PrefixListId are nil. (T-658)
+func TestParseActiveRoute_NilCIDRNoPrefixList(t *testing.T) {
+	route := types.TransitGatewayRoute{
+		DestinationCidrBlock: nil,
+		PrefixListId:         nil,
+		State:                types.TransitGatewayRouteStateActive,
+		Type:                 types.TransitGatewayRouteTypeStatic,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parseActiveRoute panicked on nil destinations: %v", r)
+		}
+	}()
+
+	result := parseActiveRoute(route)
+	if result.CIDR != "" {
+		t.Errorf("Expected empty CIDR when both destinations are nil, got %q", result.CIDR)
+	}
+}
+
+// TestParseActiveRoute_NilAttachmentPointers verifies that parseActiveRoute does
+// not panic when TransitGatewayRouteAttachment has nil ResourceId or
+// TransitGatewayAttachmentId pointers. (T-658)
+func TestParseActiveRoute_NilAttachmentPointers(t *testing.T) {
+	route := types.TransitGatewayRoute{
+		DestinationCidrBlock: aws.String("10.3.0.0/16"),
+		State:                types.TransitGatewayRouteStateActive,
+		Type:                 types.TransitGatewayRouteTypeStatic,
+		TransitGatewayAttachments: []types.TransitGatewayRouteAttachment{
+			{
+				ResourceId:                 nil,
+				TransitGatewayAttachmentId: nil,
+				ResourceType:               types.TransitGatewayAttachmentResourceTypeVpc,
+			},
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parseActiveRoute panicked on nil attachment pointers: %v", r)
+		}
+	}()
+
+	result := parseActiveRoute(route)
+	if result.Attachment.ID != "" {
+		t.Errorf("Expected empty Attachment.ID for nil pointer, got %q", result.Attachment.ID)
+	}
+	if result.Attachment.ResourceID != "" {
+		t.Errorf("Expected empty Attachment.ResourceID for nil pointer, got %q", result.Attachment.ResourceID)
+	}
+}
+
+// TestParseBlackholeRoute_NilCIDRWithPrefixList verifies the blackhole route
+// parser mirrors the active route parser in nil-safety. (T-658)
+func TestParseBlackholeRoute_NilCIDRWithPrefixList(t *testing.T) {
+	route := types.TransitGatewayRoute{
+		DestinationCidrBlock: nil,
+		PrefixListId:         aws.String("pl-87654321"),
+		State:                types.TransitGatewayRouteStateBlackhole,
+		Type:                 types.TransitGatewayRouteTypeStatic,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parseBlackholeRoute panicked on nil DestinationCidrBlock: %v", r)
+		}
+	}()
+
+	result := parseBlackholeRoute(route)
+	if result.CIDR != "pl-87654321" {
+		t.Errorf("Expected CIDR to fall back to prefix list ID 'pl-87654321', got %q", result.CIDR)
+	}
+	if result.State != "blackhole" {
+		t.Errorf("Expected State 'blackhole', got %s", result.State)
+	}
+}
+
 func TestIsValidIPAddress(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Transit Gateway route parsing in `helpers/ec2.go` panicked when AWS returned routes without a `DestinationCidrBlock` (prefix-list routes), because `*route.DestinationCidrBlock` was dereferenced without a nil guard.
- Introduce a `tgwRouteDestination` helper that falls back from `DestinationCidrBlock` to `PrefixListId` and returns an empty string if both are absent, mirroring the pattern used by `parseVPCRoutes`.
- Switch attachment pointer derefs (`ResourceId`, `TransitGatewayAttachmentId`) to `aws.ToString` for the same nil-safety, and extract a `parseBlackholeRoute` helper so the blackhole path is unit-testable (this is how the original bug slipped in).

## Root cause

`parseActiveRoute` (line ~512) and the blackhole loop inside `GetBlackholeRoutesForTransitGatewayRouteTable` (line ~549) assumed `DestinationCidrBlock` was always populated. The AWS SDK `types.TransitGatewayRoute` exposes two optional destination pointers: `DestinationCidrBlock` (used for both IPv4 and IPv6 CIDRs) and `PrefixListId`. Prefix-list routes only populate the latter, so the direct dereference panicked.

## Test plan

- [x] `go test ./helpers/ -run 'TestParseActiveRoute_|TestParseBlackholeRoute_' -v` — all pass, including four new regression tests covering nil CIDR with prefix list, nil CIDR without prefix list, nil attachment pointers, and the blackhole path.
- [x] `go test ./...` — full suite passes.
- [x] `make vet` and `make lint` — clean.

Closes T-658.