### PR TITLE
Fix T-657: Paginate ENI endpoint/NAT/TGW lookups

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -70,3 +70,12 @@ the pagination logic lives in the unexported `getAllVPCRouteTables` which takes
 the narrower `ec2.DescribeRouteTablesAPIClient` interface. Unit tests mock that
 interface (see `helpers/vpc_routetable_pagination_test.go`) — this is the same
 split used for the IAM pagination tests.
+
+The same split is used by the per-ENI lookup helpers after T-657:
+`GetVPCEndpointFromNetworkInterface`, `GetNatGatewayFromNetworkInterface`, and
+`GetTransitGatewayFromNetworkInterface` forward to unexported implementations
+that take `ec2.DescribeVpcEndpointsAPIClient`,
+`ec2.DescribeNatGatewaysAPIClient`, and
+`ec2.DescribeTransitGatewayVpcAttachmentsAPIClient` respectively. All three
+walk every page via `NewDescribe*Paginator`. Tests live in
+`helpers/ec2_eni_lookup_pagination_test.go`.

--- a/docs/agent-notes/eni-cache.md
+++ b/docs/agent-notes/eni-cache.md
@@ -23,4 +23,4 @@ Three functions use the cache for ENI detail resolution:
 
 - Pointer storage pattern: When storing pointers from range loops into maps, use `&slice[i]` (index-based) rather than `&loopVar`. The range value variable is a copy; while Go 1.22+ creates per-iteration copies, the index-based pattern is clearer and version-independent.
 - `batchFetchVPCEndpoints` and `batchFetchNATGateways` use `panic(err)` on API failure — these should eventually be converted to return errors.
-- No pagination is used for VPC endpoint and NAT gateway API calls. If a VPC has more resources than the default page size, results may be truncated.
+- Pagination: both the batch cache fetchers (`batchFetchVPCEndpoints`, `batchFetchNATGateways`, `batchFetchTransitGateways`) and the per-ENI helpers (`GetVPCEndpointFromNetworkInterface`, `GetNatGatewayFromNetworkInterface`, `GetTransitGatewayFromNetworkInterface`) walk every page via `NewDescribe*Paginator`. T-657 fixed the per-ENI helpers — a matching resource on page 2+ previously looked unattached.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -663,6 +663,15 @@ func GetNetworkInterfaces(svc ec2.DescribeNetworkInterfacesAPIClient) []types.Ne
 
 // GetTransitGatewayFromNetworkInterface returns the Transit Gateway attachment ID for a network interface
 func GetTransitGatewayFromNetworkInterface(netinterface types.NetworkInterface, svc *ec2.Client) string {
+	return getTransitGatewayFromNetworkInterface(netinterface, svc)
+}
+
+// getTransitGatewayFromNetworkInterface implements GetTransitGatewayFromNetworkInterface
+// against the minimal DescribeTransitGatewayVpcAttachmentsAPIClient interface
+// so pagination can be unit tested without a real *ec2.Client. It walks every
+// page of DescribeTransitGatewayVpcAttachments (T-657 — a matching attachment
+// on page 2+ was previously missed).
+func getTransitGatewayFromNetworkInterface(netinterface types.NetworkInterface, svc ec2.DescribeTransitGatewayVpcAttachmentsAPIClient) string {
 	vpcID := aws.ToString(netinterface.VpcId)
 	if vpcID == "" {
 		return ""
@@ -675,11 +684,18 @@ func GetTransitGatewayFromNetworkInterface(netinterface types.NetworkInterface, 
 			},
 		},
 	}
-	resp, err := svc.DescribeTransitGatewayVpcAttachments(context.Background(), params)
-	if err != nil {
-		panic(err)
+	subnetID := aws.ToString(netinterface.SubnetId)
+	paginator := ec2.NewDescribeTransitGatewayVpcAttachmentsPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		if id := matchTransitGatewayAttachment(page.TransitGatewayVpcAttachments, subnetID); id != "" {
+			return id
+		}
 	}
-	return matchTransitGatewayAttachment(resp.TransitGatewayVpcAttachments, aws.ToString(netinterface.SubnetId))
+	return ""
 }
 
 // matchTransitGatewayAttachment finds the attachment whose SubnetIds contain the given subnet.
@@ -695,8 +711,20 @@ func matchTransitGatewayAttachment(attachments []types.TransitGatewayVpcAttachme
 // GetVPCEndpointFromNetworkInterface returns the VPC endpoint associated with a network interface
 func GetVPCEndpointFromNetworkInterface(netinterface types.NetworkInterface, svc *ec2.Client) *types.VpcEndpoint {
 	// TODO: Consider caching this
+	return getVPCEndpointFromNetworkInterface(netinterface, svc)
+}
+
+// getVPCEndpointFromNetworkInterface implements GetVPCEndpointFromNetworkInterface
+// against the minimal DescribeVpcEndpointsAPIClient interface so pagination can
+// be unit tested. Walks every page of DescribeVpcEndpoints (T-657 — a matching
+// endpoint on page 2+ was previously missed).
+func getVPCEndpointFromNetworkInterface(netinterface types.NetworkInterface, svc ec2.DescribeVpcEndpointsAPIClient) *types.VpcEndpoint {
 	vpcID := aws.ToString(netinterface.VpcId)
 	if vpcID == "" {
+		return nil
+	}
+	eniID := aws.ToString(netinterface.NetworkInterfaceId)
+	if eniID == "" {
 		return nil
 	}
 	params := &ec2.DescribeVpcEndpointsInput{
@@ -707,13 +735,14 @@ func GetVPCEndpointFromNetworkInterface(netinterface types.NetworkInterface, svc
 			},
 		},
 	}
-	resp, err := svc.DescribeVpcEndpoints(context.Background(), params)
-	if err != nil {
-		panic(err)
-	}
-	eniID := aws.ToString(netinterface.NetworkInterfaceId)
-	if len(resp.VpcEndpoints) > 0 && eniID != "" {
-		for _, endpoint := range resp.VpcEndpoints {
+	paginator := ec2.NewDescribeVpcEndpointsPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		for i := range page.VpcEndpoints {
+			endpoint := page.VpcEndpoints[i]
 			if slices.Contains(endpoint.NetworkInterfaceIds, eniID) {
 				return &endpoint
 			}
@@ -724,6 +753,14 @@ func GetVPCEndpointFromNetworkInterface(netinterface types.NetworkInterface, svc
 
 // GetNatGatewayFromNetworkInterface returns the NAT gateway associated with a network interface
 func GetNatGatewayFromNetworkInterface(netinterface types.NetworkInterface, svc *ec2.Client) *types.NatGateway {
+	return getNatGatewayFromNetworkInterface(netinterface, svc)
+}
+
+// getNatGatewayFromNetworkInterface implements GetNatGatewayFromNetworkInterface
+// against the minimal DescribeNatGatewaysAPIClient interface so pagination can
+// be unit tested. Walks every page of DescribeNatGateways (T-657 — a matching
+// gateway on page 2+ was previously missed).
+func getNatGatewayFromNetworkInterface(netinterface types.NetworkInterface, svc ec2.DescribeNatGatewaysAPIClient) *types.NatGateway {
 	vpcID := aws.ToString(netinterface.VpcId)
 	if vpcID == "" {
 		return nil
@@ -736,11 +773,18 @@ func GetNatGatewayFromNetworkInterface(netinterface types.NetworkInterface, svc 
 			},
 		},
 	}
-	resp, err := svc.DescribeNatGateways(context.Background(), params)
-	if err != nil {
-		panic(err)
+	eniID := aws.ToString(netinterface.NetworkInterfaceId)
+	paginator := ec2.NewDescribeNatGatewaysPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		if match := matchNatGatewayByENI(page.NatGateways, eniID); match != nil {
+			return match
+		}
 	}
-	return matchNatGatewayByENI(resp.NatGateways, aws.ToString(netinterface.NetworkInterfaceId))
+	return nil
 }
 
 // matchNatGatewayByENI scans NAT gateways and returns the one whose addresses

--- a/helpers/ec2_eni_lookup_pagination_test.go
+++ b/helpers/ec2_eni_lookup_pagination_test.go
@@ -1,0 +1,334 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// Regression tests for T-657: the per-ENI endpoint / NAT / TGW lookup helpers
+// previously called their Describe* API once and trusted the first page of
+// results. In accounts where the matching resource is on page 2 or later the
+// ENI appeared unattached. These tests simulate multi-page responses to prove
+// the helpers now walk every page.
+
+// mockDescribeVpcEndpointsClient implements ec2.DescribeVpcEndpointsAPIClient
+// and paginates a pre-seeded slice based on NextToken so tests can force
+// multi-page responses.
+type mockDescribeVpcEndpointsClient struct {
+	endpoints []types.VpcEndpoint
+	pageSize  int
+	callCount int
+}
+
+func (m *mockDescribeVpcEndpointsClient) DescribeVpcEndpoints(_ context.Context, input *ec2.DescribeVpcEndpointsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
+	m.callCount++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.endpoints)
+	}
+	end := start + pageSize
+	if end > len(m.endpoints) {
+		end = len(m.endpoints)
+	}
+	out := &ec2.DescribeVpcEndpointsOutput{
+		VpcEndpoints: m.endpoints[start:end],
+	}
+	if end < len(m.endpoints) {
+		token := fmt.Sprintf("%d", end)
+		out.NextToken = &token
+	}
+	return out, nil
+}
+
+// mockDescribeNatGatewaysClient implements ec2.DescribeNatGatewaysAPIClient
+// with the same paginated-slice behaviour.
+type mockDescribeNatGatewaysClient struct {
+	gateways  []types.NatGateway
+	pageSize  int
+	callCount int
+}
+
+func (m *mockDescribeNatGatewaysClient) DescribeNatGateways(_ context.Context, input *ec2.DescribeNatGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error) {
+	m.callCount++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.gateways)
+	}
+	end := start + pageSize
+	if end > len(m.gateways) {
+		end = len(m.gateways)
+	}
+	out := &ec2.DescribeNatGatewaysOutput{
+		NatGateways: m.gateways[start:end],
+	}
+	if end < len(m.gateways) {
+		token := fmt.Sprintf("%d", end)
+		out.NextToken = &token
+	}
+	return out, nil
+}
+
+// mockDescribeTGWAttachmentsClient implements
+// ec2.DescribeTransitGatewayVpcAttachmentsAPIClient with paginated slice
+// behaviour.
+type mockDescribeTGWAttachmentsClient struct {
+	attachments []types.TransitGatewayVpcAttachment
+	pageSize    int
+	callCount   int
+}
+
+func (m *mockDescribeTGWAttachmentsClient) DescribeTransitGatewayVpcAttachments(_ context.Context, input *ec2.DescribeTransitGatewayVpcAttachmentsInput, _ ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
+	m.callCount++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.attachments)
+	}
+	end := start + pageSize
+	if end > len(m.attachments) {
+		end = len(m.attachments)
+	}
+	out := &ec2.DescribeTransitGatewayVpcAttachmentsOutput{
+		TransitGatewayVpcAttachments: m.attachments[start:end],
+	}
+	if end < len(m.attachments) {
+		token := fmt.Sprintf("%d", end)
+		out.NextToken = &token
+	}
+	return out, nil
+}
+
+// TestGetVPCEndpointFromNetworkInterface_FindsMatchOnLaterPage verifies that
+// a VPC endpoint on a second page of DescribeVpcEndpoints results is still
+// found. Before the fix only the first page was inspected so the ENI looked
+// unattached.
+func TestGetVPCEndpointFromNetworkInterface_FindsMatchOnLaterPage(t *testing.T) {
+	// Seed two pages: the matching endpoint is the last item so it is
+	// forced onto page two by pageSize: 1.
+	endpoints := []types.VpcEndpoint{
+		{
+			VpcEndpointId:       aws.String("vpce-page1-other"),
+			VpcId:               aws.String("vpc-aaa"),
+			NetworkInterfaceIds: []string{"eni-unrelated"},
+		},
+		{
+			VpcEndpointId:       aws.String("vpce-page2-match"),
+			VpcId:               aws.String("vpc-aaa"),
+			NetworkInterfaceIds: []string{"eni-target"},
+		},
+	}
+	mock := &mockDescribeVpcEndpointsClient{endpoints: endpoints, pageSize: 1}
+
+	eni := types.NetworkInterface{
+		NetworkInterfaceId: aws.String("eni-target"),
+		VpcId:              aws.String("vpc-aaa"),
+	}
+
+	result := getVPCEndpointFromNetworkInterface(eni, mock)
+
+	if result == nil {
+		t.Fatal("expected matching VPC endpoint on page 2, got nil (pagination bug)")
+	}
+	if aws.ToString(result.VpcEndpointId) != "vpce-page2-match" {
+		t.Errorf("got %s, want vpce-page2-match", aws.ToString(result.VpcEndpointId))
+	}
+	if mock.callCount != 2 {
+		t.Errorf("DescribeVpcEndpoints called %d times, want 2 (one per page)", mock.callCount)
+	}
+}
+
+// TestGetVPCEndpointFromNetworkInterface_NoMatch confirms nil is returned when
+// the ENI doesn't match any endpoint across all pages.
+func TestGetVPCEndpointFromNetworkInterface_NoMatch(t *testing.T) {
+	endpoints := []types.VpcEndpoint{
+		{VpcEndpointId: aws.String("vpce-a"), NetworkInterfaceIds: []string{"eni-x"}},
+		{VpcEndpointId: aws.String("vpce-b"), NetworkInterfaceIds: []string{"eni-y"}},
+	}
+	mock := &mockDescribeVpcEndpointsClient{endpoints: endpoints, pageSize: 1}
+
+	eni := types.NetworkInterface{
+		NetworkInterfaceId: aws.String("eni-target"),
+		VpcId:              aws.String("vpc-aaa"),
+	}
+
+	if result := getVPCEndpointFromNetworkInterface(eni, mock); result != nil {
+		t.Errorf("expected nil when ENI has no matching endpoint, got %s", aws.ToString(result.VpcEndpointId))
+	}
+}
+
+// TestGetNatGatewayFromNetworkInterface_FindsMatchOnLaterPage verifies that a
+// NAT gateway on a second page is still discovered.
+func TestGetNatGatewayFromNetworkInterface_FindsMatchOnLaterPage(t *testing.T) {
+	gateways := []types.NatGateway{
+		{
+			NatGatewayId: aws.String("nat-page1-other"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: aws.String("eni-unrelated")},
+			},
+		},
+		{
+			NatGatewayId: aws.String("nat-page2-match"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: aws.String("eni-target")},
+			},
+		},
+	}
+	mock := &mockDescribeNatGatewaysClient{gateways: gateways, pageSize: 1}
+
+	eni := types.NetworkInterface{
+		NetworkInterfaceId: aws.String("eni-target"),
+		VpcId:              aws.String("vpc-aaa"),
+	}
+
+	result := getNatGatewayFromNetworkInterface(eni, mock)
+
+	if result == nil {
+		t.Fatal("expected matching NAT gateway on page 2, got nil (pagination bug)")
+	}
+	if aws.ToString(result.NatGatewayId) != "nat-page2-match" {
+		t.Errorf("got %s, want nat-page2-match", aws.ToString(result.NatGatewayId))
+	}
+	if mock.callCount != 2 {
+		t.Errorf("DescribeNatGateways called %d times, want 2 (one per page)", mock.callCount)
+	}
+}
+
+// TestGetNatGatewayFromNetworkInterface_NoMatch confirms nil is returned when
+// the ENI doesn't match any NAT gateway address across pages.
+func TestGetNatGatewayFromNetworkInterface_NoMatch(t *testing.T) {
+	gateways := []types.NatGateway{
+		{
+			NatGatewayId: aws.String("nat-a"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: aws.String("eni-x")},
+			},
+		},
+		{
+			NatGatewayId: aws.String("nat-b"),
+			NatGatewayAddresses: []types.NatGatewayAddress{
+				{NetworkInterfaceId: aws.String("eni-y")},
+			},
+		},
+	}
+	mock := &mockDescribeNatGatewaysClient{gateways: gateways, pageSize: 1}
+
+	eni := types.NetworkInterface{
+		NetworkInterfaceId: aws.String("eni-target"),
+		VpcId:              aws.String("vpc-aaa"),
+	}
+
+	if result := getNatGatewayFromNetworkInterface(eni, mock); result != nil {
+		t.Errorf("expected nil when ENI has no matching NAT gateway, got %s", aws.ToString(result.NatGatewayId))
+	}
+}
+
+// TestGetTransitGatewayFromNetworkInterface_FindsMatchOnLaterPage verifies the
+// sibling TGW attachment lookup also paginates.
+func TestGetTransitGatewayFromNetworkInterface_FindsMatchOnLaterPage(t *testing.T) {
+	attachments := []types.TransitGatewayVpcAttachment{
+		{
+			TransitGatewayAttachmentId: aws.String("tgw-attach-page1-other"),
+			SubnetIds:                  []string{"subnet-unrelated"},
+		},
+		{
+			TransitGatewayAttachmentId: aws.String("tgw-attach-page2-match"),
+			SubnetIds:                  []string{"subnet-target"},
+		},
+	}
+	mock := &mockDescribeTGWAttachmentsClient{attachments: attachments, pageSize: 1}
+
+	eni := types.NetworkInterface{
+		NetworkInterfaceId: aws.String("eni-target"),
+		VpcId:              aws.String("vpc-aaa"),
+		SubnetId:           aws.String("subnet-target"),
+	}
+
+	result := getTransitGatewayFromNetworkInterface(eni, mock)
+
+	if result != "tgw-attach-page2-match" {
+		t.Fatalf("expected tgw-attach-page2-match, got %q (pagination bug)", result)
+	}
+	if mock.callCount != 2 {
+		t.Errorf("DescribeTransitGatewayVpcAttachments called %d times, want 2", mock.callCount)
+	}
+}
+
+// TestGetTransitGatewayFromNetworkInterface_NoMatch confirms an empty string
+// is returned when no attachment references the ENI's subnet.
+func TestGetTransitGatewayFromNetworkInterface_NoMatch(t *testing.T) {
+	attachments := []types.TransitGatewayVpcAttachment{
+		{TransitGatewayAttachmentId: aws.String("tgw-a"), SubnetIds: []string{"subnet-x"}},
+		{TransitGatewayAttachmentId: aws.String("tgw-b"), SubnetIds: []string{"subnet-y"}},
+	}
+	mock := &mockDescribeTGWAttachmentsClient{attachments: attachments, pageSize: 1}
+
+	eni := types.NetworkInterface{
+		NetworkInterfaceId: aws.String("eni-target"),
+		VpcId:              aws.String("vpc-aaa"),
+		SubnetId:           aws.String("subnet-target"),
+	}
+
+	if result := getTransitGatewayFromNetworkInterface(eni, mock); result != "" {
+		t.Errorf("expected empty string for unmatched subnet, got %q", result)
+	}
+}
+
+// TestGetVPCEndpointFromNetworkInterface_EmptyVPC ensures the helper
+// short-circuits (no API call) when VpcId is unset. Preserves the existing
+// contract of the public helper.
+func TestGetVPCEndpointFromNetworkInterface_EmptyVPC(t *testing.T) {
+	mock := &mockDescribeVpcEndpointsClient{}
+	eni := types.NetworkInterface{NetworkInterfaceId: aws.String("eni-x")}
+	if result := getVPCEndpointFromNetworkInterface(eni, mock); result != nil {
+		t.Errorf("expected nil result, got %s", aws.ToString(result.VpcEndpointId))
+	}
+	if mock.callCount != 0 {
+		t.Errorf("expected no API calls when VpcId is empty, got %d", mock.callCount)
+	}
+}
+
+// TestGetNatGatewayFromNetworkInterface_EmptyVPC mirrors the above for NAT.
+func TestGetNatGatewayFromNetworkInterface_EmptyVPC(t *testing.T) {
+	mock := &mockDescribeNatGatewaysClient{}
+	eni := types.NetworkInterface{NetworkInterfaceId: aws.String("eni-x")}
+	if result := getNatGatewayFromNetworkInterface(eni, mock); result != nil {
+		t.Errorf("expected nil result, got %s", aws.ToString(result.NatGatewayId))
+	}
+	if mock.callCount != 0 {
+		t.Errorf("expected no API calls when VpcId is empty, got %d", mock.callCount)
+	}
+}
+
+// TestGetTransitGatewayFromNetworkInterface_EmptyVPC mirrors the above for TGW.
+func TestGetTransitGatewayFromNetworkInterface_EmptyVPC(t *testing.T) {
+	mock := &mockDescribeTGWAttachmentsClient{}
+	eni := types.NetworkInterface{NetworkInterfaceId: aws.String("eni-x")}
+	if result := getTransitGatewayFromNetworkInterface(eni, mock); result != "" {
+		t.Errorf("expected empty result, got %q", result)
+	}
+	if mock.callCount != 0 {
+		t.Errorf("expected no API calls when VpcId is empty, got %d", mock.callCount)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes T-657. `GetVPCEndpointFromNetworkInterface`, `GetNatGatewayFromNetworkInterface`, and `GetTransitGatewayFromNetworkInterface` in `helpers/ec2.go` called `Describe*` once and trusted the first page. In large accounts an ENI whose matching endpoint / NAT gateway / TGW attachment was on a later page appeared unattached.
- Each helper now splits into a `*ec2.Client`-accepting public wrapper and an unexported implementation that takes the narrow `ec2.Describe*APIClient` interface and walks every page via `NewDescribe*Paginator`. Public signatures are unchanged so no callers need to adapt.
- Adds `helpers/ec2_eni_lookup_pagination_test.go` with mock paginated clients that force multi-page responses and assert the matching resource is found on page 2 (the regression case), plus negative-match and empty-VPC guards.

## Root cause

Historical single-shot `svc.DescribeVpcEndpoints` / `svc.DescribeNatGateways` / `svc.DescribeTransitGatewayVpcAttachments` calls. The batch variants on `ENILookupCache` were already paginated; the per-ENI siblings were not. Taking `*ec2.Client` directly also made the helpers hard to unit test, which is what let the bug go unnoticed.

## Test plan

- [x] `go test ./helpers/ -run 'TestGet(VPCEndpoint|NatGateway|TransitGateway)FromNetworkInterface' -v` — new regression tests pass.
- [x] `go test ./...` — full suite passes.
- [x] `go vet ./...` clean.
- [x] `golangci-lint run --timeout 5m` — 0 issues.
- [x] `go fmt ./...` clean.