### PR TITLE
Fix T-656: Nil-Check NAT Gateway Address ENI IDs

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -24,3 +24,13 @@ All callers must pass the subnet's VPC ID. The VPC ID is available from:
 
 - `types.RouteTable` has a `VpcId` field — always use it when filtering by VPC
 - `DescribeRouteTables` without filters returns route tables across all VPCs
+- `types.NatGatewayAddress.NetworkInterfaceId` is `*string` and AWS may omit it (e.g. for addresses in transitional states). Always guard for nil or use `aws.ToString` before comparing.
+
+## ENI Matching Helpers
+
+Pure, testable helpers live alongside the AWS-client-taking wrappers. Each scans a slice of AWS objects for an ENI or subnet match so nil-safety can be tested without mocking.
+
+- `matchTransitGatewayAttachment(attachments, subnetID)` — T-397
+- `matchNatGatewayByENI(natgateways, eniID)` — T-656 (skips addresses with nil `NetworkInterfaceId`; empty `eniID` returns nil immediately)
+
+When adding a new `Get<Resource>FromNetworkInterface` style function, extract the matching logic into a helper following this pattern. Iterate with an index (`for i := range ...`) when returning a pointer into the slice, to avoid the loop-variable pointer reuse bug (T-456).

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -696,13 +696,26 @@ func GetNatGatewayFromNetworkInterface(netinterface types.NetworkInterface, svc 
 	if err != nil {
 		panic(err)
 	}
-	eniID := aws.ToString(netinterface.NetworkInterfaceId)
-	if len(resp.NatGateways) > 0 && eniID != "" {
-		for _, natgw := range resp.NatGateways {
-			for _, address := range natgw.NatGatewayAddresses {
-				if aws.ToString(address.NetworkInterfaceId) == eniID {
-					return &natgw
-				}
+	return matchNatGatewayByENI(resp.NatGateways, aws.ToString(netinterface.NetworkInterfaceId))
+}
+
+// matchNatGatewayByENI scans NAT gateways and returns the one whose addresses
+// reference the given ENI ID. Addresses with a nil NetworkInterfaceId are
+// skipped so scanning continues past missing values instead of panicking.
+// An empty eniID short-circuits and returns nil — an unassigned ENI cannot
+// match any NAT gateway address.
+func matchNatGatewayByENI(natgateways []types.NatGateway, eniID string) *types.NatGateway {
+	if eniID == "" {
+		return nil
+	}
+	for i := range natgateways {
+		natgw := natgateways[i]
+		for _, address := range natgw.NatGatewayAddresses {
+			if address.NetworkInterfaceId == nil {
+				continue
+			}
+			if *address.NetworkInterfaceId == eniID {
+				return &natgw
 			}
 		}
 	}

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -1749,6 +1749,86 @@ func TestFormatRouteTableInfo_PrefixListRoute(t *testing.T) {
 	}
 }
 
+// Regression tests for T-656: GetNatGatewayFromNetworkInterface must tolerate
+// NAT gateway address entries and network interfaces where NetworkInterfaceId
+// is nil without panicking. Scanning must continue past missing values and
+// match the correct NAT gateway when a later address has a non-nil matching ID.
+
+func TestMatchNatGatewayByENI_NilAddressNetworkInterfaceID(t *testing.T) {
+	natgateways := []types.NatGateway{
+		{
+			NatGatewayId: aws.String("nat-aaa"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: nil},
+				{NetworkInterfaceId: aws.String("eni-match")},
+			},
+		},
+	}
+
+	result := matchNatGatewayByENI(natgateways, "eni-match")
+	if result == nil {
+		t.Fatal("expected matching NAT gateway, got nil (nil address NetworkInterfaceId aborted scan)")
+	}
+	if aws.ToString(result.NatGatewayId) != "nat-aaa" {
+		t.Errorf("expected nat-aaa, got %s", aws.ToString(result.NatGatewayId))
+	}
+}
+
+func TestMatchNatGatewayByENI_EmptyENIID(t *testing.T) {
+	natgateways := []types.NatGateway{
+		{
+			NatGatewayId: aws.String("nat-aaa"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: nil},
+			},
+		},
+	}
+
+	if result := matchNatGatewayByENI(natgateways, ""); result != nil {
+		t.Errorf("expected nil for empty eniID, got %s", aws.ToString(result.NatGatewayId))
+	}
+}
+
+func TestMatchNatGatewayByENI_NoMatch(t *testing.T) {
+	natgateways := []types.NatGateway{
+		{
+			NatGatewayId: aws.String("nat-aaa"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: aws.String("eni-other")},
+			},
+		},
+	}
+
+	if result := matchNatGatewayByENI(natgateways, "eni-missing"); result != nil {
+		t.Errorf("expected nil when no match, got %s", aws.ToString(result.NatGatewayId))
+	}
+}
+
+func TestMatchNatGatewayByENI_MatchOnLaterGateway(t *testing.T) {
+	natgateways := []types.NatGateway{
+		{
+			NatGatewayId: aws.String("nat-first"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: nil},
+			},
+		},
+		{
+			NatGatewayId: aws.String("nat-second"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: aws.String("eni-target")},
+			},
+		},
+	}
+
+	result := matchNatGatewayByENI(natgateways, "eni-target")
+	if result == nil {
+		t.Fatal("expected match on second gateway, got nil")
+	}
+	if aws.ToString(result.NatGatewayId) != "nat-second" {
+		t.Errorf("expected nat-second, got %s", aws.ToString(result.NatGatewayId))
+	}
+}
+
 func TestFormatRouteTableInfo_MixedRoutes(t *testing.T) {
 	// A route table with all three destination types: IPv4 CIDR,
 	// IPv6 CIDR, and prefix list.


### PR DESCRIPTION
## Summary

`GetNatGatewayFromNetworkInterface` in `helpers/ec2.go` iterates `natgw.NatGatewayAddresses` and matches on `address.NetworkInterfaceId`. The field is optional in the AWS SDK, so if AWS omits it the original code panicked. Commit 116b2c4 (T-601) patched the panic via `aws.ToString`, but the nil-handling was implicit and untested — a regression could easily reintroduce a direct dereference.

This PR:
- Extracts the scan into a pure helper `matchNatGatewayByENI(natgateways, eniID)` with explicit `address.NetworkInterfaceId == nil` guards so scanning continues past missing values.
- Iterates with an index to avoid the loop-variable pointer reuse bug (T-456).
- Adds four regression tests covering nil address IDs, empty ENI IDs, no match, and a match on a later NAT gateway.

## Root cause

AWS's `*string` ENI IDs are optional. A direct dereference panics; a naive comparison can also silently abort a scan at the first missing value rather than continuing.

## Fix

- `helpers/ec2.go` — `matchNatGatewayByENI` helper with explicit nil guards; `GetNatGatewayFromNetworkInterface` delegates to it.
- `helpers/ec2_test.go` — `TestMatchNatGatewayByENI_*` regression tests.
- `docs/agent-notes/ec2-helpers.md` — documents the helper pattern and AWS SDK pointer caveat.

## Test plan

- [x] `go test ./helpers/ -run TestMatchNatGatewayByENI -v`
- [x] `go test ./...`
- [x] `make test`
- [x] `make vet`
- [x] `make lint` (0 issues)