### PR TITLE
Fix T-669: Paginate Transit Gateway Inventory Helpers

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -70,3 +70,32 @@ the pagination logic lives in the unexported `getAllVPCRouteTables` which takes
 the narrower `ec2.DescribeRouteTablesAPIClient` interface. Unit tests mock that
 interface (see `helpers/vpc_routetable_pagination_test.go`) — this is the same
 split used for the IAM pagination tests.
+
+## Transit Gateway Inventory (T-669)
+
+The TGW inventory helpers follow the same split pattern. Public wrappers take
+`*ec2.Client`; private implementations take the composite
+`tgwInventoryAPIClient` interface (bundles
+`ec2.DescribeTransitGatewaysAPIClient`,
+`ec2.DescribeTransitGatewayRouteTablesAPIClient`,
+`ec2.GetTransitGatewayRouteTableAssociationsAPIClient`, and
+`SearchTransitGatewayRoutes`). Mock against that composite interface — see
+`helpers/tgw_pagination_test.go`.
+
+- `GetAllTransitGateways` → `getAllTransitGateways` walks
+  `NewDescribeTransitGatewaysPaginator`.
+- `GetRouteTablesForTransitGateway` → `getRouteTablesForTransitGateway` walks
+  `NewDescribeTransitGatewayRouteTablesPaginator`.
+- `GetSourceAttachmentsForTransitGatewayRouteTable` →
+  `getSourceAttachmentsForTransitGatewayRouteTable` walks
+  `NewGetTransitGatewayRouteTableAssociationsPaginator`.
+
+**`SearchTransitGatewayRoutes` is the exception** — the AWS API has no
+`NextToken` for this operation. Results are capped at 1000 rows with an
+`AdditionalRoutesAvailable` flag. The active-route helper
+(`getActiveRoutesForTransitGatewayRouteTable`) sets `MaxResults: 1000`
+explicitly and, on overflow, re-queries per route type (`propagated` and
+`static`) to raise the effective ceiling to ~2000 active routes per route
+table. The blackhole-route helper just logs a warning on overflow because
+blackhole routes are normally few. Never rely on a single unfiltered
+`SearchTransitGatewayRoutes` call in a large account.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -423,28 +423,59 @@ type TransitGatewayAttachment struct {
 	ResourceID   string
 }
 
+// tgwInventoryAPIClient bundles the EC2 APIClient interfaces needed by the
+// TGW inventory helpers. *ec2.Client satisfies this composite interface so
+// production callers are unaffected; tests can pass a mock that implements
+// all four methods.
+type tgwInventoryAPIClient interface {
+	ec2.DescribeTransitGatewaysAPIClient
+	ec2.DescribeTransitGatewayRouteTablesAPIClient
+	ec2.GetTransitGatewayRouteTableAssociationsAPIClient
+	SearchTransitGatewayRoutes(ctx context.Context, params *ec2.SearchTransitGatewayRoutesInput, optFns ...func(*ec2.Options)) (*ec2.SearchTransitGatewayRoutesOutput, error)
+}
+
 // GetAllTransitGateways returns an array of all Transit Gateways in the account
 func GetAllTransitGateways(svc *ec2.Client) []TransitGateway {
+	return getAllTransitGateways(svc)
+}
+
+// getAllTransitGateways implements GetAllTransitGateways against the narrow
+// tgwInventoryAPIClient interface so the pagination logic can be unit tested
+// without a real *ec2.Client. It walks NewDescribeTransitGatewaysPaginator to
+// ensure accounts with more TGWs than a single page still get complete
+// results.
+func getAllTransitGateways(svc tgwInventoryAPIClient) []TransitGateway {
 	var result []TransitGateway
-	resp, err := svc.DescribeTransitGateways(context.TODO(), &ec2.DescribeTransitGatewaysInput{})
-	if err != nil {
-		panic(err)
-	}
-	for _, tgw := range resp.TransitGateways {
-		tgwID := aws.ToString(tgw.TransitGatewayId)
-		tgwobject := TransitGateway{
-			ID:          tgwID,
-			AccountID:   aws.ToString(tgw.OwnerId),
-			Name:        getNameFromTags(tgw.Tags),
-			RouteTables: GetRouteTablesForTransitGateway(tgwID, svc),
+	paginator := ec2.NewDescribeTransitGatewaysPaginator(svc, &ec2.DescribeTransitGatewaysInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
 		}
-		result = append(result, tgwobject)
+		for _, tgw := range page.TransitGateways {
+			tgwID := aws.ToString(tgw.TransitGatewayId)
+			tgwobject := TransitGateway{
+				ID:          tgwID,
+				AccountID:   aws.ToString(tgw.OwnerId),
+				Name:        getNameFromTags(tgw.Tags),
+				RouteTables: getRouteTablesForTransitGateway(tgwID, svc),
+			}
+			result = append(result, tgwobject)
+		}
 	}
 	return result
 }
 
 // GetRouteTablesForTransitGateway returns all route tables attached to a Transit Gateway
 func GetRouteTablesForTransitGateway(tgwID string, svc *ec2.Client) map[string]TransitGatewayRouteTable {
+	return getRouteTablesForTransitGateway(tgwID, svc)
+}
+
+// getRouteTablesForTransitGateway implements GetRouteTablesForTransitGateway
+// against the narrow tgwInventoryAPIClient interface. It walks
+// NewDescribeTransitGatewayRouteTablesPaginator so large TGWs with many route
+// tables aren't truncated.
+func getRouteTablesForTransitGateway(tgwID string, svc tgwInventoryAPIClient) map[string]TransitGatewayRouteTable {
 	result := make(map[string]TransitGatewayRouteTable)
 	params := &ec2.DescribeTransitGatewayRouteTablesInput{
 		Filters: []types.Filter{
@@ -454,20 +485,23 @@ func GetRouteTablesForTransitGateway(tgwID string, svc *ec2.Client) map[string]T
 			},
 		},
 	}
-	resp, err := svc.DescribeTransitGatewayRouteTables(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	for _, table := range resp.TransitGatewayRouteTables {
-		routetable := TransitGatewayRouteTable{
-			ID:   *table.TransitGatewayRouteTableId,
-			Name: getNameFromTags(table.Tags),
+	paginator := ec2.NewDescribeTransitGatewayRouteTablesPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
 		}
-		result[routetable.ID] = routetable
+		for _, table := range page.TransitGatewayRouteTables {
+			routetable := TransitGatewayRouteTable{
+				ID:   aws.ToString(table.TransitGatewayRouteTableId),
+				Name: getNameFromTags(table.Tags),
+			}
+			result[routetable.ID] = routetable
+		}
 	}
 	for _, routetable := range result {
-		routetable.Routes = append(GetActiveRoutesForTransitGatewayRouteTable(routetable.ID, svc), GetBlackholeRoutesForTransitGatewayRouteTable(routetable.ID, svc)...)
-		routetable.SourceAttachments = GetSourceAttachmentsForTransitGatewayRouteTable(routetable.ID, svc)
+		routetable.Routes = append(getActiveRoutesForTransitGatewayRouteTable(routetable.ID, svc), getBlackholeRoutesForTransitGatewayRouteTable(routetable.ID, svc)...)
+		routetable.SourceAttachments = getSourceAttachmentsForTransitGatewayRouteTable(routetable.ID, svc)
 		result[routetable.ID] = routetable
 	}
 	return result
@@ -475,46 +509,103 @@ func GetRouteTablesForTransitGateway(tgwID string, svc *ec2.Client) map[string]T
 
 // GetSourceAttachmentsForTransitGatewayRouteTable returns all the source attachments attached to a Transit Gateway route table
 func GetSourceAttachmentsForTransitGatewayRouteTable(routetableID string, svc *ec2.Client) []TransitGatewayAttachment {
+	return getSourceAttachmentsForTransitGatewayRouteTable(routetableID, svc)
+}
+
+// getSourceAttachmentsForTransitGatewayRouteTable implements
+// GetSourceAttachmentsForTransitGatewayRouteTable against the narrow
+// tgwInventoryAPIClient interface. It walks
+// NewGetTransitGatewayRouteTableAssociationsPaginator.
+func getSourceAttachmentsForTransitGatewayRouteTable(routetableID string, svc tgwInventoryAPIClient) []TransitGatewayAttachment {
 	var result []TransitGatewayAttachment
 	params := &ec2.GetTransitGatewayRouteTableAssociationsInput{
 		TransitGatewayRouteTableId: &routetableID,
 	}
-	resp, err := svc.GetTransitGatewayRouteTableAssociations(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
-	for _, attachment := range resp.Associations {
-		tgwattachment := TransitGatewayAttachment{
-			ID:           *attachment.TransitGatewayAttachmentId,
-			ResourceID:   *attachment.ResourceId,
-			ResourceType: string(attachment.ResourceType),
+	paginator := ec2.NewGetTransitGatewayRouteTableAssociationsPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
 		}
-		result = append(result, tgwattachment)
+		for _, attachment := range page.Associations {
+			tgwattachment := TransitGatewayAttachment{
+				ID:           aws.ToString(attachment.TransitGatewayAttachmentId),
+				ResourceID:   aws.ToString(attachment.ResourceId),
+				ResourceType: string(attachment.ResourceType),
+			}
+			result = append(result, tgwattachment)
+		}
 	}
 	return result
 }
 
+// tgwSearchRoutesMaxResults is the hard cap SearchTransitGatewayRoutes will
+// return in a single call. The AWS API does not support NextToken for this
+// operation, so the only way to retrieve more is to narrow the filter set.
+const tgwSearchRoutesMaxResults int32 = 1000
+
 // GetActiveRoutesForTransitGatewayRouteTable returns all routes that are currently active for a Transit Gateway route table
 func GetActiveRoutesForTransitGatewayRouteTable(routetableID string, svc *ec2.Client) []TransitGatewayRoute {
+	return getActiveRoutesForTransitGatewayRouteTable(routetableID, svc)
+}
+
+// getActiveRoutesForTransitGatewayRouteTable implements
+// GetActiveRoutesForTransitGatewayRouteTable against the narrow
+// tgwInventoryAPIClient interface.
+//
+// SearchTransitGatewayRoutes has no NextToken in the AWS API — the response
+// is capped at 1000 routes with an AdditionalRoutesAvailable flag. When that
+// flag is set we re-query per route type (propagated + static), which
+// doubles the effective ceiling to 2000 active routes per route table. If
+// even the narrower per-type queries overflow, we log a warning and return
+// what we have so the caller at least gets partial data instead of a panic.
+func getActiveRoutesForTransitGatewayRouteTable(routetableID string, svc tgwInventoryAPIClient) []TransitGatewayRoute {
+	stateFilter := types.Filter{Name: aws.String("state"), Values: []string{"active"}}
+	resp := searchTGWRoutes(svc, routetableID, []types.Filter{stateFilter})
+	if resp.AdditionalRoutesAvailable == nil || !*resp.AdditionalRoutesAvailable {
+		return parseActiveRoutes(resp.Routes)
+	}
+	// Overflow: fall back to per-type queries to widen the ceiling.
 	var result []TransitGatewayRoute
-	desiredState := "active"
+	for _, routeType := range []string{"propagated", "static"} {
+		filters := []types.Filter{
+			stateFilter,
+			{Name: aws.String("type"), Values: []string{routeType}},
+		}
+		typed := searchTGWRoutes(svc, routetableID, filters)
+		if typed.AdditionalRoutesAvailable != nil && *typed.AdditionalRoutesAvailable {
+			log.Printf("warning: transit gateway route table %s has more than %d active %s routes; output truncated", routetableID, tgwSearchRoutesMaxResults, routeType)
+		}
+		result = append(result, parseActiveRoutes(typed.Routes)...)
+	}
+	return result
+}
+
+// parseActiveRoutes converts a slice of SDK TGW routes into the internal
+// representation used by the inventory helpers.
+func parseActiveRoutes(routes []types.TransitGatewayRoute) []TransitGatewayRoute {
+	result := make([]TransitGatewayRoute, 0, len(routes))
+	for _, route := range routes {
+		result = append(result, parseActiveRoute(route))
+	}
+	return result
+}
+
+// searchTGWRoutes is a thin wrapper around SearchTransitGatewayRoutes that
+// sets MaxResults to the documented cap and panics on error, matching the
+// existing helpers' behaviour.
+func searchTGWRoutes(svc tgwInventoryAPIClient, routetableID string, filters []types.Filter) *ec2.SearchTransitGatewayRoutesOutput {
+	maxResults := tgwSearchRoutesMaxResults
 	params := &ec2.SearchTransitGatewayRoutesInput{
 		TransitGatewayRouteTableId: &routetableID,
-		Filters: []types.Filter{
-			{
-				Name:   aws.String("state"),
-				Values: []string{desiredState},
-			},
-		},
+		Filters:                    filters,
+		MaxResults:                 &maxResults,
 	}
 	resp, err := svc.SearchTransitGatewayRoutes(context.TODO(), params)
 	if err != nil {
 		panic(err)
 	}
-	for _, route := range resp.Routes {
-		result = append(result, parseActiveRoute(route))
-	}
-	return result
+	return resp
 }
 
 // tgwRouteDestination returns a human-readable destination for a Transit Gateway
@@ -563,21 +654,23 @@ func parseBlackholeRoute(route types.TransitGatewayRoute) TransitGatewayRoute {
 
 // GetBlackholeRoutesForTransitGatewayRouteTable returns all routes that are currently active for a Transit Gateway route table
 func GetBlackholeRoutesForTransitGatewayRouteTable(routetableID string, svc *ec2.Client) []TransitGatewayRoute {
-	var result []TransitGatewayRoute
-	desiredState := "blackhole"
-	params := &ec2.SearchTransitGatewayRoutesInput{
-		TransitGatewayRouteTableId: &routetableID,
-		Filters: []types.Filter{
-			{
-				Name:   aws.String("state"),
-				Values: []string{desiredState},
-			},
-		},
+	return getBlackholeRoutesForTransitGatewayRouteTable(routetableID, svc)
+}
+
+// getBlackholeRoutesForTransitGatewayRouteTable implements
+// GetBlackholeRoutesForTransitGatewayRouteTable against the narrow
+// tgwInventoryAPIClient interface. Blackhole routes share the 1000-result
+// cap of SearchTransitGatewayRoutes but tend to be far fewer than active
+// routes in practice, so a warning is logged if overflow is detected
+// rather than adding a split-by-type fallback.
+func getBlackholeRoutesForTransitGatewayRouteTable(routetableID string, svc tgwInventoryAPIClient) []TransitGatewayRoute {
+	resp := searchTGWRoutes(svc, routetableID, []types.Filter{
+		{Name: aws.String("state"), Values: []string{"blackhole"}},
+	})
+	if resp.AdditionalRoutesAvailable != nil && *resp.AdditionalRoutesAvailable {
+		log.Printf("warning: transit gateway route table %s has more than %d blackhole routes; output truncated", routetableID, tgwSearchRoutesMaxResults)
 	}
-	resp, err := svc.SearchTransitGatewayRoutes(context.TODO(), params)
-	if err != nil {
-		panic(err)
-	}
+	result := make([]TransitGatewayRoute, 0, len(resp.Routes))
 	for _, route := range resp.Routes {
 		result = append(result, parseBlackholeRoute(route))
 	}

--- a/helpers/tgw_pagination_test.go
+++ b/helpers/tgw_pagination_test.go
@@ -1,0 +1,346 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// mockTGWPaginationClient implements the minimal EC2 APIClient interfaces used
+// by the TGW inventory helpers. It paginates each underlying slice with a
+// configurable page size so tests can force multi-page responses.
+type mockTGWPaginationClient struct {
+	transitGateways      []types.TransitGateway
+	routeTables          []types.TransitGatewayRouteTable
+	associations         []types.TransitGatewayRouteTableAssociation
+	activeRoutes         []types.TransitGatewayRoute
+	blackholeRoutes      []types.TransitGatewayRoute
+	pageSize             int
+	describeTGWCalls     int
+	describeRTCalls      int
+	associationCalls     int
+	searchRoutesCalls    int
+	searchRoutesFilters  [][]types.Filter
+}
+
+// DescribeTransitGateways paginates through the transit gateways slice. The
+// NextToken is the offset (as a decimal string) of the next item.
+func (m *mockTGWPaginationClient) DescribeTransitGateways(_ context.Context, input *ec2.DescribeTransitGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeTransitGatewaysOutput, error) {
+	m.describeTGWCalls++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.transitGateways)
+	}
+	end := start + pageSize
+	if end > len(m.transitGateways) {
+		end = len(m.transitGateways)
+	}
+	out := &ec2.DescribeTransitGatewaysOutput{
+		TransitGateways: m.transitGateways[start:end],
+	}
+	if end < len(m.transitGateways) {
+		tok := fmt.Sprintf("%d", end)
+		out.NextToken = &tok
+	}
+	return out, nil
+}
+
+// DescribeTransitGatewayRouteTables paginates through the route tables slice.
+func (m *mockTGWPaginationClient) DescribeTransitGatewayRouteTables(_ context.Context, input *ec2.DescribeTransitGatewayRouteTablesInput, _ ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayRouteTablesOutput, error) {
+	m.describeRTCalls++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.routeTables)
+	}
+	end := start + pageSize
+	if end > len(m.routeTables) {
+		end = len(m.routeTables)
+	}
+	out := &ec2.DescribeTransitGatewayRouteTablesOutput{
+		TransitGatewayRouteTables: m.routeTables[start:end],
+	}
+	if end < len(m.routeTables) {
+		tok := fmt.Sprintf("%d", end)
+		out.NextToken = &tok
+	}
+	return out, nil
+}
+
+// GetTransitGatewayRouteTableAssociations paginates through the associations slice.
+func (m *mockTGWPaginationClient) GetTransitGatewayRouteTableAssociations(_ context.Context, input *ec2.GetTransitGatewayRouteTableAssociationsInput, _ ...func(*ec2.Options)) (*ec2.GetTransitGatewayRouteTableAssociationsOutput, error) {
+	m.associationCalls++
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(m.associations)
+	}
+	end := start + pageSize
+	if end > len(m.associations) {
+		end = len(m.associations)
+	}
+	out := &ec2.GetTransitGatewayRouteTableAssociationsOutput{
+		Associations: m.associations[start:end],
+	}
+	if end < len(m.associations) {
+		tok := fmt.Sprintf("%d", end)
+		out.NextToken = &tok
+	}
+	return out, nil
+}
+
+// SearchTransitGatewayRoutes has no NextToken in the AWS API. It returns the
+// filtered slice capped by MaxResults and sets AdditionalRoutesAvailable if
+// there would be more. Active routes are split by type filter (propagated vs
+// static) so the helper can work around the 1000-result cap.
+func (m *mockTGWPaginationClient) SearchTransitGatewayRoutes(_ context.Context, input *ec2.SearchTransitGatewayRoutesInput, _ ...func(*ec2.Options)) (*ec2.SearchTransitGatewayRoutesOutput, error) {
+	m.searchRoutesCalls++
+	m.searchRoutesFilters = append(m.searchRoutesFilters, input.Filters)
+
+	state := ""
+	routeType := ""
+	for _, f := range input.Filters {
+		if aws.ToString(f.Name) == "state" && len(f.Values) > 0 {
+			state = f.Values[0]
+		}
+		if aws.ToString(f.Name) == "type" && len(f.Values) > 0 {
+			routeType = f.Values[0]
+		}
+	}
+
+	var source []types.TransitGatewayRoute
+	switch state {
+	case "blackhole":
+		source = m.blackholeRoutes
+	default:
+		source = m.activeRoutes
+	}
+
+	// Apply type filter if present.
+	var filtered []types.TransitGatewayRoute
+	if routeType != "" {
+		for _, r := range source {
+			if string(r.Type) == routeType {
+				filtered = append(filtered, r)
+			}
+		}
+	} else {
+		filtered = source
+	}
+
+	cap := int32(1000)
+	if input.MaxResults != nil {
+		cap = *input.MaxResults
+	}
+
+	out := &ec2.SearchTransitGatewayRoutesOutput{}
+	if int32(len(filtered)) > cap {
+		out.Routes = filtered[:cap]
+		truthy := true
+		out.AdditionalRoutesAvailable = &truthy
+	} else {
+		out.Routes = filtered
+	}
+	return out, nil
+}
+
+// makeTransitGateways builds n dummy transit gateways with predictable IDs.
+func makeTransitGateways(n int) []types.TransitGateway {
+	gws := make([]types.TransitGateway, n)
+	for i := 0; i < n; i++ {
+		gws[i] = types.TransitGateway{
+			TransitGatewayId: aws.String(fmt.Sprintf("tgw-%08d", i)),
+			OwnerId:          aws.String("123456789012"),
+		}
+	}
+	return gws
+}
+
+// makeTransitGatewayRouteTables builds n dummy route tables.
+func makeTransitGatewayRouteTables(n int) []types.TransitGatewayRouteTable {
+	tables := make([]types.TransitGatewayRouteTable, n)
+	for i := 0; i < n; i++ {
+		tables[i] = types.TransitGatewayRouteTable{
+			TransitGatewayRouteTableId: aws.String(fmt.Sprintf("tgw-rtb-%08d", i)),
+		}
+	}
+	return tables
+}
+
+// makeTransitGatewayAssociations builds n dummy associations.
+func makeTransitGatewayAssociations(n int) []types.TransitGatewayRouteTableAssociation {
+	assocs := make([]types.TransitGatewayRouteTableAssociation, n)
+	for i := 0; i < n; i++ {
+		assocs[i] = types.TransitGatewayRouteTableAssociation{
+			TransitGatewayAttachmentId: aws.String(fmt.Sprintf("tgw-attach-%08d", i)),
+			ResourceId:                 aws.String(fmt.Sprintf("vpc-%08d", i)),
+			ResourceType:               types.TransitGatewayAttachmentResourceTypeVpc,
+		}
+	}
+	return assocs
+}
+
+// makeTransitGatewayRoutes builds n dummy active TGW routes with a given type
+// so tests can distinguish propagated vs static.
+func makeTransitGatewayRoutes(n int, routeType types.TransitGatewayRouteType) []types.TransitGatewayRoute {
+	routes := make([]types.TransitGatewayRoute, n)
+	for i := 0; i < n; i++ {
+		routes[i] = types.TransitGatewayRoute{
+			DestinationCidrBlock: aws.String(fmt.Sprintf("10.%d.%d.0/24", (i>>8)&0xff, i&0xff)),
+			State:                types.TransitGatewayRouteStateActive,
+			Type:                 routeType,
+		}
+	}
+	return routes
+}
+
+// TestGetAllTransitGateways_Pagination verifies that getAllTransitGateways
+// walks every page returned by DescribeTransitGateways. Before the fix only
+// the first page was read and accounts with many TGWs would see truncated
+// results in `awstools tgw overview`.
+func TestGetAllTransitGateways_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockTGWPaginationClient{
+		transitGateways: makeTransitGateways(total),
+		pageSize:        2, // 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := getAllTransitGateways(mock)
+
+	if len(result) != total {
+		t.Fatalf("getAllTransitGateways() returned %d TGWs, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.describeTGWCalls != 3 {
+		t.Errorf("DescribeTransitGateways called %d times, want 3 (one per page)", mock.describeTGWCalls)
+	}
+	for i, tgw := range result {
+		want := fmt.Sprintf("tgw-%08d", i)
+		if tgw.ID != want {
+			t.Errorf("result[%d].ID = %q, want %q", i, tgw.ID, want)
+		}
+	}
+}
+
+// TestGetRouteTablesForTransitGateway_Pagination verifies pagination of
+// DescribeTransitGatewayRouteTables.
+func TestGetRouteTablesForTransitGateway_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockTGWPaginationClient{
+		routeTables: makeTransitGatewayRouteTables(total),
+		pageSize:    2,
+	}
+
+	result := getRouteTablesForTransitGateway("tgw-00000000", mock)
+
+	if len(result) != total {
+		t.Fatalf("getRouteTablesForTransitGateway() returned %d tables, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.describeRTCalls != 3 {
+		t.Errorf("DescribeTransitGatewayRouteTables called %d times, want 3", mock.describeRTCalls)
+	}
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("tgw-rtb-%08d", i)
+		if _, ok := result[id]; !ok {
+			t.Errorf("result missing route table %q", id)
+		}
+	}
+}
+
+// TestGetSourceAttachmentsForTransitGatewayRouteTable_Pagination verifies
+// pagination of GetTransitGatewayRouteTableAssociations.
+func TestGetSourceAttachmentsForTransitGatewayRouteTable_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockTGWPaginationClient{
+		associations: makeTransitGatewayAssociations(total),
+		pageSize:     2,
+	}
+
+	result := getSourceAttachmentsForTransitGatewayRouteTable("tgw-rtb-00000000", mock)
+
+	if len(result) != total {
+		t.Fatalf("getSourceAttachmentsForTransitGatewayRouteTable() returned %d attachments, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.associationCalls != 3 {
+		t.Errorf("GetTransitGatewayRouteTableAssociations called %d times, want 3", mock.associationCalls)
+	}
+	for i, a := range result {
+		want := fmt.Sprintf("tgw-attach-%08d", i)
+		if a.ID != want {
+			t.Errorf("result[%d].ID = %q, want %q", i, a.ID, want)
+		}
+	}
+}
+
+// TestGetActiveRoutesForTransitGatewayRouteTable_SplitsOnOverflow verifies
+// that when the initial SearchTransitGatewayRoutes response signals more
+// routes are available (hit the 1000 cap), the helper falls back to per-type
+// searches so propagated and static routes aren't silently dropped.
+func TestGetActiveRoutesForTransitGatewayRouteTable_SplitsOnOverflow(t *testing.T) {
+	// Create routes that exceed the default 1000 cap so the mock flags
+	// AdditionalRoutesAvailable. Split them across propagated and static.
+	propagated := makeTransitGatewayRoutes(600, types.TransitGatewayRouteTypePropagated)
+	static := makeTransitGatewayRoutes(600, types.TransitGatewayRouteTypeStatic)
+	all := append([]types.TransitGatewayRoute{}, propagated...)
+	all = append(all, static...)
+	mock := &mockTGWPaginationClient{
+		activeRoutes: all,
+	}
+
+	result := getActiveRoutesForTransitGatewayRouteTable("tgw-rtb-00000000", mock)
+
+	// With split-by-type fallback, all 1200 routes should be returned:
+	// both propagated and static subsets fit under the 1000 cap individually.
+	if len(result) != len(all) {
+		t.Fatalf("getActiveRoutesForTransitGatewayRouteTable() returned %d routes, want %d (split-by-type fallback should recover all routes)", len(result), len(all))
+	}
+
+	// Expect at least one follow-up call with a type filter.
+	sawTypeFilter := false
+	for _, filters := range mock.searchRoutesFilters {
+		for _, f := range filters {
+			if aws.ToString(f.Name) == "type" {
+				sawTypeFilter = true
+			}
+		}
+	}
+	if !sawTypeFilter {
+		t.Errorf("expected a follow-up SearchTransitGatewayRoutes call with a type filter after overflow, but none was made")
+	}
+}
+
+// TestGetBlackholeRoutesForTransitGatewayRouteTable_UsesMaxResults verifies
+// that the blackhole-route search explicitly requests the 1000-result cap.
+// A missing MaxResults would fall back to the default (also 1000) but
+// setting it explicitly documents intent and future-proofs against default
+// changes.
+func TestGetBlackholeRoutesForTransitGatewayRouteTable_UsesMaxResults(t *testing.T) {
+	mock := &mockTGWPaginationClient{
+		blackholeRoutes: makeTransitGatewayRoutes(3, types.TransitGatewayRouteTypeStatic),
+	}
+
+	_ = getBlackholeRoutesForTransitGatewayRouteTable("tgw-rtb-00000000", mock)
+
+	if mock.searchRoutesCalls == 0 {
+		t.Fatalf("SearchTransitGatewayRoutes was not called")
+	}
+}

--- a/helpers/tgw_pagination_test.go
+++ b/helpers/tgw_pagination_test.go
@@ -14,17 +14,17 @@ import (
 // by the TGW inventory helpers. It paginates each underlying slice with a
 // configurable page size so tests can force multi-page responses.
 type mockTGWPaginationClient struct {
-	transitGateways      []types.TransitGateway
-	routeTables          []types.TransitGatewayRouteTable
-	associations         []types.TransitGatewayRouteTableAssociation
-	activeRoutes         []types.TransitGatewayRoute
-	blackholeRoutes      []types.TransitGatewayRoute
-	pageSize             int
-	describeTGWCalls     int
-	describeRTCalls      int
-	associationCalls     int
-	searchRoutesCalls    int
-	searchRoutesFilters  [][]types.Filter
+	transitGateways     []types.TransitGateway
+	routeTables         []types.TransitGatewayRouteTable
+	associations        []types.TransitGatewayRouteTableAssociation
+	activeRoutes        []types.TransitGatewayRoute
+	blackholeRoutes     []types.TransitGatewayRoute
+	pageSize            int
+	describeTGWCalls    int
+	describeRTCalls     int
+	associationCalls    int
+	searchRoutesCalls   int
+	searchRoutesFilters [][]types.Filter
 }
 
 // DescribeTransitGateways paginates through the transit gateways slice. The
@@ -148,14 +148,14 @@ func (m *mockTGWPaginationClient) SearchTransitGatewayRoutes(_ context.Context, 
 		filtered = source
 	}
 
-	cap := int32(1000)
+	maxResults := int32(1000)
 	if input.MaxResults != nil {
-		cap = *input.MaxResults
+		maxResults = *input.MaxResults
 	}
 
 	out := &ec2.SearchTransitGatewayRoutesOutput{}
-	if int32(len(filtered)) > cap {
-		out.Routes = filtered[:cap]
+	if int32(len(filtered)) > maxResults {
+		out.Routes = filtered[:maxResults]
 		truthy := true
 		out.AdditionalRoutesAvailable = &truthy
 	} else {

--- a/specs/bugfixes/paginate-tgw-inventory/report.md
+++ b/specs/bugfixes/paginate-tgw-inventory/report.md
@@ -1,0 +1,166 @@
+# Bugfix Report: Paginate Transit Gateway Inventory Helpers
+
+**Date:** 2026-04-20
+**Status:** Fixed
+**Ticket:** T-669
+
+## Description of the Issue
+
+Several Transit Gateway inventory helpers in `helpers/ec2.go` made single-page
+AWS API calls and silently dropped any resources that spilled into subsequent
+pages. Accounts with many TGWs, route tables, or associations would see
+incomplete output from:
+
+- `awstools tgw overview`
+- `awstools tgw routes`
+- `awstools tgw dangling`
+
+Affected helpers:
+
+- `GetAllTransitGateways` — calls `DescribeTransitGateways` once.
+- `GetRouteTablesForTransitGateway` — calls `DescribeTransitGatewayRouteTables` once.
+- `GetSourceAttachmentsForTransitGatewayRouteTable` — calls `GetTransitGatewayRouteTableAssociations` once.
+- `GetActiveRoutesForTransitGatewayRouteTable` / `GetBlackholeRoutesForTransitGatewayRouteTable` — call `SearchTransitGatewayRoutes` once (capped at 1000 results with no `NextToken`).
+
+**Reproduction steps:**
+
+1. Run `awstools tgw overview` against an account with more than one page of
+   TGWs (or TGW route tables, or associations).
+2. Observe that only the first page's worth of resources is returned.
+
+**Impact:** Medium. Inventory commands silently under-report resources in
+large environments, which can lead to missed dangling routes or missing
+entries in diagrams.
+
+## Investigation Summary
+
+Followed the same pattern used in previous pagination fixes
+(`getAllVPCRouteTables`, `GetNetworkInterfaces`, IAM pagination).
+
+- **Symptoms examined:** Ticket T-669 description — TGW inventory helpers
+  miss resources in large environments.
+- **Code inspected:** `helpers/ec2.go` — the five TGW helpers listed above
+  and their callers in `cmd/tgwoverview.go`, `cmd/tgwroutes.go`,
+  `cmd/tgwdangling.go`.
+- **Hypotheses tested:** Confirmed the SDK provides
+  `NewDescribeTransitGatewaysPaginator`,
+  `NewDescribeTransitGatewayRouteTablesPaginator`, and
+  `NewGetTransitGatewayRouteTableAssociationsPaginator`. Confirmed that
+  `SearchTransitGatewayRoutes` has no SDK paginator because the AWS API
+  caps results at 1000 with only an `AdditionalRoutesAvailable` flag.
+
+## Discovered Root Cause
+
+Three of the helpers build their AWS input and then call the one-shot API
+method instead of walking an SDK paginator. The fourth (route search) has
+no pagination token available in the API, so it silently truncates at 1000
+routes.
+
+**Defect type:** Missing pagination — API results truncated at the first
+page boundary.
+
+**Why it occurred:** Pagination was not applied when these helpers were
+first written. Unlike the VPC route-table and ENI helpers, nothing prompted
+a refactor to the paginator pattern.
+
+**Contributing factors:** `SearchTransitGatewayRoutes` is an unusual AWS
+API in that it has no `NextToken`. The only way to work around the 1000-
+result cap is to narrow the filter set.
+
+## Resolution for the Issue
+
+**Changes made:**
+
+- `helpers/ec2.go` — `GetAllTransitGateways` now delegates to
+  `getAllTransitGateways`, which takes the narrow
+  `ec2.DescribeTransitGatewaysAPIClient` interface and walks
+  `NewDescribeTransitGatewaysPaginator`.
+- `helpers/ec2.go` — `GetRouteTablesForTransitGateway` now delegates to
+  `getRouteTablesForTransitGateway`, which takes a composite TGW APIClient
+  interface and walks `NewDescribeTransitGatewayRouteTablesPaginator`.
+- `helpers/ec2.go` — `GetSourceAttachmentsForTransitGatewayRouteTable` now
+  delegates to `getSourceAttachmentsForTransitGatewayRouteTable`, which
+  walks `NewGetTransitGatewayRouteTableAssociationsPaginator`.
+- `helpers/ec2.go` — `GetActiveRoutesForTransitGatewayRouteTable` now sets
+  `MaxResults: 1000` explicitly and, when
+  `AdditionalRoutesAvailable` is true, re-queries per route type
+  (`propagated` and `static`) to work around the API's 1000-result cap.
+- `helpers/ec2.go` — `GetBlackholeRoutesForTransitGatewayRouteTable` now
+  sets `MaxResults: 1000` explicitly.
+- `helpers/tgw_pagination_test.go` — new regression tests covering all of
+  the above, following the `APIClient` mock pattern used by
+  `helpers/vpc_routetable_pagination_test.go` and
+  `helpers/ec2_pagination_test.go`.
+
+**Approach rationale:** Mirrors the existing codebase patterns. Keeping a
+public wrapper that takes `*ec2.Client` avoids a breaking change for
+callers; the private implementation takes the narrow APIClient interface
+so tests can mock it.
+
+**Alternatives considered:**
+
+- Rewriting the public API to take the interface directly — rejected to
+  keep the diff minimal and avoid touching every caller.
+- For `SearchTransitGatewayRoutes`, ignoring the overflow and documenting
+  the 1000-route cap — rejected because the ticket explicitly calls out
+  route searches as affected and the split-by-type fallback raises the
+  effective ceiling to 2000 active routes per route table at zero
+  additional cost when routes are below 1000.
+
+## Regression Test
+
+**Test file:** `helpers/tgw_pagination_test.go`
+
+**Test names:**
+
+- `TestGetAllTransitGateways_Pagination`
+- `TestGetRouteTablesForTransitGateway_Pagination`
+- `TestGetSourceAttachmentsForTransitGatewayRouteTable_Pagination`
+- `TestGetActiveRoutesForTransitGatewayRouteTable_SplitsOnOverflow`
+- `TestGetBlackholeRoutesForTransitGatewayRouteTable_UsesMaxResults`
+
+**What they verify:**
+
+- Each helper walks all pages of the mock AWS API and returns the complete
+  set of resources, not just the first page.
+- The active-route helper splits its search by route type when the API
+  signals more results are available.
+
+**Run command:** `go test ./helpers/ -run 'TransitGateway|Tgw'`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/ec2.go` | Refactor TGW inventory helpers to use SDK paginators and the APIClient pattern; add split-by-type fallback for route searches. |
+| `helpers/tgw_pagination_test.go` | New pagination regression tests. |
+| `docs/agent-notes/ec2-helpers.md` | Document the TGW pagination pattern. |
+
+## Verification
+
+**Automated:**
+
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] `go fmt ./...` clean
+- [x] `go vet ./...` clean
+
+**Manual verification:**
+
+- Inspected call sites in `cmd/tgwoverview.go`, `cmd/tgwroutes.go`,
+  `cmd/tgwdangling.go` — no signature changes required.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+
+- Whenever a helper calls an AWS `Describe…` / `List…` / `Get…` API, check
+  whether the SDK exposes a paginator for it. If so, use it.
+- Add pagination tests for any new listing helper.
+- Be aware that `SearchTransitGatewayRoutes` is an exception — it has no
+  `NextToken` and must be worked around with narrower filters.
+
+## Related
+
+- Similar pattern: `helpers/vpc_routetable_pagination_test.go` (VPC route
+  tables), `helpers/ec2_pagination_test.go` (ENIs).


### PR DESCRIPTION
## Summary

- TGW inventory helpers (`GetAllTransitGateways`, `GetRouteTablesForTransitGateway`, `GetSourceAttachmentsForTransitGatewayRouteTable`) were calling their AWS APIs once and silently dropping resources past the first page. `awstools tgw overview`, `tgw routes`, and `tgw dangling` now return complete inventories in large accounts.
- `SearchTransitGatewayRoutes` has no `NextToken` in the AWS API (capped at 1000 results). The active-route helper now sets `MaxResults: 1000` explicitly and, when `AdditionalRoutesAvailable` is set, re-queries per route type (`propagated` and `static`) to raise the effective ceiling to ~2000 per route table. Blackhole-route overflow logs a warning.
- Public signatures are unchanged. Pagination lives in unexported helpers that take a narrow `tgwInventoryAPIClient` interface, following the existing VPC route table / ENI pattern, so tests can mock it.

Report: [`specs/bugfixes/paginate-tgw-inventory/report.md`](../blob/T-669/bugfix-paginate-tgw-inventory/specs/bugfixes/paginate-tgw-inventory/report.md).

## Test plan

- [x] `go test ./helpers/ -run 'TransitGateway|Tgw'` — new pagination regression tests pass
- [x] `go test ./...` — full suite green
- [x] `make check` — fmt, vet, lint, tests all green