### PR TITLE
Fix T-818: IAM Trust Policy Actions

### DIFF
--- a/docs/agent-notes/iam-helpers.md
+++ b/docs/agent-notes/iam-helpers.md
@@ -33,3 +33,21 @@ Affected functions: `getUserList`, `GetPoliciesMap`, `GetUserPoliciesMapForUser`
 - `cmd/iamuserlist.go` — Calls `GetUserDetails`, `GetGroupDetails`, `HasAccessKeys`, `GetLastAccessKeyDate`
 - `cmd/iamrolelist.go` — Calls `GetRolesAndPolicies`
 - `cmd/names.go` — Calls `GetAccountAlias`
+
+## Trust Policy Action Parsing (T-818)
+
+`IAMPolicyDocumentStatement.Action` is typed `any` because AWS policy
+documents allow either a string or an array. After JSON unmarshal the runtime
+value is `string` or `[]any`. `CanBeAssumedFrom` delegates to two helpers in
+`helpers/iamresources.go`:
+
+- `normalizeActions(action any) []string` — converts `string`, `[]string`, or
+  `[]any` into a flat string slice (any unknown type yields `nil`).
+- `statementAllowsAssumeRole(statement) bool` — requires
+  `Effect == "Allow"` (case-insensitive) and matches normalised actions
+  case-insensitively against `assumeRoleActions`
+  (`sts:AssumeRole`, `sts:AssumeRoleWithSAML`).
+
+When adding new trust actions (e.g. `sts:AssumeRoleWithWebIdentity`) extend
+`assumeRoleActions`. Deny statements are always excluded from the returned
+allowances.

--- a/helpers/iamresources.go
+++ b/helpers/iamresources.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -62,22 +63,71 @@ type IAMRole struct {
 	Verbose          bool
 }
 
+// assumeRoleActions lists the trust-policy actions that grant the ability to
+// assume a role. Matched case-insensitively against the statement's Action.
+var assumeRoleActions = []string{
+	"sts:AssumeRole",
+	"sts:AssumeRoleWithSAML",
+}
+
+// statementAllowsAssumeRole reports whether a trust-policy statement allows
+// an assume-role action. It requires Effect == "Allow" (case-insensitive) and
+// accepts Action as a string or a slice (string or any), matching the known
+// assume-role actions case-insensitively.
+func statementAllowsAssumeRole(statement IAMPolicyDocumentStatement) bool {
+	if !strings.EqualFold(statement.Effect, "Allow") {
+		return false
+	}
+	for _, action := range normalizeActions(statement.Action) {
+		for _, want := range assumeRoleActions {
+			if strings.EqualFold(action, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// normalizeActions converts the polymorphic Action value into a slice of
+// strings. AWS policy documents allow Action as either a single string or an
+// array; after JSON unmarshal into an `any` field, the runtime value is a
+// `string` or `[]any`. A typed `[]string` is also accepted for callers that
+// construct statements directly.
+func normalizeActions(action any) []string {
+	switch v := action.(type) {
+	case string:
+		return []string{v}
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // CanBeAssumedFrom returns information about the assumerole policy
 func (role *IAMRole) CanBeAssumedFrom() []string {
 	allowances := []string{}
 	for _, statement := range role.AssumeRolePolicy.Statement {
-		if statement.Action == "sts:AssumeRole" || statement.Action == "sts:AssumeRoleWithSAML" {
-			// Create a slice of keys for consistent ordering
-			keys := make([]string, 0, len(statement.Principal))
-			for key := range statement.Principal {
-				keys = append(keys, key)
-			}
-			// Sort keys alphabetically for consistent ordering
-			sort.Strings(keys)
-			for _, key := range keys {
-				allowance := fmt.Sprintf("%s: %s", key, statement.Principal[key])
-				allowances = append(allowances, allowance)
-			}
+		if !statementAllowsAssumeRole(statement) {
+			continue
+		}
+		// Create a slice of keys for consistent ordering
+		keys := make([]string, 0, len(statement.Principal))
+		for key := range statement.Principal {
+			keys = append(keys, key)
+		}
+		// Sort keys alphabetically for consistent ordering
+		sort.Strings(keys)
+		for _, key := range keys {
+			allowance := fmt.Sprintf("%s: %s", key, statement.Principal[key])
+			allowances = append(allowances, allowance)
 		}
 	}
 	return allowances

--- a/helpers/iamroles_test.go
+++ b/helpers/iamroles_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -106,7 +107,7 @@ func TestIAMRole_CanBeAssumedFrom_ExtendedCases(t *testing.T) {
 			expected: []string{"Service: ec2.amazonaws.com", "Federated: arn:aws:iam::123456789012:saml-provider/Provider"},
 		},
 		{
-			name: "role with deny effect - function doesn't check Effect field",
+			name: "role with deny effect is excluded",
 			role: IAMRole{
 				AssumeRolePolicy: IAMPolicyDocument{
 					Statement: []IAMPolicyDocumentStatement{
@@ -120,13 +121,205 @@ func TestIAMRole_CanBeAssumedFrom_ExtendedCases(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"Service: ec2.amazonaws.com"}, // Function currently doesn't check Effect
+			expected: []string{},
+		},
+		{
+			name: "role with action slice of any including assume role (T-818)",
+			role: IAMRole{
+				AssumeRolePolicy: IAMPolicyDocument{
+					Statement: []IAMPolicyDocumentStatement{
+						{
+							Effect: "Allow",
+							// JSON unmarshal of ["sts:AssumeRole", "sts:TagSession"] into any yields []any
+							Action: []any{"sts:AssumeRole", "sts:TagSession"},
+							Principal: map[string]string{
+								"Service": "ec2.amazonaws.com",
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"Service: ec2.amazonaws.com"},
+		},
+		{
+			name: "role with action slice of strings including assume role",
+			role: IAMRole{
+				AssumeRolePolicy: IAMPolicyDocument{
+					Statement: []IAMPolicyDocumentStatement{
+						{
+							Effect: "Allow",
+							Action: []string{"sts:TagSession", "sts:AssumeRoleWithSAML"},
+							Principal: map[string]string{
+								"Federated": "arn:aws:iam::123456789012:saml-provider/Provider",
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"Federated: arn:aws:iam::123456789012:saml-provider/Provider"},
+		},
+		{
+			name: "role with action slice missing any assume role action",
+			role: IAMRole{
+				AssumeRolePolicy: IAMPolicyDocument{
+					Statement: []IAMPolicyDocumentStatement{
+						{
+							Effect: "Allow",
+							Action: []any{"sts:TagSession", "sts:SetSourceIdentity"},
+							Principal: map[string]string{
+								"Service": "ec2.amazonaws.com",
+							},
+						},
+					},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "role with non-standard casing on action matches case-insensitively (T-818)",
+			role: IAMRole{
+				AssumeRolePolicy: IAMPolicyDocument{
+					Statement: []IAMPolicyDocumentStatement{
+						{
+							Effect: "Allow",
+							Action: "STS:AssumeRole",
+							Principal: map[string]string{
+								"Service": "ec2.amazonaws.com",
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"Service: ec2.amazonaws.com"},
+		},
+		{
+			name: "role with non-standard casing on effect still treated as allow",
+			role: IAMRole{
+				AssumeRolePolicy: IAMPolicyDocument{
+					Statement: []IAMPolicyDocumentStatement{
+						{
+							Effect: "allow",
+							Action: "sts:AssumeRole",
+							Principal: map[string]string{
+								"Service": "ec2.amazonaws.com",
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"Service: ec2.amazonaws.com"},
+		},
+		{
+			name: "mixed allow and deny statements only returns allow principals",
+			role: IAMRole{
+				AssumeRolePolicy: IAMPolicyDocument{
+					Statement: []IAMPolicyDocumentStatement{
+						{
+							Effect: "Deny",
+							Action: "sts:AssumeRole",
+							Principal: map[string]string{
+								"AWS": "arn:aws:iam::999999999999:root",
+							},
+						},
+						{
+							Effect: "Allow",
+							Action: []any{"sts:AssumeRole"},
+							Principal: map[string]string{
+								"Service": "ec2.amazonaws.com",
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"Service: ec2.amazonaws.com"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.role.CanBeAssumedFrom()
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("CanBeAssumedFrom() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIAMRole_CanBeAssumedFrom_JSONUnmarshal verifies the parser handles
+// trust policy shapes after a real JSON unmarshal round-trip — including
+// Action as an array, as produced by AWS, and mixed Effect values (T-818).
+func TestIAMRole_CanBeAssumedFrom_JSONUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		document string
+		expected []string
+	}{
+		{
+			name: "single string action unmarshalled",
+			document: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": "sts:AssumeRole",
+						"Principal": {"Service": "ec2.amazonaws.com"}
+					}
+				]
+			}`,
+			expected: []string{"Service: ec2.amazonaws.com"},
+		},
+		{
+			name: "array action with assume role and tag session unmarshalled (T-818)",
+			document: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": ["sts:AssumeRole", "sts:TagSession"],
+						"Principal": {"Service": "ec2.amazonaws.com"}
+					}
+				]
+			}`,
+			expected: []string{"Service: ec2.amazonaws.com"},
+		},
+		{
+			name: "array action without assume role is excluded",
+			document: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": ["sts:TagSession"],
+						"Principal": {"Service": "ec2.amazonaws.com"}
+					}
+				]
+			}`,
+			expected: []string{},
+		},
+		{
+			name: "deny statement is excluded after unmarshal (T-818)",
+			document: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Deny",
+						"Action": "sts:AssumeRole",
+						"Principal": {"AWS": "arn:aws:iam::999999999999:root"}
+					}
+				]
+			}`,
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc IAMPolicyDocument
+			if err := json.Unmarshal([]byte(tt.document), &doc); err != nil {
+				t.Fatalf("failed to unmarshal policy document: %v", err)
+			}
+			role := IAMRole{AssumeRolePolicy: doc}
+			result := role.CanBeAssumedFrom()
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("CanBeAssumedFrom() = %v, want %v", result, tt.expected)
 			}


### PR DESCRIPTION
## Summary

Fixes T-818. `IAMRole.CanBeAssumedFrom` misread role trust policies: it
compared `Action` as a string, never checked `Effect`, and matched
case-sensitively. As a result, trust policies with array actions (e.g.
`["sts:AssumeRole", "sts:TagSession"]`) disappeared from the IAM role
overview, and `Deny` statements were reported as valid assumers.

- Added `statementAllowsAssumeRole` and `normalizeActions` helpers in
  `helpers/iamresources.go`. The parser now requires `Effect == "Allow"`
  (case-insensitive) and accepts `string`, `[]string`, and `[]any`
  Action values, matching the known assume-role actions case-insensitively.
- Flipped the pre-existing `role with deny effect` test that explicitly
  pinned the buggy behaviour, and added regression coverage for array
  actions, casing variations, mixed allow/deny statements, and a JSON
  unmarshal round-trip that mirrors how trust policies are parsed in
  production.

## Test plan

- [x] `go test ./helpers/ -run 'TestIAMRole_CanBeAssumedFrom' -v`
- [x] `go test ./...`
- [x] `make lint`
- [x] `go vet ./...`