### PR TITLE
fix: paginate VPC peering inventory helper (T-746)

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -70,3 +70,20 @@ the pagination logic lives in the unexported `getAllVPCRouteTables` which takes
 the narrower `ec2.DescribeRouteTablesAPIClient` interface. Unit tests mock that
 interface (see `helpers/vpc_routetable_pagination_test.go`) — this is the same
 split used for the IAM pagination tests.
+
+`GetAllVpcPeers` follows the same split: the exported function takes
+`*ec2.Client` while the unexported `getAllVpcPeers` takes
+`ec2.DescribeVpcPeeringConnectionsAPIClient` and walks
+`ec2.NewDescribeVpcPeeringConnectionsPaginator` (T-746). Before that fix the
+helper issued a single `DescribeVpcPeeringConnections` call and silently
+dropped peerings on subsequent pages.
+
+## VPN Connections API
+
+`DescribeVpnConnections` is **not** a paginated AWS API — the input/output
+structs have no `NextToken` or `MaxResults` and the SDK provides no paginator.
+A single call returns every VPN connection in the region. `addAllVpnNames`
+(`helpers/ec2.go`) therefore uses one call, but takes
+`ec2.DescribeVpnConnectionsAPIClient` instead of `*ec2.Client` so the helper
+is unit-testable (T-746). The same applies to `DescribeVpnGateways`, which is
+currently not used anywhere in the codebase.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -203,16 +203,24 @@ func addAllTransitGatewayNames(svc *ec2.Client, result map[string]string) map[st
 	return result
 }
 
-// addAllVPCNames returns the names of all vpns in a map
-func addAllVpnNames(svc *ec2.Client, result map[string]string) map[string]string {
+// addAllVpnNames adds every VPN connection's display name to the result map.
+// AWS's DescribeVpnConnections API is not paginated (no NextToken/MaxResults),
+// so a single call returns every VPN connection in the region. The helper
+// accepts the narrow ec2.DescribeVpnConnectionsAPIClient interface so it can
+// be unit tested without a real *ec2.Client.
+func addAllVpnNames(svc ec2.DescribeVpnConnectionsAPIClient, result map[string]string) map[string]string {
 	resp, err := svc.DescribeVpnConnections(context.TODO(), &ec2.DescribeVpnConnectionsInput{})
 	if err != nil {
 		panic(err)
 	}
 	for _, vpn := range resp.VpnConnections {
-		result[*vpn.VpnConnectionId] = *vpn.VpnConnectionId
+		vpnID := aws.ToString(vpn.VpnConnectionId)
+		if vpnID == "" {
+			continue
+		}
+		result[vpnID] = vpnID
 		if name := getNameFromTags(vpn.Tags); name != "" {
-			result[*vpn.VpnConnectionId] = name
+			result[vpnID] = name
 		}
 	}
 	return result
@@ -269,30 +277,43 @@ type VPCHolder struct {
 	AccountID string
 }
 
-// GetAllVpcPeers returns the peerings that are present in this region of this account
+// GetAllVpcPeers returns the peerings that are present in this region of this
+// account. It paginates through every page of DescribeVpcPeeringConnections so
+// accounts with more peerings than fit in a single response are fully
+// enumerated.
 func GetAllVpcPeers(svc *ec2.Client) []VpcPeering {
+	return getAllVpcPeers(svc)
+}
+
+// getAllVpcPeers implements GetAllVpcPeers against the minimal
+// DescribeVpcPeeringConnectionsAPIClient interface so the pagination logic can
+// be unit tested without a real *ec2.Client.
+func getAllVpcPeers(svc ec2.DescribeVpcPeeringConnectionsAPIClient) []VpcPeering {
 	var result []VpcPeering
-	resp, err := svc.DescribeVpcPeeringConnections(context.TODO(), &ec2.DescribeVpcPeeringConnectionsInput{})
-	if err != nil {
-		panic(err)
-	}
-	for _, connection := range resp.VpcPeeringConnections {
-		peering := VpcPeering{
-			PeeringID: aws.ToString(connection.VpcPeeringConnectionId),
+	paginator := ec2.NewDescribeVpcPeeringConnectionsPaginator(svc, &ec2.DescribeVpcPeeringConnectionsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
 		}
-		if connection.RequesterVpcInfo != nil {
-			peering.RequesterVpc = VPCHolder{
-				ID:        aws.ToString(connection.RequesterVpcInfo.VpcId),
-				AccountID: aws.ToString(connection.RequesterVpcInfo.OwnerId),
+		for _, connection := range page.VpcPeeringConnections {
+			peering := VpcPeering{
+				PeeringID: aws.ToString(connection.VpcPeeringConnectionId),
 			}
-		}
-		if connection.AccepterVpcInfo != nil {
-			peering.AccepterVpc = VPCHolder{
-				ID:        aws.ToString(connection.AccepterVpcInfo.VpcId),
-				AccountID: aws.ToString(connection.AccepterVpcInfo.OwnerId),
+			if connection.RequesterVpcInfo != nil {
+				peering.RequesterVpc = VPCHolder{
+					ID:        aws.ToString(connection.RequesterVpcInfo.VpcId),
+					AccountID: aws.ToString(connection.RequesterVpcInfo.OwnerId),
+				}
 			}
+			if connection.AccepterVpcInfo != nil {
+				peering.AccepterVpc = VPCHolder{
+					ID:        aws.ToString(connection.AccepterVpcInfo.VpcId),
+					AccountID: aws.ToString(connection.AccepterVpcInfo.OwnerId),
+				}
+			}
+			result = append(result, peering)
 		}
-		result = append(result, peering)
 	}
 	return result
 }

--- a/helpers/ec2_vpc_pagination_test.go
+++ b/helpers/ec2_vpc_pagination_test.go
@@ -1,0 +1,178 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// mockDescribeVpcPeeringConnectionsClient simulates DescribeVpcPeeringConnections
+// pagination by splitting a pre-configured slice of peering connections across
+// multiple pages based on the NextToken. It satisfies
+// ec2.DescribeVpcPeeringConnectionsAPIClient.
+type mockDescribeVpcPeeringConnectionsClient struct {
+	peers     []types.VpcPeeringConnection
+	pageSize  int
+	callCount int
+}
+
+func (m *mockDescribeVpcPeeringConnectionsClient) DescribeVpcPeeringConnections(_ context.Context, input *ec2.DescribeVpcPeeringConnectionsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	m.callCount++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(m.peers) {
+		end = len(m.peers)
+	}
+	output := &ec2.DescribeVpcPeeringConnectionsOutput{
+		VpcPeeringConnections: m.peers[start:end],
+	}
+	if end < len(m.peers) {
+		next := fmt.Sprintf("%d", end)
+		output.NextToken = &next
+	}
+	return output, nil
+}
+
+// makeVpcPeeringConnections builds n dummy peering connections with unique IDs.
+func makeVpcPeeringConnections(n int) []types.VpcPeeringConnection {
+	peers := make([]types.VpcPeeringConnection, n)
+	for i := range n {
+		id := fmt.Sprintf("pcx-%08d", i)
+		requester := fmt.Sprintf("vpc-req-%08d", i)
+		accepter := fmt.Sprintf("vpc-acc-%08d", i)
+		peers[i] = types.VpcPeeringConnection{
+			VpcPeeringConnectionId: aws.String(id),
+			RequesterVpcInfo: &types.VpcPeeringConnectionVpcInfo{
+				VpcId:   aws.String(requester),
+				OwnerId: aws.String("111111111111"),
+			},
+			AccepterVpcInfo: &types.VpcPeeringConnectionVpcInfo{
+				VpcId:   aws.String(accepter),
+				OwnerId: aws.String("222222222222"),
+			},
+			Tags: []types.Tag{
+				{Key: aws.String("Name"), Value: aws.String(fmt.Sprintf("peer-name-%d", i))},
+			},
+		}
+	}
+	return peers
+}
+
+// TestGetAllVpcPeers_Pagination verifies that GetAllVpcPeers retrieves every
+// peering connection across multiple pages. Before the fix it only returned
+// the first page of DescribeVpcPeeringConnections.
+func TestGetAllVpcPeers_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockDescribeVpcPeeringConnectionsClient{
+		peers:    makeVpcPeeringConnections(total),
+		pageSize: 2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := getAllVpcPeers(mock)
+
+	if len(result) != total {
+		t.Fatalf("getAllVpcPeers() returned %d peerings, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.callCount < 3 {
+		t.Errorf("expected at least 3 DescribeVpcPeeringConnections calls for %d peerings at page size %d, got %d", total, mock.pageSize, mock.callCount)
+	}
+	for i, peer := range result {
+		wantID := fmt.Sprintf("pcx-%08d", i)
+		if peer.PeeringID != wantID {
+			t.Errorf("result[%d].PeeringID = %q, want %q", i, peer.PeeringID, wantID)
+		}
+		wantReq := fmt.Sprintf("vpc-req-%08d", i)
+		if peer.RequesterVpc.ID != wantReq {
+			t.Errorf("result[%d].RequesterVpc.ID = %q, want %q", i, peer.RequesterVpc.ID, wantReq)
+		}
+		wantAcc := fmt.Sprintf("vpc-acc-%08d", i)
+		if peer.AccepterVpc.ID != wantAcc {
+			t.Errorf("result[%d].AccepterVpc.ID = %q, want %q", i, peer.AccepterVpc.ID, wantAcc)
+		}
+	}
+}
+
+// mockDescribeVpnConnectionsClient satisfies ec2.DescribeVpnConnectionsAPIClient
+// and returns a preset slice of VPN connections. AWS's DescribeVpnConnections
+// API does not support pagination (no NextToken/MaxResults fields), so this
+// mock simply returns the full slice in one call. The regression test verifies
+// that addAllVpnNames aggregates every VPN name in the response and uses the
+// API client interface so the helper is unit-testable without a real client.
+type mockDescribeVpnConnectionsClient struct {
+	vpns      []types.VpnConnection
+	callCount int
+}
+
+func (m *mockDescribeVpnConnectionsClient) DescribeVpnConnections(_ context.Context, _ *ec2.DescribeVpnConnectionsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpnConnectionsOutput, error) {
+	m.callCount++
+	return &ec2.DescribeVpnConnectionsOutput{VpnConnections: m.vpns}, nil
+}
+
+// makeVpnConnections builds n VPN connections with predictable IDs and Name
+// tags. The first half have Name tags; the second half only have IDs so the
+// fallback path is also exercised.
+func makeVpnConnections(n int) []types.VpnConnection {
+	vpns := make([]types.VpnConnection, n)
+	for i := range n {
+		id := fmt.Sprintf("vpn-%08d", i)
+		conn := types.VpnConnection{
+			VpnConnectionId: aws.String(id),
+		}
+		if i < n/2 {
+			conn.Tags = []types.Tag{
+				{Key: aws.String("Name"), Value: aws.String(fmt.Sprintf("vpn-name-%d", i))},
+			}
+		}
+		vpns[i] = conn
+	}
+	return vpns
+}
+
+// TestAddAllVpnNames_AggregatesAllConnections verifies that addAllVpnNames
+// aggregates every VPN connection returned by the AWS API. The AWS API is
+// not paginated, but the helper must still work against the
+// DescribeVpnConnectionsAPIClient interface so it can be unit tested and so
+// the single-call behaviour is guaranteed.
+func TestAddAllVpnNames_AggregatesAllConnections(t *testing.T) {
+	total := 4
+	mock := &mockDescribeVpnConnectionsClient{
+		vpns: makeVpnConnections(total),
+	}
+
+	result := addAllVpnNames(mock, map[string]string{})
+
+	if len(result) != total {
+		t.Fatalf("addAllVpnNames() returned %d entries, want %d", len(result), total)
+	}
+	for i := range total {
+		id := fmt.Sprintf("vpn-%08d", i)
+		got, ok := result[id]
+		if !ok {
+			t.Errorf("addAllVpnNames() missing entry for %s", id)
+			continue
+		}
+		want := id
+		if i < total/2 {
+			want = fmt.Sprintf("vpn-name-%d", i)
+		}
+		if got != want {
+			t.Errorf("addAllVpnNames()[%s] = %q, want %q", id, got, want)
+		}
+	}
+	if mock.callCount != 1 {
+		t.Errorf("DescribeVpnConnections called %d times, want 1", mock.callCount)
+	}
+}


### PR DESCRIPTION
## Summary

- `GetAllVpcPeers` in `helpers/ec2.go` issued a single `DescribeVpcPeeringConnections` call and silently dropped peerings on subsequent pages in large accounts. Rewrite it to walk `NewDescribeVpcPeeringConnectionsPaginator`, following the `GetAllVPCRouteTables`/`getAllVPCRouteTables` split so pagination logic is testable against the narrow `DescribeVpcPeeringConnectionsAPIClient` interface.
- `addAllVpnNames` is rewritten to take `DescribeVpnConnectionsAPIClient`. AWS's `DescribeVpnConnections` API is not paginated (no `NextToken`/`MaxResults`), so it still issues one call, but the interface makes the helper unit-testable and guards the ID/Name-tag fallback.
- Adds regression tests in `helpers/ec2_vpc_pagination_test.go` covering three peering pages and the full VPN-name aggregation, and documents both behaviours in `docs/agent-notes/ec2-helpers.md`.

Fixes T-746.

## Test plan

- [x] `go test ./helpers/ -run "TestGetAllVpcPeers_Pagination|TestAddAllVpnNames_AggregatesAllConnections" -v`
- [x] `go test ./...`
- [x] `make test`
- [x] `go fmt ./...`