### PR TITLE
Fix T-667: Paginate ENI Listing

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -24,3 +24,12 @@ All callers must pass the subnet's VPC ID. The VPC ID is available from:
 
 - `types.RouteTable` has a `VpcId` field — always use it when filtering by VPC
 - `DescribeRouteTables` without filters returns route tables across all VPCs
+
+## ENI Listing
+
+`GetNetworkInterfaces` (`helpers/ec2.go`) accepts
+`ec2.DescribeNetworkInterfacesAPIClient` rather than `*ec2.Client` directly.
+`*ec2.Client` satisfies the interface so real callers are unaffected, and
+tests can pass a mock. The helper uses `NewDescribeNetworkInterfacesPaginator`
+so large accounts don't get truncated output. `GetVPCUsageOverview` reuses
+this helper; there is no separate private `retrieveNetworkInterfaces`.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -607,14 +607,22 @@ func getNameFromTags(tags []types.Tag) string {
 	return ""
 }
 
-// GetNetworkInterfaces retrieves all network interfaces in the region
-func GetNetworkInterfaces(svc *ec2.Client) []types.NetworkInterface {
-	params := &ec2.DescribeNetworkInterfacesInput{}
-	resp, err := svc.DescribeNetworkInterfaces(context.TODO(), params)
-	if err != nil {
-		panic(err)
+// GetNetworkInterfaces retrieves all network interfaces in the region, paging
+// through every response so accounts with more ENIs than a single
+// DescribeNetworkInterfaces page still get complete results. The parameter
+// type is the AWS SDK paginator's own interface so tests can supply a mock
+// while real callers continue to pass an *ec2.Client.
+func GetNetworkInterfaces(svc ec2.DescribeNetworkInterfacesAPIClient) []types.NetworkInterface {
+	var result []types.NetworkInterface
+	paginator := ec2.NewDescribeNetworkInterfacesPaginator(svc, &ec2.DescribeNetworkInterfacesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		result = append(result, page.NetworkInterfaces...)
 	}
-	return resp.NetworkInterfaces
+	return result
 }
 
 // GetTransitGatewayFromNetworkInterface returns the Transit Gateway attachment ID for a network interface
@@ -762,7 +770,7 @@ type VPCUsageSummary struct {
 func GetVPCUsageOverview(svc *ec2.Client) VPCOverview {
 	vpcs := retrieveVPCData(svc)
 	subnets := retrieveSubnetData(svc)
-	networkInterfaces := retrieveNetworkInterfaces(svc)
+	networkInterfaces := GetNetworkInterfaces(svc)
 	routeTables := retrieveRouteTables(svc)
 
 	var vpcUsageInfos []VPCUsageInfo
@@ -856,20 +864,6 @@ func retrieveSubnetData(svc *ec2.Client) []types.Subnet {
 			panic(err)
 		}
 		result = append(result, page.Subnets...)
-	}
-	return result
-}
-
-// retrieveNetworkInterfaces fetches all network interfaces using DescribeNetworkInterfaces API
-func retrieveNetworkInterfaces(svc *ec2.Client) []types.NetworkInterface {
-	var result []types.NetworkInterface
-	paginator := ec2.NewDescribeNetworkInterfacesPaginator(svc, &ec2.DescribeNetworkInterfacesInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(context.TODO())
-		if err != nil {
-			panic(err)
-		}
-		result = append(result, page.NetworkInterfaces...)
 	}
 	return result
 }

--- a/helpers/ec2_pagination_test.go
+++ b/helpers/ec2_pagination_test.go
@@ -1,0 +1,86 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// mockDescribeNetworkInterfacesAPIClient implements the
+// ec2.DescribeNetworkInterfacesAPIClient interface and paginates the provided
+// interfaces using a fixed page size so tests can force multi-page responses.
+type mockDescribeNetworkInterfacesAPIClient struct {
+	interfaces []types.NetworkInterface
+	pageSize   int
+	callCount  int
+}
+
+// DescribeNetworkInterfaces returns a slice of the mock's interfaces, using
+// NextToken to advance through pages. When no further pages exist, NextToken
+// is left nil so the paginator stops.
+func (m *mockDescribeNetworkInterfacesAPIClient) DescribeNetworkInterfaces(_ context.Context, input *ec2.DescribeNetworkInterfacesInput, _ ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	m.callCount++
+	start := 0
+	if input.NextToken != nil {
+		fmt.Sscanf(*input.NextToken, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.interfaces)
+	}
+	end := start + pageSize
+	if end > len(m.interfaces) {
+		end = len(m.interfaces)
+	}
+	out := &ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: m.interfaces[start:end],
+	}
+	if end < len(m.interfaces) {
+		token := fmt.Sprintf("%d", end)
+		out.NextToken = &token
+	}
+	return out, nil
+}
+
+// makeNetworkInterfaces generates n synthetic ENI records with predictable IDs
+// so tests can assert completeness across pages.
+func makeNetworkInterfaces(n int) []types.NetworkInterface {
+	result := make([]types.NetworkInterface, n)
+	for i := 0; i < n; i++ {
+		result[i] = types.NetworkInterface{
+			NetworkInterfaceId: aws.String(fmt.Sprintf("eni-%04d", i)),
+		}
+	}
+	return result
+}
+
+// TestGetNetworkInterfaces_Pagination verifies that GetNetworkInterfaces
+// retrieves every ENI across multiple pages. Before the fix the helper only
+// called DescribeNetworkInterfaces once, so accounts with more ENIs than a
+// single page would see truncated output in `awstools vpc enis`.
+func TestGetNetworkInterfaces_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockDescribeNetworkInterfacesAPIClient{
+		interfaces: makeNetworkInterfaces(total),
+		pageSize:   2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := GetNetworkInterfaces(mock)
+
+	if len(result) != total {
+		t.Fatalf("GetNetworkInterfaces() returned %d ENIs, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.callCount != 3 {
+		t.Errorf("DescribeNetworkInterfaces called %d times, want 3 (one per page)", mock.callCount)
+	}
+	for i, eni := range result {
+		want := fmt.Sprintf("eni-%04d", i)
+		if aws.ToString(eni.NetworkInterfaceId) != want {
+			t.Errorf("GetNetworkInterfaces()[%d].NetworkInterfaceId = %s, want %s", i, aws.ToString(eni.NetworkInterfaceId), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `helpers.GetNetworkInterfaces` made a single `DescribeNetworkInterfaces` call. `cmd/vpcenis.go` relies on it, so accounts with more ENIs than fit in one page got truncated output.
- Switched the helper to `NewDescribeNetworkInterfacesPaginator` and widened its parameter type to `ec2.DescribeNetworkInterfacesAPIClient` (satisfied by `*ec2.Client`) so the behaviour is unit-testable.
- Removed the now-duplicate private `retrieveNetworkInterfaces`; `GetVPCUsageOverview` reuses the public helper.

## Root Cause

The helper predates the pagination conventions used elsewhere in `helpers/ec2.go`. It was never updated when the repo adopted SDK paginators for every other list API, and there was no regression test to catch the truncation.

## Test plan

- [x] `go test ./helpers/ -run Pagination -v` (new test forces 3 pages and confirms all 5 ENIs come back; the helper is called once per page)
- [x] `go test ./...`
- [x] `make check` (fmt, vet, golangci-lint, tests)

Closes T-667.