### PR TITLE
fix: nil-safe STS caller identity mapping (T-734)

### DIFF
--- a/config/awsconfig.go
+++ b/config/awsconfig.go
@@ -21,6 +21,7 @@ import (
 type AWSConfig struct {
 	AccountAlias string
 	AccountID    string
+	Arn          string
 	Config       aws.Config
 	ProfileName  string
 	Region       string
@@ -65,8 +66,19 @@ func (config *AWSConfig) setCallerInfo() {
 	if err != nil {
 		panic(err)
 	}
-	config.AccountID = *result.Account
-	config.UserID = *result.UserId
+	config.AccountID, config.UserID, config.Arn = resolveCallerIdentity(result)
+}
+
+// resolveCallerIdentity safely extracts the Account, UserId, and Arn
+// fields from an STS GetCallerIdentity response. The AWS SDK returns
+// these as *string and in some edge cases (e.g. SSO sessions in
+// specific states) one or more may be nil; aws.ToString converts nil
+// pointers to empty strings rather than panicking.
+func resolveCallerIdentity(result *sts.GetCallerIdentityOutput) (accountID, userID, arn string) {
+	if result == nil {
+		return "", "", ""
+	}
+	return aws.ToString(result.Account), aws.ToString(result.UserId), aws.ToString(result.Arn)
 }
 
 func (config *AWSConfig) setAlias() {

--- a/config/awsconfig_nil_safety_test.go
+++ b/config/awsconfig_nil_safety_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// Regression tests for T-734: setCallerInfo and its helper must not panic
+// when STS GetCallerIdentity returns nil Account, Arn, or UserId fields.
+//
+// In some edge cases (notably SSO sessions in specific states) the AWS
+// SDK returns a *sts.GetCallerIdentityOutput with one or more of these
+// pointer fields unset. The previous code dereferenced them directly,
+// which panicked.
+
+func TestResolveCallerIdentity_Populated(t *testing.T) {
+	out := &sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test"),
+		UserId:  aws.String("AIDACKCEVSQ6C2EXAMPLE"),
+	}
+	accountID, userID, arn := resolveCallerIdentity(out)
+	if accountID != "123456789012" {
+		t.Errorf("expected account ID 123456789012, got %q", accountID)
+	}
+	if userID != "AIDACKCEVSQ6C2EXAMPLE" {
+		t.Errorf("expected user ID AIDACKCEVSQ6C2EXAMPLE, got %q", userID)
+	}
+	if arn != "arn:aws:iam::123456789012:user/test" {
+		t.Errorf("expected arn arn:aws:iam::123456789012:user/test, got %q", arn)
+	}
+}
+
+func TestResolveCallerIdentity_NilAccount(t *testing.T) {
+	// Account nil — must return empty string for AccountID without panicking.
+	out := &sts.GetCallerIdentityOutput{
+		Arn:    aws.String("arn:aws:iam::123456789012:user/test"),
+		UserId: aws.String("AIDACKCEVSQ6C2EXAMPLE"),
+	}
+	accountID, userID, arn := resolveCallerIdentity(out)
+	if accountID != "" {
+		t.Errorf("expected empty accountID for nil Account, got %q", accountID)
+	}
+	if userID != "AIDACKCEVSQ6C2EXAMPLE" {
+		t.Errorf("expected user ID AIDACKCEVSQ6C2EXAMPLE, got %q", userID)
+	}
+	if arn != "arn:aws:iam::123456789012:user/test" {
+		t.Errorf("expected arn arn:aws:iam::123456789012:user/test, got %q", arn)
+	}
+}
+
+func TestResolveCallerIdentity_NilUserID(t *testing.T) {
+	// UserId nil — must return empty string for UserID without panicking.
+	out := &sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test"),
+	}
+	accountID, userID, arn := resolveCallerIdentity(out)
+	if accountID != "123456789012" {
+		t.Errorf("expected accountID 123456789012, got %q", accountID)
+	}
+	if userID != "" {
+		t.Errorf("expected empty userID for nil UserId, got %q", userID)
+	}
+	if arn != "arn:aws:iam::123456789012:user/test" {
+		t.Errorf("expected arn arn:aws:iam::123456789012:user/test, got %q", arn)
+	}
+}
+
+func TestResolveCallerIdentity_NilArn(t *testing.T) {
+	// Arn nil — must return empty string for arn without panicking.
+	out := &sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+		UserId:  aws.String("AIDACKCEVSQ6C2EXAMPLE"),
+	}
+	accountID, userID, arn := resolveCallerIdentity(out)
+	if accountID != "123456789012" {
+		t.Errorf("expected accountID 123456789012, got %q", accountID)
+	}
+	if userID != "AIDACKCEVSQ6C2EXAMPLE" {
+		t.Errorf("expected userID AIDACKCEVSQ6C2EXAMPLE, got %q", userID)
+	}
+	if arn != "" {
+		t.Errorf("expected empty arn for nil Arn, got %q", arn)
+	}
+}
+
+func TestResolveCallerIdentity_AllNilFields(t *testing.T) {
+	// All fields nil — every returned value must be empty, no panic.
+	out := &sts.GetCallerIdentityOutput{}
+	accountID, userID, arn := resolveCallerIdentity(out)
+	if accountID != "" || userID != "" || arn != "" {
+		t.Errorf("expected all empty strings for nil fields, got accountID=%q userID=%q arn=%q", accountID, userID, arn)
+	}
+}
+
+func TestResolveCallerIdentity_NilOutput(t *testing.T) {
+	// Nil output — must return empty strings without panicking.
+	accountID, userID, arn := resolveCallerIdentity(nil)
+	if accountID != "" || userID != "" || arn != "" {
+		t.Errorf("expected all empty strings for nil output, got accountID=%q userID=%q arn=%q", accountID, userID, arn)
+	}
+}

--- a/docs/agent-notes/aws-config.md
+++ b/docs/agent-notes/aws-config.md
@@ -1,0 +1,23 @@
+# AWS Config
+
+## Overview
+
+`config/awsconfig.go` holds the `AWSConfig` struct and service-client factories. `DefaultAwsConfig` loads the SDK config, applies profile/region overrides, then calls `setCallerInfo` (STS GetCallerIdentity) and `setAlias` (IAM ListAccountAliases).
+
+## Caller Identity (STS)
+
+`setCallerInfo` populates `AccountID`, `UserID`, and `Arn` on `AWSConfig`.
+
+**Important:** `sts.GetCallerIdentityOutput.Account`, `.Arn`, and `.UserId` are all `*string`. In some edge cases (notably SSO sessions in specific states) they can be nil. Always use the `resolveCallerIdentity` helper (or `aws.ToString`) — never dereference directly. This was the root cause of T-734.
+
+The same pattern applies to `helpers/sts.go:GetAccountID`, which uses `accountIDFromIdentity` to safely extract the account ID.
+
+## Account Alias
+
+`setAlias` uses `iam.ListAccountAliases` which is account-scoped (only returns the caller's own alias). If the call fails or returns no aliases, `AccountAlias` falls back to `AccountID`. For cross-account alias lookup see `docs/agent-notes/role-discovery.md` (uses SSO `ListAccounts` instead).
+
+## Failure Modes
+
+- Invalid profile or missing credentials → `DefaultAwsConfig` panics (caught by CLI). Tests recover from this panic explicitly.
+- STS call failure → `setCallerInfo` panics. Not graceful — consider error propagation if this ever becomes a common failure mode.
+- Partial STS response (nil fields) → handled via `resolveCallerIdentity`; identity fields become empty strings, no panic.

--- a/helpers/sts.go
+++ b/helpers/sts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
@@ -15,5 +16,17 @@ func GetAccountID(svc *sts.Client) string {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	return *result.Account
+	return accountIDFromIdentity(result)
+}
+
+// accountIDFromIdentity safely extracts the Account field from an STS
+// GetCallerIdentity response. The AWS SDK returns Account as *string
+// and in some edge cases (e.g. SSO sessions in specific states) it can
+// be nil; aws.ToString converts nil pointers to empty strings rather
+// than panicking.
+func accountIDFromIdentity(result *sts.GetCallerIdentityOutput) string {
+	if result == nil {
+		return ""
+	}
+	return aws.ToString(result.Account)
 }

--- a/helpers/sts_nil_safety_test.go
+++ b/helpers/sts_nil_safety_test.go
@@ -1,0 +1,53 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// Regression tests for T-734: GetAccountID must not panic when the STS
+// GetCallerIdentity response contains nil Account, Arn, or UserId fields.
+//
+// In edge cases (e.g. SSO sessions in specific states) the AWS SDK can
+// return a *sts.GetCallerIdentityOutput with one or more of these pointer
+// fields unset. Previously the code dereferenced `*result.Account`
+// directly, which panicked.
+
+func TestAccountIDFromIdentity_Populated(t *testing.T) {
+	out := &sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test"),
+		UserId:  aws.String("AIDACKCEVSQ6C2EXAMPLE"),
+	}
+	if got := accountIDFromIdentity(out); got != "123456789012" {
+		t.Fatalf("expected account ID 123456789012, got %q", got)
+	}
+}
+
+func TestAccountIDFromIdentity_NilAccount(t *testing.T) {
+	// Expected: empty string instead of panic when Account is nil.
+	out := &sts.GetCallerIdentityOutput{
+		Arn:    aws.String("arn:aws:iam::123456789012:user/test"),
+		UserId: aws.String("AIDACKCEVSQ6C2EXAMPLE"),
+	}
+	if got := accountIDFromIdentity(out); got != "" {
+		t.Fatalf("expected empty string for nil Account, got %q", got)
+	}
+}
+
+func TestAccountIDFromIdentity_NilOutput(t *testing.T) {
+	// Expected: empty string instead of panic when the whole output is nil.
+	if got := accountIDFromIdentity(nil); got != "" {
+		t.Fatalf("expected empty string for nil output, got %q", got)
+	}
+}
+
+func TestAccountIDFromIdentity_AllNilFields(t *testing.T) {
+	// Expected: empty string when every field is nil (SSO edge case).
+	out := &sts.GetCallerIdentityOutput{}
+	if got := accountIDFromIdentity(out); got != "" {
+		t.Fatalf("expected empty string for all-nil fields, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes T-734: `config/awsconfig.go:setCallerInfo` and `helpers/sts.go:GetAccountID` dereferenced `*result.Account`, `*result.UserId`, and related STS pointer fields directly. When AWS returns a partial identity payload (e.g. SSO sessions in specific states) those pointers can be nil, causing a panic.
- Extracts `resolveCallerIdentity` (in `config`) and `accountIDFromIdentity` (in `helpers`) — small pure helpers that use `aws.ToString` and handle nil output safely.
- Adds the resolved ARN to `AWSConfig.Arn` instead of discarding it.
- Adds regression tests covering populated, nil-field, all-nil, and nil-output cases.

## Root cause

AWS SDK v2 exposes `sts.GetCallerIdentityOutput.Account`, `.Arn`, and `.UserId` as `*string`. The original code assumed they were always populated and dereferenced them directly.

## Test plan

- [x] `CGO_ENABLED=0 go test ./config/ ./helpers/ -run "TestResolveCallerIdentity|TestAccountIDFromIdentity" -v` — 10 new tests, all pass
- [x] `CGO_ENABLED=0 go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --timeout 5m` — 0 issues