### PR TITLE
Fix T-762: Paginate RDS Instance Inventory Helper

### DIFF
--- a/helpers/rds.go
+++ b/helpers/rds.go
@@ -32,18 +32,26 @@ func GetAllRdsResourceNames(svc *rds.Client) map[string]string {
 	return result
 }
 
-func addAllInstanceNames(svc *rds.Client, result map[string]string) map[string]string {
-	resp, err := svc.DescribeDBInstances(context.TODO(), &rds.DescribeDBInstancesInput{})
-	if err != nil {
-		panic(err)
-	}
-	for _, dbinstance := range resp.DBInstances {
-		result[*dbinstance.DbiResourceId] = *dbinstance.DBInstanceIdentifier
-		if dbinstance.TagList != nil {
-			for _, tag := range dbinstance.TagList {
-				if *tag.Key == "Name" {
-					result[*dbinstance.DbiResourceId] = *tag.Value
-					break
+// addAllInstanceNames adds every DB instance's display name to the result map.
+// AWS's DescribeDBInstances API paginates at 100 instances per page by default,
+// so this helper walks NewDescribeDBInstancesPaginator until every page is
+// consumed. Accepting the narrow rds.DescribeDBInstancesAPIClient interface
+// lets the pagination logic be unit tested without a real *rds.Client.
+func addAllInstanceNames(svc rds.DescribeDBInstancesAPIClient, result map[string]string) map[string]string {
+	paginator := rds.NewDescribeDBInstancesPaginator(svc, &rds.DescribeDBInstancesInput{})
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, dbinstance := range resp.DBInstances {
+			result[*dbinstance.DbiResourceId] = *dbinstance.DBInstanceIdentifier
+			if dbinstance.TagList != nil {
+				for _, tag := range dbinstance.TagList {
+					if *tag.Key == "Name" {
+						result[*dbinstance.DbiResourceId] = *tag.Value
+						break
+					}
 				}
 			}
 		}

--- a/helpers/rds_pagination_test.go
+++ b/helpers/rds_pagination_test.go
@@ -1,0 +1,105 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// mockDescribeDBInstancesClient simulates DescribeDBInstances pagination by
+// splitting a pre-configured slice of DB instances across multiple pages based
+// on the Marker. It satisfies rds.DescribeDBInstancesAPIClient.
+type mockDescribeDBInstancesClient struct {
+	instances []types.DBInstance
+	pageSize  int
+	callCount int
+}
+
+func (m *mockDescribeDBInstancesClient) DescribeDBInstances(_ context.Context, input *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+	m.callCount++
+	start := 0
+	if input.Marker != nil {
+		if _, err := fmt.Sscanf(*input.Marker, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	end := start + pageSize
+	if end > len(m.instances) {
+		end = len(m.instances)
+	}
+	output := &rds.DescribeDBInstancesOutput{
+		DBInstances: m.instances[start:end],
+	}
+	if end < len(m.instances) {
+		next := fmt.Sprintf("%d", end)
+		output.Marker = &next
+	}
+	return output, nil
+}
+
+// makeDBInstances builds n DB instances with predictable IDs and Name tags.
+// The first half have Name tags; the second half only have IDs so the fallback
+// path is also exercised.
+func makeDBInstances(n int) []types.DBInstance {
+	instances := make([]types.DBInstance, n)
+	for i := range n {
+		id := fmt.Sprintf("db-instance-%04d", i)
+		resourceID := fmt.Sprintf("db-ABCDEFGHIJK%05d", i)
+		inst := types.DBInstance{
+			DBInstanceIdentifier: aws.String(id),
+			DbiResourceId:        aws.String(resourceID),
+		}
+		if i < n/2 {
+			inst.TagList = []types.Tag{
+				{Key: aws.String("Environment"), Value: aws.String("production")},
+				{Key: aws.String("Name"), Value: aws.String(fmt.Sprintf("db-name-%d", i))},
+			}
+		}
+		instances[i] = inst
+	}
+	return instances
+}
+
+// TestAddAllInstanceNames_Pagination verifies that addAllInstanceNames
+// retrieves every DB instance across multiple pages. Before the fix it only
+// returned the first page of DescribeDBInstances, which silently truncated the
+// result for accounts with more than ~100 DB instances.
+func TestAddAllInstanceNames_Pagination(t *testing.T) {
+	total := 5
+	mock := &mockDescribeDBInstancesClient{
+		instances: makeDBInstances(total),
+		pageSize:  2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := addAllInstanceNames(mock, map[string]string{})
+
+	if len(result) != total {
+		t.Fatalf("addAllInstanceNames() returned %d entries, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.callCount < 3 {
+		t.Errorf("expected at least 3 DescribeDBInstances calls for %d instances at page size %d, got %d", total, mock.pageSize, mock.callCount)
+	}
+	for i := range total {
+		resourceID := fmt.Sprintf("db-ABCDEFGHIJK%05d", i)
+		got, ok := result[resourceID]
+		if !ok {
+			t.Errorf("addAllInstanceNames() missing entry for %s", resourceID)
+			continue
+		}
+		want := fmt.Sprintf("db-instance-%04d", i)
+		if i < total/2 {
+			want = fmt.Sprintf("db-name-%d", i)
+		}
+		if got != want {
+			t.Errorf("addAllInstanceNames()[%s] = %q, want %q", resourceID, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `helpers/rds.go:addAllInstanceNames` made a single `DescribeDBInstances` call and ignored the `Marker` returned when the response was truncated. In accounts with more than ~100 DB instances the helper silently returned a partial naming map, which propagated incomplete output through every command that consumes `GetAllRdsResourceNames` (e.g. `awstools names`).
- Replaced the single-shot call with `NewDescribeDBInstancesPaginator` and changed the helper to accept the `rds.DescribeDBInstancesAPIClient` interface so the pagination logic can be unit tested, matching the pattern already established for IAM (T-498), TGW inventory (T-669), VPC peering (T-746), and other helpers in the repo.
- `GetAllRdsResourceNames` keeps its existing `*rds.Client` parameter, so call sites in `cmd/names.go` are unchanged.

## Root cause

`addAllInstanceNames` never inspected the `Marker` field on `DescribeDBInstancesOutput`. The AWS RDS API truncates at 100 instances per page by default and does not warn callers that results are incomplete, so the bug is invisible without inspecting the raw response.

## Test plan

- [x] New regression test `TestAddAllInstanceNames_Pagination` (in `helpers/rds_pagination_test.go`) walks a mock paginated client across 3 pages of 5 instances and asserts every instance is aggregated. Before the fix the test does not even compile against the old `*rds.Client` signature; after the fix it passes.
- [x] `go test ./...` passes across `cmd`, `config`, and `helpers`.
- [x] `make check` passes (`go fmt`, `go vet`, `golangci-lint`, tests).

Closes T-762.