### PR TITLE
Fix T-714: S3 Security Report Unknowns

### DIFF
--- a/cmd/s3list.go
+++ b/cmd/s3list.go
@@ -24,6 +24,11 @@ var publicBucketsOnly bool
 var unencryptedBucketsOnly bool
 var includeTags string
 
+// s3StateUnknown is the label used in the bucket listing whenever a
+// per-bucket detail call failed and the true state could not be
+// determined (see T-714).
+const s3StateUnknown = "Unknown"
+
 func init() {
 	s3Cmd.AddCommand(s3listCmd)
 	s3listCmd.Flags().BoolVar(&publicBucketsOnly, "public-only", false, "Only show public buckets")
@@ -48,10 +53,18 @@ func s3List(_ *cobra.Command, _ []string) {
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
 	for _, bucket := range buckets {
-		if publicBucketsOnly && !bucket.IsPublic {
+		// --public-only excludes buckets that are confirmed private.
+		// Buckets with an unknown public state are kept so the user
+		// still sees them (and the rendered "Unknown" makes the state
+		// visible); exclude only those we know to be private.
+		if publicBucketsOnly && bucket.IsPublic != nil && !*bucket.IsPublic {
 			continue
 		}
-		if unencryptedBucketsOnly && bucket.HasEncryption {
+		// --unencrypted-only excludes buckets that are confirmed
+		// encrypted. Buckets whose encryption state could not be
+		// determined are also excluded so we do not falsely flag them
+		// as unencrypted.
+		if unencryptedBucketsOnly && (bucket.HasEncryption == nil || *bucket.HasEncryption) {
 			continue
 		}
 		content := make(map[string]any)
@@ -60,19 +73,25 @@ func s3List(_ *cobra.Command, _ []string) {
 		content["AccountName"] = getName(awsConfig.AccountID)
 		content["Region"] = bucket.Region
 		content["Owner"] = bucket.Owner
-		content["Is Private"] = !bucket.IsPublic
-		content["Policy is locked down"] = !bucket.PublicPolicy
-		content["ACLs are locked down"] = !bucket.OpenACLs
+		content["Is Private"] = negatedTriState(bucket.IsPublic)
+		content["Policy is locked down"] = negatedTriState(bucket.PublicPolicy)
+		content["ACLs are locked down"] = negatedTriState(bucket.OpenACLs)
 
 		content["Public Access Block"] = parsePublicAccessBlock(bucket.PublicAccessBlockConfiguration)
-		if bucket.HasEncryption {
+		switch {
+		case bucket.HasEncryption == nil:
+			content["Encryption"] = s3StateUnknown
+		case *bucket.HasEncryption:
 			content["Encryption"] = s3EncryptionToString(bucket.EncryptionRules)
-		} else {
+		default:
 			content["Encryption"] = false
 		}
-		if bucket.LoggingEnabled {
+		switch {
+		case bucket.LoggingEnabled == nil:
+			content["Logs to"] = s3StateUnknown
+		case *bucket.LoggingEnabled:
 			content["Logs to"] = bucket.LoggingBucket
-		} else {
+		default:
 			content["Logs to"] = false
 		}
 		if includeTags != "" {
@@ -89,12 +108,32 @@ func s3List(_ *cobra.Command, _ []string) {
 		if settings.IsVerbose() {
 			content["Policy"] = bucket.Policy
 		}
-		content["Versioning"] = bucket.Versioning
-		content["Versioning MFA delete"] = bucket.VersioningMFAEnabled
+		content["Versioning"] = triState(bucket.Versioning)
+		content["Versioning MFA delete"] = triState(bucket.VersioningMFAEnabled)
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
 	}
 	output.Write()
+}
+
+// triState renders an optional boolean for the bucket listing output.
+// A nil value means the underlying AWS call failed and is shown as
+// s3StateUnknown so the report does not imply a confirmed answer.
+func triState(v *bool) any {
+	if v == nil {
+		return s3StateUnknown
+	}
+	return *v
+}
+
+// negatedTriState renders the negation of an optional boolean. Nil
+// stays s3StateUnknown — inverting an unknown answer is still
+// unknown.
+func negatedTriState(v *bool) any {
+	if v == nil {
+		return s3StateUnknown
+	}
+	return !*v
 }
 
 func s3EncryptionToString(rules []types.ServerSideEncryptionRule) string {

--- a/docs/agent-notes/s3-helpers.md
+++ b/docs/agent-notes/s3-helpers.md
@@ -1,0 +1,72 @@
+# S3 helpers notes
+
+Scope: `helpers/s3.go` plus its consumers in `cmd/s3list.go` and
+`cmd/s3.go`.
+
+## Architecture
+
+- `GetBucketDetails(svc S3API) []S3Bucket` is the single entry point
+  used by the CLI. It calls `ListBuckets` once and then issues a
+  sequence of per-bucket detail calls.
+- `S3API` is a helper-owned interface (added for T-714). It lists
+  only the S3 SDK methods used inside the helper so tests can inject
+  per-call failures with a `mockS3Client`.
+- The production `*s3.Client` satisfies `S3API` implicitly — no
+  change needed at the call site beyond the signature.
+
+## Tri-state booleans (T-714)
+
+Several fields on `S3Bucket` are `*bool` rather than `bool`:
+
+- `IsPublic`, `PublicPolicy`, `OpenACLs`
+- `LoggingEnabled`
+- `HasEncryption`
+- `Versioning`, `VersioningMFAEnabled`
+
+A `nil` pointer means the underlying AWS call failed and the state
+is unknown. A non-nil pointer is a confirmed answer. Never treat
+`nil` as "off" for security decisions — it must stay explicit. In
+particular:
+
+- `cmd/s3list.go` filters (`--public-only`, `--unencrypted-only`)
+  exclude confirmed-safe buckets but keep unknowns visible so the
+  user can investigate.
+- `cmd/s3list.go` render helpers (`triState`, `negatedTriState`)
+  print `Unknown` for nil values.
+
+`IsPublic` is a composite of policy status + ACL state + PAB. The
+aggregation lives in `computeBucketIsPublic`. Rules:
+
+- A confirmed-public input makes the bucket public unless the PAB
+  fully neutralises it.
+- A fully-locked PAB (`Restrict + BlockPolicy + IgnorePublicAcls`
+  all true) forces "not public" even when inputs are unknown.
+- Otherwise, any unknown input makes the composite unknown too,
+  because the unknown side could flip the answer.
+
+## PAB handling is T-693's scope
+
+`PublicAccessBlockConfiguration` itself is still the SDK type (a
+value, not a pointer). T-693 handles the "unknown PAB" case
+separately. T-714 intentionally left it alone.
+
+## Error handling
+
+`GetBucketDetails` logs a warning to `os.Stderr` for every failed
+detail call via `warnS3DetailError`. It does not abort processing —
+the failing field is simply left `nil`. `GetAllBuckets` still panics
+on `ListBuckets` failure (pre-existing behaviour); there is no
+useful fallback when the initial list cannot be obtained.
+
+## Testing
+
+- `helpers/s3_test.go` has `mockS3Client` (implements `S3API`) plus
+  `healthyS3Mock()` which returns a mock where every call succeeds
+  with benign data. Tests override individual function fields to
+  simulate specific failures.
+- Use `silenceStderr(t)` to suppress the warning noise that
+  `GetBucketDetails` writes on failure paths.
+- Regression tests for T-714:
+  `TestGetBucketDetails_UnknownOnDetailErrors`,
+  `TestGetBucketDetails_HealthyPathSetsPointers`,
+  `TestComputeBucketIsPublic`.

--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -10,26 +11,51 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-// S3Bucket represents detailed information about an S3 bucket including security, encryption, and configuration settings
+// S3API defines the subset of the S3 client used by helpers.GetBucketDetails.
+// It exists so tests can inject per-call failures when exercising the
+// "unknown state" handling in the security report.
+type S3API interface {
+	ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
+	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	GetBucketLogging(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error)
+	GetBucketEncryption(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error)
+	GetBucketTagging(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+	GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+	GetBucketReplication(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error)
+	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+}
+
+// S3Bucket represents detailed information about an S3 bucket including
+// security, encryption, and configuration settings.
+//
+// The tri-state boolean fields (`IsPublic`, `PublicPolicy`, `OpenACLs`,
+// `LoggingEnabled`, `HasEncryption`, `Versioning`,
+// `VersioningMFAEnabled`) are `*bool`: a nil value means the relevant
+// AWS call failed and the state is unknown. Callers must treat nil
+// distinctly from `false` — in particular, security-report filters
+// should not assume "unknown" means "confirmed off".
 type S3Bucket struct {
 	Account                        string
 	ACLs                           []types.Grant
 	EncryptionRules                []types.ServerSideEncryptionRule
-	HasEncryption                  bool
-	IsPublic                       bool
+	HasEncryption                  *bool
+	IsPublic                       *bool
 	LoggingBucket                  string
-	LoggingEnabled                 bool
+	LoggingEnabled                 *bool
 	Name                           string
-	OpenACLs                       bool
+	OpenACLs                       *bool
 	Owner                          string
 	Policy                         string
 	PublicAccessBlockConfiguration types.PublicAccessBlockConfiguration
-	PublicPolicy                   bool
+	PublicPolicy                   *bool
 	Region                         string
 	Replication                    types.ReplicationConfiguration
 	Tags                           map[string]string
-	Versioning                     bool
-	VersioningMFAEnabled           bool
+	Versioning                     *bool
+	VersioningMFAEnabled           *bool
 }
 
 // normalizeBucketLocation converts the LocationConstraint returned by
@@ -60,9 +86,16 @@ func resolveOwnerName(owner *types.Owner) string {
 	return aws.ToString(owner.ID)
 }
 
-// GetAllBuckets returns an overview of all buckets
-// GetAllBuckets retrieves all S3 buckets and returns them along with the owner name
-func GetAllBuckets(svc *s3.Client) ([]types.Bucket, string) {
+// warnS3DetailError emits a stderr warning that a per-bucket detail
+// call failed. The bucket is still included in the result set with the
+// affected field left as "unknown" (nil).
+func warnS3DetailError(bucket, call string, err error) {
+	fmt.Fprintf(os.Stderr, "Warning: S3 %s for bucket %q failed, marking state unknown: %v\n", call, bucket, err)
+}
+
+// GetAllBuckets retrieves all S3 buckets and returns them along with
+// the owner name.
+func GetAllBuckets(svc S3API) ([]types.Bucket, string) {
 	params := &s3.ListBucketsInput{}
 	resp, err := svc.ListBuckets(context.TODO(), params)
 
@@ -73,35 +106,54 @@ func GetAllBuckets(svc *s3.Client) ([]types.Bucket, string) {
 	return resp.Buckets, resolveOwnerName(resp.Owner)
 }
 
-// GetBucketDetails retrieves detailed information for all S3 buckets including encryption, versioning, and policies
-func GetBucketDetails(svc *s3.Client) []S3Bucket {
+// GetBucketDetails retrieves detailed information for all S3 buckets
+// including encryption, versioning, and policies. Detail calls that
+// fail leave the relevant tri-state field on S3Bucket as nil
+// ("unknown") rather than defaulting to false.
+func GetBucketDetails(svc S3API) []S3Bucket {
 	buckets, owner := GetAllBuckets(svc)
 	result := make([]S3Bucket, 0)
 	for _, bucket := range buckets {
+		bucketName := aws.ToString(bucket.Name)
 		tags := make(map[string]string)
-		statusresp, _ := svc.GetBucketPolicyStatus(context.TODO(), &s3.GetBucketPolicyStatusInput{Bucket: bucket.Name})
-		isPublic := false
-		policyIsPublic := false
-		if statusresp != nil {
-			isPublic = aws.ToBool(statusresp.PolicyStatus.IsPublic)
-			policyIsPublic = aws.ToBool(statusresp.PolicyStatus.IsPublic)
+
+		var policyIsPublic *bool
+		statusresp, err := svc.GetBucketPolicyStatus(context.TODO(), &s3.GetBucketPolicyStatusInput{Bucket: bucket.Name})
+		switch {
+		case err != nil:
+			warnS3DetailError(bucketName, "GetBucketPolicyStatus", err)
+		case statusresp != nil && statusresp.PolicyStatus != nil:
+			policyIsPublic = boolPtr(aws.ToBool(statusresp.PolicyStatus.IsPublic))
+		default:
+			// Response was empty; S3 returns this when no bucket
+			// policy exists, which is a definitive "not public".
+			policyIsPublic = boolPtr(false)
 		}
-		aclresp, _ := svc.GetBucketAcl(context.TODO(), &s3.GetBucketAclInput{Bucket: bucket.Name})
+
+		var openacls *bool
+		aclresp, err := svc.GetBucketAcl(context.TODO(), &s3.GetBucketAclInput{Bucket: bucket.Name})
 		acls := make([]types.Grant, 0)
-		if aclresp != nil {
-			acls = aclresp.Grants
-		}
-		openacls := hasOpenACLs(acls)
-		if openacls {
-			isPublic = true
-		}
-		// PublicAccessBlock overrides other public making settings
-		publicresp, _ := svc.GetPublicAccessBlock(context.TODO(), &s3.GetPublicAccessBlockInput{Bucket: bucket.Name})
-		if publicresp != nil {
-			if (aws.ToBool(publicresp.PublicAccessBlockConfiguration.IgnorePublicAcls) || !openacls) && aws.ToBool(publicresp.PublicAccessBlockConfiguration.RestrictPublicBuckets) {
-				isPublic = false
+		if err != nil {
+			warnS3DetailError(bucketName, "GetBucketAcl", err)
+		} else {
+			if aclresp != nil {
+				acls = aclresp.Grants
 			}
+			openacls = boolPtr(hasOpenACLs(acls))
 		}
+
+		// PublicAccessBlock overrides other public-making settings.
+		publicresp, err := svc.GetPublicAccessBlock(context.TODO(), &s3.GetPublicAccessBlockInput{Bucket: bucket.Name})
+		var pab *types.PublicAccessBlockConfiguration
+		if err != nil {
+			// T-693 covers PAB's own "unknown" handling specifically;
+			// here we only record that we could not read it.
+			warnS3DetailError(bucketName, "GetPublicAccessBlock", err)
+		} else if publicresp != nil && publicresp.PublicAccessBlockConfiguration != nil {
+			pab = publicresp.PublicAccessBlockConfiguration
+		}
+
+		isPublic := computeBucketIsPublic(policyIsPublic, openacls, pab)
 
 		locationresp, err := svc.GetBucketLocation(context.TODO(), &s3.GetBucketLocationInput{Bucket: bucket.Name})
 		var region string
@@ -111,7 +163,7 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 			region = normalizeBucketLocation(locationresp.LocationConstraint)
 		}
 		bucketObject := S3Bucket{
-			Name:         *bucket.Name,
+			Name:         bucketName,
 			Owner:        owner,
 			IsPublic:     isPublic,
 			Region:       region,
@@ -120,60 +172,145 @@ func GetBucketDetails(svc *s3.Client) []S3Bucket {
 			PublicPolicy: policyIsPublic,
 		}
 
-		if publicresp != nil {
+		if publicresp != nil && publicresp.PublicAccessBlockConfiguration != nil {
 			bucketObject.PublicAccessBlockConfiguration = *publicresp.PublicAccessBlockConfiguration
 		}
 
-		loggingresp, _ := svc.GetBucketLogging(context.TODO(), &s3.GetBucketLoggingInput{Bucket: bucket.Name})
-		if loggingresp != nil && loggingresp.LoggingEnabled != nil {
-			if aws.ToString(loggingresp.LoggingEnabled.TargetBucket) != "" {
-				bucketObject.LoggingEnabled = true
-				bucketObject.LoggingBucket = aws.ToString(loggingresp.LoggingEnabled.TargetBucket)
+		loggingresp, err := svc.GetBucketLogging(context.TODO(), &s3.GetBucketLoggingInput{Bucket: bucket.Name})
+		if err != nil {
+			warnS3DetailError(bucketName, "GetBucketLogging", err)
+		} else {
+			enabled := false
+			if loggingresp != nil && loggingresp.LoggingEnabled != nil {
+				target := aws.ToString(loggingresp.LoggingEnabled.TargetBucket)
+				if target != "" {
+					enabled = true
+					bucketObject.LoggingBucket = target
+				}
 			}
+			bucketObject.LoggingEnabled = boolPtr(enabled)
 		}
 
 		params := &s3.GetBucketEncryptionInput{Bucket: bucket.Name}
-		resp, _ := svc.GetBucketEncryption(context.TODO(), params)
-
-		hasEncryption := false
-		if resp != nil {
-			hasEncryption = true
-			bucketObject.EncryptionRules = resp.ServerSideEncryptionConfiguration.Rules
+		resp, err := svc.GetBucketEncryption(context.TODO(), params)
+		if err != nil {
+			warnS3DetailError(bucketName, "GetBucketEncryption", err)
+		} else {
+			if resp != nil && resp.ServerSideEncryptionConfiguration != nil {
+				bucketObject.EncryptionRules = resp.ServerSideEncryptionConfiguration.Rules
+				bucketObject.HasEncryption = boolPtr(true)
+			} else {
+				bucketObject.HasEncryption = boolPtr(false)
+			}
 		}
-		bucketObject.HasEncryption = hasEncryption
 
-		tagsResp, _ := svc.GetBucketTagging(context.TODO(), &s3.GetBucketTaggingInput{Bucket: bucket.Name})
-		if tagsResp != nil {
+		tagsResp, err := svc.GetBucketTagging(context.TODO(), &s3.GetBucketTaggingInput{Bucket: bucket.Name})
+		if err != nil {
+			// Tag retrieval commonly fails (NoSuchTagSet) for buckets
+			// with no tags; treat as "no tags" rather than an error.
+			// Other failures are logged but not fatal.
+			warnS3DetailError(bucketName, "GetBucketTagging", err)
+		} else if tagsResp != nil {
 			for _, tag := range tagsResp.TagSet {
-				tags[*tag.Key] = *tag.Value
+				tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
 			}
 		}
 		bucketObject.Tags = tags
-		policyResp, _ := svc.GetBucketPolicy(context.TODO(), &s3.GetBucketPolicyInput{Bucket: bucket.Name})
-		if policyResp != nil && policyResp.Policy != nil {
+
+		policyResp, err := svc.GetBucketPolicy(context.TODO(), &s3.GetBucketPolicyInput{Bucket: bucket.Name})
+		if err != nil {
+			warnS3DetailError(bucketName, "GetBucketPolicy", err)
+		} else if policyResp != nil && policyResp.Policy != nil {
 			bucketObject.Policy = *policyResp.Policy
 		}
-		replicationResp, _ := svc.GetBucketReplication(context.TODO(), &s3.GetBucketReplicationInput{Bucket: bucket.Name})
-		if replicationResp != nil && replicationResp.ReplicationConfiguration != nil {
+
+		replicationResp, err := svc.GetBucketReplication(context.TODO(), &s3.GetBucketReplicationInput{Bucket: bucket.Name})
+		if err != nil {
+			warnS3DetailError(bucketName, "GetBucketReplication", err)
+		} else if replicationResp != nil && replicationResp.ReplicationConfiguration != nil {
 			bucketObject.Replication = *replicationResp.ReplicationConfiguration
 		}
-		versioningResp, _ := svc.GetBucketVersioning(context.TODO(), &s3.GetBucketVersioningInput{Bucket: bucket.Name})
-		if versioningResp != nil {
-			if versioningResp.Status == types.BucketVersioningStatusEnabled {
-				bucketObject.Versioning = true
-			} else {
-				bucketObject.Versioning = false
-			}
-			if versioningResp.MFADelete == types.MFADeleteStatusEnabled {
-				bucketObject.VersioningMFAEnabled = true
-			} else {
-				bucketObject.VersioningMFAEnabled = false
-			}
+
+		versioningResp, err := svc.GetBucketVersioning(context.TODO(), &s3.GetBucketVersioningInput{Bucket: bucket.Name})
+		if err != nil {
+			warnS3DetailError(bucketName, "GetBucketVersioning", err)
+		} else if versioningResp != nil {
+			bucketObject.Versioning = boolPtr(versioningResp.Status == types.BucketVersioningStatusEnabled)
+			bucketObject.VersioningMFAEnabled = boolPtr(versioningResp.MFADelete == types.MFADeleteStatusEnabled)
 		}
+
 		result = append(result, bucketObject)
 
 	}
 	return result
+}
+
+// boolPtr returns a pointer to the given boolean value.
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+// computeBucketIsPublic returns the bucket's overall public state
+// based on policy status, ACL state, and Public Access Block
+// configuration. The result is nil ("unknown") whenever a contributing
+// input is unknown and could flip the answer:
+//   - If either the policy status or ACL state is unknown, the only
+//     way to claim "not public" is if the Public Access Block both
+//     restricts public buckets AND either ignores public ACLs or is
+//     irrelevant because the ACLs are known-clean.
+//   - A confirmed public input (policy or ACL) always makes the
+//     bucket public unless the PAB restricts public buckets AND
+//     blocks the corresponding path (IgnorePublicAcls for ACLs,
+//     BlockPublicPolicy for the policy).
+func computeBucketIsPublic(policyIsPublic, openACLs *bool, pab *types.PublicAccessBlockConfiguration) *bool {
+	// Extract the PAB booleans once. A missing PAB means "no block
+	// applied" for the purposes of this computation.
+	restrictPublicBuckets := false
+	ignorePublicAcls := false
+	blockPublicPolicy := false
+	if pab != nil {
+		restrictPublicBuckets = aws.ToBool(pab.RestrictPublicBuckets)
+		ignorePublicAcls = aws.ToBool(pab.IgnorePublicAcls)
+		blockPublicPolicy = aws.ToBool(pab.BlockPublicPolicy)
+	}
+
+	// When PAB fully locks the bucket down we can answer "not public"
+	// regardless of policy/ACL state, even if they are unknown.
+	if restrictPublicBuckets && ignorePublicAcls && blockPublicPolicy {
+		return boolPtr(false)
+	}
+
+	// Otherwise, evaluate each source and factor in the PAB.
+	policyContribution := policyIsPublic
+	if policyContribution != nil && *policyContribution && restrictPublicBuckets && blockPublicPolicy {
+		// PAB neutralises a public policy.
+		f := false
+		policyContribution = &f
+	}
+
+	aclContribution := openACLs
+	if aclContribution != nil && *aclContribution && restrictPublicBuckets && ignorePublicAcls {
+		// PAB neutralises public ACLs.
+		f := false
+		aclContribution = &f
+	}
+
+	// Any confirmed-true makes the bucket public.
+	if policyContribution != nil && *policyContribution {
+		return boolPtr(true)
+	}
+	if aclContribution != nil && *aclContribution {
+		return boolPtr(true)
+	}
+
+	// If either input is unknown, the overall answer is unknown —
+	// the unknown side could still be public.
+	if policyContribution == nil || aclContribution == nil {
+		return nil
+	}
+
+	// Both inputs confirmed not public.
+	return boolPtr(false)
 }
 
 // hasOpenACLs checks whether any grant in the list represents an open (public) ACL.

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -1,10 +1,14 @@
 package helpers
 
 import (
+	"context"
+	"errors"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
@@ -200,15 +204,15 @@ func TestS3Bucket_Struct(t *testing.T) {
 		Account:              "123456789012",
 		Name:                 "my-test-bucket",
 		Owner:                "bucket-owner",
-		IsPublic:             true,
+		IsPublic:             aws.Bool(true),
 		Region:               "us-west-2",
-		OpenACLs:             false,
-		PublicPolicy:         true,
-		LoggingEnabled:       true,
+		OpenACLs:             aws.Bool(false),
+		PublicPolicy:         aws.Bool(true),
+		LoggingEnabled:       aws.Bool(true),
 		LoggingBucket:        "logging-bucket",
-		HasEncryption:        true,
-		Versioning:           true,
-		VersioningMFAEnabled: false,
+		HasEncryption:        aws.Bool(true),
+		Versioning:           aws.Bool(true),
+		VersioningMFAEnabled: aws.Bool(false),
 		Tags: map[string]string{
 			"Environment": "Production",
 			"Team":        "DevOps",
@@ -223,32 +227,32 @@ func TestS3Bucket_Struct(t *testing.T) {
 	if bucket.Name != "my-test-bucket" {
 		t.Errorf("Expected Name to be 'my-test-bucket', got %s", bucket.Name)
 	}
-	if !bucket.IsPublic {
-		t.Errorf("Expected IsPublic to be true, got %v", bucket.IsPublic)
+	if !aws.ToBool(bucket.IsPublic) {
+		t.Errorf("Expected IsPublic to be true, got %v", aws.ToBool(bucket.IsPublic))
 	}
 	if bucket.Region != "us-west-2" {
 		t.Errorf("Expected Region to be 'us-west-2', got %s", bucket.Region)
 	}
-	if bucket.OpenACLs {
-		t.Errorf("Expected OpenACLs to be false, got %v", bucket.OpenACLs)
+	if aws.ToBool(bucket.OpenACLs) {
+		t.Errorf("Expected OpenACLs to be false, got %v", aws.ToBool(bucket.OpenACLs))
 	}
-	if !bucket.PublicPolicy {
-		t.Errorf("Expected PublicPolicy to be true, got %v", bucket.PublicPolicy)
+	if !aws.ToBool(bucket.PublicPolicy) {
+		t.Errorf("Expected PublicPolicy to be true, got %v", aws.ToBool(bucket.PublicPolicy))
 	}
-	if !bucket.LoggingEnabled {
-		t.Errorf("Expected LoggingEnabled to be true, got %v", bucket.LoggingEnabled)
+	if !aws.ToBool(bucket.LoggingEnabled) {
+		t.Errorf("Expected LoggingEnabled to be true, got %v", aws.ToBool(bucket.LoggingEnabled))
 	}
 	if bucket.LoggingBucket != "logging-bucket" {
 		t.Errorf("Expected LoggingBucket to be 'logging-bucket', got %s", bucket.LoggingBucket)
 	}
-	if !bucket.HasEncryption {
-		t.Errorf("Expected HasEncryption to be true, got %v", bucket.HasEncryption)
+	if !aws.ToBool(bucket.HasEncryption) {
+		t.Errorf("Expected HasEncryption to be true, got %v", aws.ToBool(bucket.HasEncryption))
 	}
-	if !bucket.Versioning {
-		t.Errorf("Expected Versioning to be true, got %v", bucket.Versioning)
+	if !aws.ToBool(bucket.Versioning) {
+		t.Errorf("Expected Versioning to be true, got %v", aws.ToBool(bucket.Versioning))
 	}
-	if bucket.VersioningMFAEnabled {
-		t.Errorf("Expected VersioningMFAEnabled to be false, got %v", bucket.VersioningMFAEnabled)
+	if aws.ToBool(bucket.VersioningMFAEnabled) {
+		t.Errorf("Expected VersioningMFAEnabled to be false, got %v", aws.ToBool(bucket.VersioningMFAEnabled))
 	}
 
 	// Test tags
@@ -312,7 +316,7 @@ func TestS3Bucket_ACLsAndGrants(t *testing.T) {
 
 func TestS3Bucket_EncryptionRules(t *testing.T) {
 	bucket := S3Bucket{
-		HasEncryption: true,
+		HasEncryption: aws.Bool(true),
 		EncryptionRules: []types.ServerSideEncryptionRule{
 			{
 				ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
@@ -322,8 +326,8 @@ func TestS3Bucket_EncryptionRules(t *testing.T) {
 		},
 	}
 
-	if !bucket.HasEncryption {
-		t.Errorf("Expected HasEncryption to be true, got %v", bucket.HasEncryption)
+	if !aws.ToBool(bucket.HasEncryption) {
+		t.Errorf("Expected HasEncryption to be true, got %v", aws.ToBool(bucket.HasEncryption))
 	}
 
 	if len(bucket.EncryptionRules) != 1 {
@@ -563,5 +567,344 @@ func TestS3Bucket_PublicAccessBlockConfiguration(t *testing.T) {
 	}
 	if !aws.ToBool(config.RestrictPublicBuckets) {
 		t.Errorf("Expected RestrictPublicBuckets to be true, got %v", aws.ToBool(config.RestrictPublicBuckets))
+	}
+}
+
+// mockS3Client implements S3API. Each method delegates to a function
+// field so individual tests can return specific responses or errors
+// per call.
+type mockS3Client struct {
+	listBuckets           func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	getBucketPolicyStatus func(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	getBucketAcl          func(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	getPublicAccessBlock  func(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
+	getBucketLocation     func(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	getBucketLogging      func(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error)
+	getBucketEncryption   func(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error)
+	getBucketTagging      func(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+	getBucketPolicy       func(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+	getBucketReplication  func(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error)
+	getBucketVersioning   func(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+}
+
+func (m *mockS3Client) ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	return m.listBuckets(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+	return m.getBucketPolicyStatus(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+	return m.getBucketAcl(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+	return m.getPublicAccessBlock(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	return m.getBucketLocation(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketLogging(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+	return m.getBucketLogging(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketEncryption(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+	return m.getBucketEncryption(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketTagging(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error) {
+	return m.getBucketTagging(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+	return m.getBucketPolicy(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketReplication(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error) {
+	return m.getBucketReplication(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	return m.getBucketVersioning(ctx, params, optFns...)
+}
+
+// healthyS3Mock returns a mock where every detail call succeeds with
+// a benign default response. Individual tests override the fields
+// they want to fail.
+func healthyS3Mock(bucketName string) *mockS3Client {
+	return &mockS3Client{
+		listBuckets: func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{{Name: aws.String(bucketName)}},
+				Owner:   &types.Owner{DisplayName: aws.String("owner"), ID: aws.String("owner-id")},
+			}, nil
+		},
+		getBucketPolicyStatus: func(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+			return &s3.GetBucketPolicyStatusOutput{PolicyStatus: &types.PolicyStatus{IsPublic: aws.Bool(false)}}, nil
+		},
+		getBucketAcl: func(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+			return &s3.GetBucketAclOutput{Grants: []types.Grant{}}, nil
+		},
+		getPublicAccessBlock: func(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			return &s3.GetPublicAccessBlockOutput{PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{}}, nil
+		},
+		getBucketLocation: func(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+			return &s3.GetBucketLocationOutput{LocationConstraint: types.BucketLocationConstraintEuWest1}, nil
+		},
+		getBucketLogging: func(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+			return &s3.GetBucketLoggingOutput{LoggingEnabled: &types.LoggingEnabled{TargetBucket: aws.String("log-target")}}, nil
+		},
+		getBucketEncryption: func(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+			return &s3.GetBucketEncryptionOutput{
+				ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+					Rules: []types.ServerSideEncryptionRule{{
+						ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+							SSEAlgorithm: types.ServerSideEncryptionAes256,
+						},
+					}},
+				},
+			}, nil
+		},
+		getBucketTagging: func(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error) {
+			return &s3.GetBucketTaggingOutput{TagSet: []types.Tag{}}, nil
+		},
+		getBucketPolicy: func(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+			return &s3.GetBucketPolicyOutput{Policy: aws.String("")}, nil
+		},
+		getBucketReplication: func(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error) {
+			return &s3.GetBucketReplicationOutput{}, nil
+		},
+		getBucketVersioning: func(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			return &s3.GetBucketVersioningOutput{Status: types.BucketVersioningStatusEnabled, MFADelete: types.MFADeleteStatusEnabled}, nil
+		},
+	}
+}
+
+// silenceStderr redirects os.Stderr to /dev/null for the duration of
+// a test so warning logs emitted by GetBucketDetails don't pollute
+// the test output. It restores the original file descriptor on
+// cleanup.
+func silenceStderr(t *testing.T) {
+	t.Helper()
+	orig := os.Stderr
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open /dev/null: %v", err)
+	}
+	os.Stderr = devNull
+	t.Cleanup(func() {
+		os.Stderr = orig
+		devNull.Close()
+	})
+}
+
+// TestGetBucketDetails_UnknownOnDetailErrors is the regression test
+// for T-714. When any of the per-bucket detail calls fails, the
+// matching tri-state field on the returned S3Bucket must be nil
+// ("unknown") rather than falsely defaulting to false.
+func TestGetBucketDetails_UnknownOnDetailErrors(t *testing.T) {
+	const bucketName = "test-bucket"
+	errBoom := errors.New("boom")
+
+	tests := []struct {
+		name       string
+		breakMock  func(m *mockS3Client)
+		expectNil  func(b S3Bucket) bool
+		fieldLabel string
+	}{
+		{
+			name: "GetBucketEncryption failure => HasEncryption is unknown",
+			breakMock: func(m *mockS3Client) {
+				m.getBucketEncryption = func(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+					return nil, errBoom
+				}
+			},
+			expectNil:  func(b S3Bucket) bool { return b.HasEncryption == nil },
+			fieldLabel: "HasEncryption",
+		},
+		{
+			name: "GetBucketVersioning failure => Versioning and VersioningMFAEnabled are unknown",
+			breakMock: func(m *mockS3Client) {
+				m.getBucketVersioning = func(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+					return nil, errBoom
+				}
+			},
+			expectNil:  func(b S3Bucket) bool { return b.Versioning == nil && b.VersioningMFAEnabled == nil },
+			fieldLabel: "Versioning/VersioningMFAEnabled",
+		},
+		{
+			name: "GetBucketLogging failure => LoggingEnabled is unknown",
+			breakMock: func(m *mockS3Client) {
+				m.getBucketLogging = func(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+					return nil, errBoom
+				}
+			},
+			expectNil:  func(b S3Bucket) bool { return b.LoggingEnabled == nil },
+			fieldLabel: "LoggingEnabled",
+		},
+		{
+			name: "GetBucketAcl failure => OpenACLs and IsPublic are unknown",
+			breakMock: func(m *mockS3Client) {
+				m.getBucketAcl = func(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+					return nil, errBoom
+				}
+			},
+			// IsPublic must also be unknown because an unknown ACL
+			// could flip the answer.
+			expectNil:  func(b S3Bucket) bool { return b.OpenACLs == nil && b.IsPublic == nil },
+			fieldLabel: "OpenACLs/IsPublic",
+		},
+		{
+			name: "GetBucketPolicyStatus failure => PublicPolicy and IsPublic are unknown",
+			breakMock: func(m *mockS3Client) {
+				m.getBucketPolicyStatus = func(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+					return nil, errBoom
+				}
+			},
+			expectNil:  func(b S3Bucket) bool { return b.PublicPolicy == nil && b.IsPublic == nil },
+			fieldLabel: "PublicPolicy/IsPublic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			silenceStderr(t)
+			mock := healthyS3Mock(bucketName)
+			tt.breakMock(mock)
+
+			buckets := GetBucketDetails(mock)
+			if len(buckets) != 1 {
+				t.Fatalf("expected 1 bucket, got %d", len(buckets))
+			}
+			if !tt.expectNil(buckets[0]) {
+				t.Errorf("expected %s to be nil (unknown); got bucket=%+v", tt.fieldLabel, buckets[0])
+			}
+		})
+	}
+}
+
+// TestGetBucketDetails_HealthyPathSetsPointers verifies that when all
+// detail calls succeed the tri-state pointers are populated (not nil).
+func TestGetBucketDetails_HealthyPathSetsPointers(t *testing.T) {
+	silenceStderr(t)
+	mock := healthyS3Mock("ok-bucket")
+
+	buckets := GetBucketDetails(mock)
+	if len(buckets) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(buckets))
+	}
+	b := buckets[0]
+	if b.HasEncryption == nil || !*b.HasEncryption {
+		t.Errorf("HasEncryption expected true, got %v", b.HasEncryption)
+	}
+	if b.Versioning == nil || !*b.Versioning {
+		t.Errorf("Versioning expected true, got %v", b.Versioning)
+	}
+	if b.VersioningMFAEnabled == nil || !*b.VersioningMFAEnabled {
+		t.Errorf("VersioningMFAEnabled expected true, got %v", b.VersioningMFAEnabled)
+	}
+	if b.LoggingEnabled == nil || !*b.LoggingEnabled {
+		t.Errorf("LoggingEnabled expected true, got %v", b.LoggingEnabled)
+	}
+	if b.LoggingBucket != "log-target" {
+		t.Errorf("LoggingBucket expected log-target, got %q", b.LoggingBucket)
+	}
+	if b.OpenACLs == nil || *b.OpenACLs {
+		t.Errorf("OpenACLs expected false, got %v", b.OpenACLs)
+	}
+	if b.PublicPolicy == nil || *b.PublicPolicy {
+		t.Errorf("PublicPolicy expected false, got %v", b.PublicPolicy)
+	}
+	if b.IsPublic == nil || *b.IsPublic {
+		t.Errorf("IsPublic expected false, got %v", b.IsPublic)
+	}
+}
+
+// TestComputeBucketIsPublic covers the tri-state aggregation logic so
+// that unknown policy/ACL inputs don't silently become "not public".
+func TestComputeBucketIsPublic(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   *bool
+		acls     *bool
+		pab      *types.PublicAccessBlockConfiguration
+		expected *bool
+	}{
+		{
+			name:     "both confirmed not public, no PAB => not public",
+			policy:   aws.Bool(false),
+			acls:     aws.Bool(false),
+			pab:      nil,
+			expected: aws.Bool(false),
+		},
+		{
+			name:     "confirmed public policy => public",
+			policy:   aws.Bool(true),
+			acls:     aws.Bool(false),
+			pab:      nil,
+			expected: aws.Bool(true),
+		},
+		{
+			name:     "confirmed public ACLs => public",
+			policy:   aws.Bool(false),
+			acls:     aws.Bool(true),
+			pab:      nil,
+			expected: aws.Bool(true),
+		},
+		{
+			name:     "unknown policy, clean ACLs, no PAB => unknown",
+			policy:   nil,
+			acls:     aws.Bool(false),
+			pab:      nil,
+			expected: nil,
+		},
+		{
+			name:     "clean policy, unknown ACLs, no PAB => unknown",
+			policy:   aws.Bool(false),
+			acls:     nil,
+			pab:      nil,
+			expected: nil,
+		},
+		{
+			name:   "unknown inputs but PAB fully locks down => not public",
+			policy: nil,
+			acls:   nil,
+			pab: &types.PublicAccessBlockConfiguration{
+				BlockPublicAcls:       aws.Bool(true),
+				BlockPublicPolicy:     aws.Bool(true),
+				IgnorePublicAcls:      aws.Bool(true),
+				RestrictPublicBuckets: aws.Bool(true),
+			},
+			expected: aws.Bool(false),
+		},
+		{
+			name:   "public policy neutralised by PAB => not public",
+			policy: aws.Bool(true),
+			acls:   aws.Bool(false),
+			pab: &types.PublicAccessBlockConfiguration{
+				BlockPublicAcls:       aws.Bool(true),
+				BlockPublicPolicy:     aws.Bool(true),
+				IgnorePublicAcls:      aws.Bool(true),
+				RestrictPublicBuckets: aws.Bool(true),
+			},
+			expected: aws.Bool(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeBucketIsPublic(tt.policy, tt.acls, tt.pab)
+			switch {
+			case got == nil && tt.expected == nil:
+				// ok
+			case got == nil || tt.expected == nil:
+				t.Fatalf("got=%v, want=%v", got, tt.expected)
+			case *got != *tt.expected:
+				t.Fatalf("got=%v, want=%v", *got, *tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `helpers.GetBucketDetails` silently dropped errors from per-bucket detail API calls, so the S3 security report misclassified buckets when those calls failed (e.g. `--unencrypted-only` included buckets whose encryption state could not be read).
- Convert the tri-state boolean fields on `S3Bucket` (`IsPublic`, `PublicPolicy`, `OpenACLs`, `LoggingEnabled`, `HasEncryption`, `Versioning`, `VersioningMFAEnabled`) to `*bool`, leaving them `nil` when the underlying AWS call fails. `s3 list` shows `Unknown` and filters behave conservatively.
- Introduces an `S3API` interface so regression tests can inject per-call failures. Logs a stderr warning whenever a detail call fails. `PublicAccessBlockConfiguration` is intentionally left alone — T-693 handles its own unknown state.

## Root cause

Every detail call used the `resp, _ := svc.Foo(...)` pattern. On failure `resp` was nil and the destination boolean kept its Go zero value of `false`, indistinguishable from a confirmed-off answer. The composite `IsPublic` inherited the same problem.

## Fix

- `helpers/s3.go`: new `S3API` interface; `GetBucketDetails` records errors, logs warnings to stderr, and leaves the matching `*bool` field nil. `computeBucketIsPublic` aggregates policy + ACL + PAB with proper unknown handling.
- `cmd/s3list.go`: filters exclude only confirmed-safe buckets; rendered output shows `Unknown` for nil states.
- `helpers/s3_test.go`: added `mockS3Client`, `TestGetBucketDetails_UnknownOnDetailErrors`, `TestGetBucketDetails_HealthyPathSetsPointers`, `TestComputeBucketIsPublic`; updated existing struct tests for the new `*bool` fields.

## Test plan

- [x] `go test ./...`
- [x] `make check` (fmt, vet, lint, test)
- [x] Regression tests: `go test ./helpers/ -run "TestGetBucketDetails|TestComputeBucketIsPublic" -v`