### PR TITLE
Fix T-693: S3 Public Access Block Unknown State

### DIFF
--- a/cmd/s3list.go
+++ b/cmd/s3list.go
@@ -105,7 +105,15 @@ func s3EncryptionToString(rules []types.ServerSideEncryptionRule) string {
 	return result
 }
 
-func parsePublicAccessBlock(config types.PublicAccessBlockConfiguration) string {
+// parsePublicAccessBlock renders a PublicAccessBlockConfiguration as a human
+// readable string. A nil config means the underlying GetPublicAccessBlock call
+// failed or returned no configuration (e.g. no PAB set, or access denied) and
+// is reported as "Unknown" so it is not confused with a bucket that has all
+// four flags explicitly set to false.
+func parsePublicAccessBlock(config *types.PublicAccessBlockConfiguration) string {
+	if config == nil {
+		return "Unknown"
+	}
 	if aws.ToBool(config.BlockPublicAcls) && aws.ToBool(config.BlockPublicPolicy) && aws.ToBool(config.IgnorePublicAcls) && aws.ToBool(config.RestrictPublicBuckets) {
 		return "All true"
 	}

--- a/cmd/s3list_test.go
+++ b/cmd/s3list_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// TestParsePublicAccessBlock verifies that parsePublicAccessBlock distinguishes
+// between "unknown" (no PAB configured or GetPublicAccessBlock failed) and the
+// legitimate "all four flags false" state. Regression test for T-693.
+func TestParsePublicAccessBlock(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *types.PublicAccessBlockConfiguration
+		want   string
+	}{
+		{
+			name:   "unknown when nil",
+			config: nil,
+			want:   "Unknown",
+		},
+		{
+			name: "all true",
+			config: &types.PublicAccessBlockConfiguration{
+				BlockPublicAcls:       aws.Bool(true),
+				BlockPublicPolicy:     aws.Bool(true),
+				IgnorePublicAcls:      aws.Bool(true),
+				RestrictPublicBuckets: aws.Bool(true),
+			},
+			want: "All true",
+		},
+		{
+			name: "all false",
+			config: &types.PublicAccessBlockConfiguration{
+				BlockPublicAcls:       aws.Bool(false),
+				BlockPublicPolicy:     aws.Bool(false),
+				IgnorePublicAcls:      aws.Bool(false),
+				RestrictPublicBuckets: aws.Bool(false),
+			},
+			want: "All false",
+		},
+		{
+			name: "mixed",
+			config: &types.PublicAccessBlockConfiguration{
+				BlockPublicAcls:       aws.Bool(true),
+				BlockPublicPolicy:     aws.Bool(false),
+				IgnorePublicAcls:      aws.Bool(true),
+				RestrictPublicBuckets: aws.Bool(false),
+			},
+			want: "Block Public ACLs: true, Block Public Policy: false, Ignore Public ACLs: true, Restrict Public Buckets: false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePublicAccessBlock(tt.config)
+			if got != tt.want {
+				t.Errorf("parsePublicAccessBlock() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/agent-notes/s3-helpers.md
+++ b/docs/agent-notes/s3-helpers.md
@@ -1,0 +1,11 @@
+# S3 Helpers
+
+## PublicAccessBlock tri-state
+
+`S3Bucket.PublicAccessBlockConfiguration` is a `*types.PublicAccessBlockConfiguration` (pointer), not a value. A `nil` pointer means the state is unknown — either the bucket has no PAB configured (AWS returns `NoSuchPublicAccessBlockConfiguration`) or the caller lacks `s3:GetBucketPublicAccessBlock`. This must be distinct from a non-nil config whose four `*bool` flags are all `false`, which is an explicit permissive configuration.
+
+The renderer `parsePublicAccessBlock` in `cmd/s3list.go` returns the literal string `"Unknown"` for the nil case. Previously the code used a value type and silently swallowed the error, so unknown buckets were rendered as "All false" — indistinguishable from the legitimate all-false state (bug T-693).
+
+## GetBucketDetails error tolerance
+
+`GetBucketDetails` tolerates most per-bucket API errors (PAB, policy, ACL, logging, encryption, tags, replication, versioning) because AWS frequently returns "NoSuch*" errors when a feature is not configured. When adding a new per-bucket API call, prefer to represent the unknown/absent state distinctly (pointer or explicit known flag) rather than relying on zero values, to avoid collisions with legitimate values.

--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -23,7 +23,7 @@ type S3Bucket struct {
 	OpenACLs                       bool
 	Owner                          string
 	Policy                         string
-	PublicAccessBlockConfiguration types.PublicAccessBlockConfiguration
+	PublicAccessBlockConfiguration *types.PublicAccessBlockConfiguration
 	PublicPolicy                   bool
 	Region                         string
 	Replication                    types.ReplicationConfiguration
@@ -95,10 +95,18 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 		if openacls {
 			isPublic = true
 		}
-		// PublicAccessBlock overrides other public making settings
-		publicresp, _ := svc.GetPublicAccessBlock(context.TODO(), &s3.GetPublicAccessBlockInput{Bucket: bucket.Name})
-		if publicresp != nil {
-			if (aws.ToBool(publicresp.PublicAccessBlockConfiguration.IgnorePublicAcls) || !openacls) && aws.ToBool(publicresp.PublicAccessBlockConfiguration.RestrictPublicBuckets) {
+		// PublicAccessBlock overrides other public making settings. The error
+		// is intentionally tolerated: the call routinely fails with
+		// NoSuchPublicAccessBlockConfiguration for buckets that simply have
+		// no PAB set. When the call fails we leave pabConfig nil so callers
+		// can distinguish "unknown" from a real "all false" configuration.
+		publicresp, pabErr := svc.GetPublicAccessBlock(context.TODO(), &s3.GetPublicAccessBlockInput{Bucket: bucket.Name})
+		var pabConfig *types.PublicAccessBlockConfiguration
+		if pabErr == nil && publicresp != nil {
+			pabConfig = publicresp.PublicAccessBlockConfiguration
+		}
+		if pabConfig != nil {
+			if (aws.ToBool(pabConfig.IgnorePublicAcls) || !openacls) && aws.ToBool(pabConfig.RestrictPublicBuckets) {
 				isPublic = false
 			}
 		}
@@ -120,9 +128,7 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 			PublicPolicy: policyIsPublic,
 		}
 
-		if publicresp != nil {
-			bucketObject.PublicAccessBlockConfiguration = *publicresp.PublicAccessBlockConfiguration
-		}
+		bucketObject.PublicAccessBlockConfiguration = pabConfig
 
 		loggingresp, _ := svc.GetBucketLogging(context.TODO(), &s3.GetBucketLoggingInput{Bucket: bucket.Name})
 		if loggingresp != nil && loggingresp.LoggingEnabled != nil {

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -543,7 +543,7 @@ func TestNormalizeBucketLocation(t *testing.T) {
 
 func TestS3Bucket_PublicAccessBlockConfiguration(t *testing.T) {
 	bucket := S3Bucket{
-		PublicAccessBlockConfiguration: types.PublicAccessBlockConfiguration{
+		PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
 			BlockPublicAcls:       aws.Bool(true),
 			BlockPublicPolicy:     aws.Bool(true),
 			IgnorePublicAcls:      aws.Bool(true),
@@ -552,6 +552,9 @@ func TestS3Bucket_PublicAccessBlockConfiguration(t *testing.T) {
 	}
 
 	config := bucket.PublicAccessBlockConfiguration
+	if config == nil {
+		t.Fatalf("Expected PublicAccessBlockConfiguration to be set, got nil")
+	}
 	if !aws.ToBool(config.BlockPublicAcls) {
 		t.Errorf("Expected BlockPublicAcls to be true, got %v", aws.ToBool(config.BlockPublicAcls))
 	}
@@ -563,5 +566,31 @@ func TestS3Bucket_PublicAccessBlockConfiguration(t *testing.T) {
 	}
 	if !aws.ToBool(config.RestrictPublicBuckets) {
 		t.Errorf("Expected RestrictPublicBuckets to be true, got %v", aws.ToBool(config.RestrictPublicBuckets))
+	}
+}
+
+// TestS3Bucket_PublicAccessBlockUnknown verifies that an S3Bucket with no
+// PublicAccessBlockConfiguration (e.g. when the GetPublicAccessBlock API call
+// failed or returned no configuration) is represented distinctly from a bucket
+// whose PAB has all four flags set to false. Regression test for T-693.
+func TestS3Bucket_PublicAccessBlockUnknown(t *testing.T) {
+	unknown := S3Bucket{}
+	if unknown.PublicAccessBlockConfiguration != nil {
+		t.Errorf("Expected PublicAccessBlockConfiguration to be nil when unknown, got %+v", unknown.PublicAccessBlockConfiguration)
+	}
+
+	allFalse := S3Bucket{
+		PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       aws.Bool(false),
+			BlockPublicPolicy:     aws.Bool(false),
+			IgnorePublicAcls:      aws.Bool(false),
+			RestrictPublicBuckets: aws.Bool(false),
+		},
+	}
+	if allFalse.PublicAccessBlockConfiguration == nil {
+		t.Fatalf("Expected PublicAccessBlockConfiguration to be set for all-false bucket")
+	}
+	if aws.ToBool(allFalse.PublicAccessBlockConfiguration.BlockPublicAcls) {
+		t.Errorf("Expected BlockPublicAcls to be false, got true")
 	}
 }


### PR DESCRIPTION
## Summary

- `helpers.GetBucketDetails` was ignoring the error from `GetPublicAccessBlock` and storing the zero-value `types.PublicAccessBlockConfiguration` on the bucket. Because `aws.ToBool(nil)` is `false`, buckets with no PAB configured (or where the caller lacked permission) were rendered as `All false` — identical to a bucket that legitimately had all four flags explicitly disabled.
- Change `S3Bucket.PublicAccessBlockConfiguration` to `*types.PublicAccessBlockConfiguration` and only populate it when the API call succeeds. `cmd.parsePublicAccessBlock` now treats nil as `Unknown`.
- Added regression tests in `helpers/s3_test.go` (`TestS3Bucket_PublicAccessBlockUnknown`) and a table-driven `cmd/s3list_test.go` (`TestParsePublicAccessBlock`) covering unknown/all-true/all-false/mixed.

## Test plan

- [x] `go test ./helpers/ ./cmd/ -run "PublicAccessBlock|ParsePublicAccessBlock" -v`
- [x] `go test ./...`
- [x] `go fmt ./...`
- [x] `make lint`

Transit: T-693