### PR TITLE
Fix T-757: Paginate ENI IP Finder Search

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -54,6 +54,15 @@ tests can pass a mock. The helper uses `NewDescribeNetworkInterfacesPaginator`
 so large accounts don't get truncated output. `GetVPCUsageOverview` reuses
 this helper; there is no separate private `retrieveNetworkInterfaces`.
 
+`searchENIsByIP` (used by `FindIPAddressDetails` / `vpc ip-finder`) follows
+the same pattern after T-757: it takes
+`ec2.DescribeNetworkInterfacesAPIClient` and walks every page via
+`NewDescribeNetworkInterfacesPaginator`. Before the fix a single
+`DescribeNetworkInterfaces` call was made with an `addresses.private-ip-address`
+filter, so multi-VPC matches for the same RFC1918 IP on later pages were
+silently dropped (and the "multiple matches" warning never fired). Tests live
+in `helpers/ec2_ipfinder_pagination_test.go`.
+
 ## ENI Matching Helpers
 
 Pure, testable helpers live alongside the AWS-client-taking wrappers. Each scans a slice of AWS objects for an ENI or subnet match so nil-safety can be tested without mocking.

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -1965,18 +1965,28 @@ func handleAWSAPIError(err error, apiName string) {
 	panic(fmt.Errorf("failed to call %s: %v", apiName, err))
 }
 
-// searchENIsByIP searches for ENIs with a specific IP address
-func searchENIsByIP(svc *ec2.Client, filters []types.Filter) []types.NetworkInterface {
+// searchENIsByIP searches for ENIs matching the given filters, walking every
+// page of DescribeNetworkInterfaces. Before T-757 this helper issued a single
+// unpaginated call, so in large accounts (and in multi-VPC environments where
+// the same private IP can legitimately appear on several ENIs) matches on
+// later pages were silently dropped. The parameter is the paginator's own
+// interface so *ec2.Client still satisfies it while tests can pass a mock.
+func searchENIsByIP(svc ec2.DescribeNetworkInterfacesAPIClient, filters []types.Filter) []types.NetworkInterface {
 	input := &ec2.DescribeNetworkInterfacesInput{
 		Filters: filters,
 	}
 
-	resp, err := svc.DescribeNetworkInterfaces(context.TODO(), input)
-	if err != nil {
-		handleAWSAPIError(err, "DescribeNetworkInterfaces")
+	var result []types.NetworkInterface
+	paginator := ec2.NewDescribeNetworkInterfacesPaginator(svc, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			handleAWSAPIError(err, "DescribeNetworkInterfaces")
+		}
+		result = append(result, page.NetworkInterfaces...)
 	}
 
-	return resp.NetworkInterfaces
+	return result
 }
 
 // isSecondaryIP checks if the IP address is a secondary IP on the ENI

--- a/helpers/ec2_ipfinder_pagination_test.go
+++ b/helpers/ec2_ipfinder_pagination_test.go
@@ -1,0 +1,160 @@
+package helpers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// Regression tests for T-757: searchENIsByIP previously issued a single
+// DescribeNetworkInterfaces call and ignored pagination. In accounts with many
+// ENIs — including multi-VPC environments where the same RFC1918 address can
+// appear on ENIs in several VPCs — matches on later pages were silently
+// dropped, hiding multi-match warnings and returning incomplete results.
+
+// makeNetworkInterfacesWithIP builds n synthetic ENIs whose primary private
+// address is the supplied IP so filter-based searches can be simulated.
+func makeNetworkInterfacesWithIP(n int, ip string, idPrefix string) []types.NetworkInterface {
+	result := make([]types.NetworkInterface, n)
+	for i := 0; i < n; i++ {
+		result[i] = types.NetworkInterface{
+			NetworkInterfaceId: aws.String(fmt.Sprintf("%s-%04d", idPrefix, i)),
+			VpcId:              aws.String(fmt.Sprintf("vpc-%04d", i)),
+			PrivateIpAddress:   aws.String(ip),
+			PrivateIpAddresses: []types.NetworkInterfacePrivateIpAddress{
+				{
+					PrivateIpAddress: aws.String(ip),
+					Primary:          aws.Bool(true),
+				},
+			},
+		}
+	}
+	return result
+}
+
+// TestSearchENIsByIP_Pagination verifies that searchENIsByIP walks every page
+// of DescribeNetworkInterfaces. Before the fix only the first page was
+// processed, so matches on page 2+ were lost — including in multi-VPC
+// environments where the filter `addresses.private-ip-address` could legitimately
+// match ENIs across many VPCs that reuse the same private IP.
+func TestSearchENIsByIP_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockDescribeNetworkInterfacesAPIClient{
+		interfaces: makeNetworkInterfacesWithIP(total, "10.0.1.100", "eni-match"),
+		pageSize:   2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	filters := []types.Filter{
+		{
+			Name:   aws.String("addresses.private-ip-address"),
+			Values: []string{"10.0.1.100"},
+		},
+	}
+
+	result := searchENIsByIP(mock, filters)
+
+	if len(result) != total {
+		t.Fatalf("searchENIsByIP() returned %d ENIs, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.callCount != 3 {
+		t.Errorf("DescribeNetworkInterfaces called %d times, want 3 (one per page)", mock.callCount)
+	}
+	for i, eni := range result {
+		want := fmt.Sprintf("eni-match-%04d", i)
+		if aws.ToString(eni.NetworkInterfaceId) != want {
+			t.Errorf("searchENIsByIP()[%d].NetworkInterfaceId = %s, want %s", i, aws.ToString(eni.NetworkInterfaceId), want)
+		}
+	}
+}
+
+// TestSearchENIsByIP_PaginationMultiVPC simulates the exact scenario from the
+// ticket: the same private IP appears on ENIs across multiple VPCs spread over
+// several response pages. The helper must return every match so the caller can
+// emit the "multiple matches" warning instead of silently returning the first
+// page's entry.
+func TestSearchENIsByIP_PaginationMultiVPC(t *testing.T) {
+	// 4 ENIs, each in a different VPC, all with the same IP
+	interfaces := makeNetworkInterfacesWithIP(4, "10.0.1.100", "eni-vpc")
+	mock := &mockDescribeNetworkInterfacesAPIClient{
+		interfaces: interfaces,
+		pageSize:   1, // force 4 pages, one ENI per page
+	}
+
+	filters := []types.Filter{
+		{
+			Name:   aws.String("addresses.private-ip-address"),
+			Values: []string{"10.0.1.100"},
+		},
+	}
+
+	result := searchENIsByIP(mock, filters)
+
+	if len(result) != 4 {
+		t.Fatalf("searchENIsByIP() returned %d ENIs across VPCs, want 4 (later-page matches dropped)", len(result))
+	}
+	if mock.callCount != 4 {
+		t.Errorf("DescribeNetworkInterfaces called %d times, want 4 (one per page)", mock.callCount)
+	}
+
+	// Ensure each result comes from a distinct VPC — proving we collected
+	// matches across pages rather than returning duplicates from page 1.
+	seen := make(map[string]bool)
+	for _, eni := range result {
+		vpcID := aws.ToString(eni.VpcId)
+		if seen[vpcID] {
+			t.Errorf("duplicate VPC %s in results — paginator may be re-reading page 1", vpcID)
+		}
+		seen[vpcID] = true
+	}
+}
+
+// TestSearchENIsByIP_SinglePage verifies the helper still works when results
+// fit in a single page — no unnecessary additional calls.
+func TestSearchENIsByIP_SinglePage(t *testing.T) {
+	mock := &mockDescribeNetworkInterfacesAPIClient{
+		interfaces: makeNetworkInterfacesWithIP(2, "10.0.1.100", "eni-single"),
+		// pageSize 0 → everything in one page
+	}
+
+	filters := []types.Filter{
+		{
+			Name:   aws.String("addresses.private-ip-address"),
+			Values: []string{"10.0.1.100"},
+		},
+	}
+
+	result := searchENIsByIP(mock, filters)
+
+	if len(result) != 2 {
+		t.Fatalf("searchENIsByIP() returned %d ENIs, want 2", len(result))
+	}
+	if mock.callCount != 1 {
+		t.Errorf("DescribeNetworkInterfaces called %d times, want 1", mock.callCount)
+	}
+}
+
+// TestSearchENIsByIP_NoMatches verifies the helper returns an empty slice when
+// no ENIs match the filter.
+func TestSearchENIsByIP_NoMatches(t *testing.T) {
+	mock := &mockDescribeNetworkInterfacesAPIClient{
+		interfaces: []types.NetworkInterface{},
+	}
+
+	filters := []types.Filter{
+		{
+			Name:   aws.String("addresses.private-ip-address"),
+			Values: []string{"10.0.1.100"},
+		},
+	}
+
+	result := searchENIsByIP(mock, filters)
+
+	if len(result) != 0 {
+		t.Errorf("searchENIsByIP() returned %d ENIs, want 0", len(result))
+	}
+	if mock.callCount != 1 {
+		t.Errorf("DescribeNetworkInterfaces called %d times, want 1", mock.callCount)
+	}
+}


### PR DESCRIPTION
## Summary

- `helpers.searchENIsByIP` (used by `FindIPAddressDetails` and `awstools vpc ip-finder`) previously issued a single `DescribeNetworkInterfaces` call and ignored pagination.
- In large or multi-VPC accounts where the same RFC1918 address appears on ENIs across several VPCs, matches on later pages were silently dropped and the "multiple matches" warning never fired.
- Narrow the helper to `ec2.DescribeNetworkInterfacesAPIClient` and walk every page via `NewDescribeNetworkInterfacesPaginator`. `*ec2.Client` still satisfies the parameter so no callers change. This mirrors the pattern already used by `GetNetworkInterfaces` and other paginated helpers (T-667, T-657, T-746).

## Root cause

`searchENIsByIP` called `svc.DescribeNetworkInterfaces` once and returned `resp.NetworkInterfaces` without consulting `NextToken`. The `addresses.private-ip-address` filter legitimately matches ENIs across many VPCs in accounts reusing RFC1918 ranges, so any matches beyond the first page were dropped.

## Fix

`helpers/ec2.go` — `searchENIsByIP` now takes `ec2.DescribeNetworkInterfacesAPIClient` and loops the paginator until `HasMorePages()` returns false, accumulating every match. Errors still go through `handleAWSAPIError`.

## Test plan

- [x] Regression tests in `helpers/ec2_ipfinder_pagination_test.go`:
  - `TestSearchENIsByIP_Pagination` — 5 ENIs spread over 3 pages all returned
  - `TestSearchENIsByIP_PaginationMultiVPC` — 4 ENIs in 4 VPCs with the same IP spread over 4 pages all returned (the ticket scenario)
  - `TestSearchENIsByIP_SinglePage` — no regression for the common case
  - `TestSearchENIsByIP_NoMatches` — empty-result path still works
- [x] `go test ./...` passes
- [x] `make test` passes