### PR TITLE
Fix T-758: Paginate App Mesh Inventory Helpers

### DIFF
--- a/docs/agent-notes/appmesh-helpers.md
+++ b/docs/agent-notes/appmesh-helpers.md
@@ -1,0 +1,55 @@
+# App Mesh Helpers
+
+Notes on `helpers/appmesh.go` and its test files.
+
+## Architecture
+
+- All list helpers take `AppMeshAPI`, a narrow interface declared at the
+  top of `helpers/appmesh.go`. `*appmesh.Client` satisfies it. Tests
+  supply a mock.
+- `AppMeshAPI` intentionally declares every List/Describe method with the
+  same signature the AWS SDK v2 uses, which means the interface is also
+  compatible with the SDK's per-operation `ListXxxAPIClient` interfaces
+  used by paginators.
+
+## Pagination
+
+Four list operations are used and all are paginated (as of T-758):
+
+- `ListVirtualRouters` via `NewListVirtualRoutersPaginator`
+- `ListRoutes` via `NewListRoutesPaginator` (one paginator per router)
+- `ListVirtualNodes` via `NewListVirtualNodesPaginator`
+- `ListVirtualServices` via `NewListVirtualServicesPaginator`
+
+`ListMeshes` is not currently used anywhere in the codebase — every
+command takes the mesh name as a CLI argument. If that changes, follow
+the same paginator pattern with `NewListMeshesPaginator`.
+
+## Error handling
+
+- List-page errors return `nil` from the helper so callers treat the
+  mesh as unavailable. Describe-per-item errors are logged and the item
+  is skipped (`continue`), matching the pre-pagination behaviour.
+- There is no `context` plumbing in these helpers — they use
+  `context.TODO()` consistent with the rest of `helpers/`.
+
+## Tests
+
+- `helpers/appmesh_test.go` — covers nil/missing-field handling for
+  route spec variants (HTTP, HTTP/2, gRPC, TCP) and API error paths.
+- `helpers/appmesh_pagination_test.go` — covers multi-page responses
+  using `mockPaginatedAppMeshClient`, an `AppMeshAPI` mock that slices
+  pre-seeded fixtures by `NextToken`. Use this mock for any future
+  regression test that needs multi-page behaviour.
+
+## Gotchas
+
+- `GetAllUnservicedAppMeshNodes` is highly sensitive to pagination
+  correctness: it classifies a node as "dangling" whenever it is not
+  referenced by any route. Incomplete pagination on either routes or
+  nodes produces false positives. Before T-758's fix, large meshes would
+  mis-report nodes that were only referenced by routes on later pages.
+- `getAllAppMeshRoutes` iterates routers and then paginates routes for
+  each router. A failure on one router's routes is logged and the loop
+  continues with the next router — partial results are better than
+  aborting the whole traversal.

--- a/helpers/appmesh.go
+++ b/helpers/appmesh.go
@@ -22,29 +22,35 @@ type AppMeshAPI interface {
 	DescribeVirtualService(ctx context.Context, params *appmesh.DescribeVirtualServiceInput, optFns ...func(*appmesh.Options)) (*appmesh.DescribeVirtualServiceOutput, error)
 }
 
-// getAllAppMeshRoutes retrieves all of the routes in the mesh
+// getAllAppMeshRoutes retrieves all of the routes in the mesh. Both
+// ListVirtualRouters and ListRoutes paginate via NextToken; the SDK
+// paginators are used so large meshes do not get truncated.
 func getAllAppMeshRoutes(meshName *string, svc AppMeshAPI) []types.RouteRef {
-	routersInput := &appmesh.ListVirtualRoutersInput{
+	routersPaginator := appmesh.NewListVirtualRoutersPaginator(svc, &appmesh.ListVirtualRoutersInput{
 		MeshName: meshName,
-	}
+	})
 
-	routers, err := svc.ListVirtualRouters(context.TODO(), routersInput)
-	if err != nil {
-		fmt.Print(err)
-		return nil
-	}
 	var routeslist = []types.RouteRef{}
-	for _, routers := range routers.VirtualRouters {
-		routesInput := &appmesh.ListRoutesInput{
-			MeshName:          meshName,
-			VirtualRouterName: routers.VirtualRouterName,
-		}
-		routes, err := svc.ListRoutes(context.TODO(), routesInput)
+	for routersPaginator.HasMorePages() {
+		routersPage, err := routersPaginator.NextPage(context.TODO())
 		if err != nil {
 			fmt.Print(err)
-			continue
+			return nil
 		}
-		routeslist = append(routeslist, routes.Routes...)
+		for _, router := range routersPage.VirtualRouters {
+			routesPaginator := appmesh.NewListRoutesPaginator(svc, &appmesh.ListRoutesInput{
+				MeshName:          meshName,
+				VirtualRouterName: router.VirtualRouterName,
+			})
+			for routesPaginator.HasMorePages() {
+				routesPage, err := routesPaginator.NextPage(context.TODO())
+				if err != nil {
+					fmt.Print(err)
+					break
+				}
+				routeslist = append(routeslist, routesPage.Routes...)
+			}
+		}
 	}
 
 	return routeslist
@@ -70,54 +76,62 @@ func getAppMeshRouteDescriptions(meshName *string, svc AppMeshAPI) []*types.Rout
 	return routedetails
 }
 
-// getAllAppMeshNodes retrieves all of the VirtualNodes in the mesh
+// getAllAppMeshNodes retrieves all of the VirtualNodes in the mesh. The
+// SDK paginator is walked so meshes with many virtual nodes are not
+// truncated at the first page.
 func getAllAppMeshNodes(meshName *string, svc AppMeshAPI) []*types.VirtualNodeData {
-	nodesInput := &appmesh.ListVirtualNodesInput{
+	paginator := appmesh.NewListVirtualNodesPaginator(svc, &appmesh.ListVirtualNodesInput{
 		MeshName: meshName,
-	}
-	nodes, err := svc.ListVirtualNodes(context.TODO(), nodesInput)
-	if err != nil {
-		fmt.Print(err)
-		return nil
-	}
+	})
 	var nodelist = []*types.VirtualNodeData{}
-	for _, node := range nodes.VirtualNodes {
-		input := &appmesh.DescribeVirtualNodeInput{
-			MeshName:        node.MeshName,
-			VirtualNodeName: node.VirtualNodeName,
-		}
-		nodetails, err := svc.DescribeVirtualNode(context.TODO(), input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
 		if err != nil {
 			fmt.Print(err)
-			continue
+			return nil
 		}
-		nodelist = append(nodelist, nodetails.VirtualNode)
+		for _, node := range page.VirtualNodes {
+			input := &appmesh.DescribeVirtualNodeInput{
+				MeshName:        node.MeshName,
+				VirtualNodeName: node.VirtualNodeName,
+			}
+			nodetails, err := svc.DescribeVirtualNode(context.TODO(), input)
+			if err != nil {
+				fmt.Print(err)
+				continue
+			}
+			nodelist = append(nodelist, nodetails.VirtualNode)
+		}
 	}
 	return nodelist
 }
 
-// getAllAppMeshVirtualServices retrieves all of the VirtualServices in the mesh
+// getAllAppMeshVirtualServices retrieves all of the VirtualServices in
+// the mesh. The SDK paginator is walked so meshes with many virtual
+// services are not truncated at the first page.
 func getAllAppMeshVirtualServices(meshName *string, svc AppMeshAPI) []*types.VirtualServiceData {
-	servicesInput := &appmesh.ListVirtualServicesInput{
+	paginator := appmesh.NewListVirtualServicesPaginator(svc, &appmesh.ListVirtualServicesInput{
 		MeshName: meshName,
-	}
-	services, err := svc.ListVirtualServices(context.TODO(), servicesInput)
-	if err != nil {
-		fmt.Print(err)
-		return nil
-	}
+	})
 	var servicelist = []*types.VirtualServiceData{}
-	for _, service := range services.VirtualServices {
-		input := &appmesh.DescribeVirtualServiceInput{
-			MeshName:           service.MeshName,
-			VirtualServiceName: service.VirtualServiceName,
-		}
-		servicedetails, err := svc.DescribeVirtualService(context.TODO(), input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
 		if err != nil {
 			fmt.Print(err)
-			continue
+			return nil
 		}
-		servicelist = append(servicelist, servicedetails.VirtualService)
+		for _, service := range page.VirtualServices {
+			input := &appmesh.DescribeVirtualServiceInput{
+				MeshName:           service.MeshName,
+				VirtualServiceName: service.VirtualServiceName,
+			}
+			servicedetails, err := svc.DescribeVirtualService(context.TODO(), input)
+			if err != nil {
+				fmt.Print(err)
+				continue
+			}
+			servicelist = append(servicelist, servicedetails.VirtualService)
+		}
 	}
 	return servicelist
 }

--- a/helpers/appmesh_pagination_test.go
+++ b/helpers/appmesh_pagination_test.go
@@ -1,0 +1,251 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/appmesh"
+	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
+)
+
+// The App Mesh list helpers originally called ListVirtualRouters,
+// ListRoutes, ListVirtualNodes, and ListVirtualServices only once. Meshes
+// with enough resources to paginate had their inventory truncated at the
+// first page, producing incomplete route maps and false dangling-node
+// reports. These regression tests exercise the APIClient-style mock with a
+// multi-page response so every helper is forced to walk NextToken.
+
+// mockPaginatedAppMeshClient serves mesh resources from pre-configured
+// slices, paginating each List call by page size using NextToken. It
+// satisfies AppMeshAPI so the existing helpers can be driven by it.
+type mockPaginatedAppMeshClient struct {
+	routers  []types.VirtualRouterRef
+	routes   []types.RouteRef
+	nodes    []types.VirtualNodeRef
+	services []types.VirtualServiceRef
+
+	pageSize int
+
+	listRoutersCalls  int
+	listRoutesCalls   int
+	listNodesCalls    int
+	listServicesCalls int
+}
+
+func (m *mockPaginatedAppMeshClient) pageBounds(total int, token *string) (int, int, *string) {
+	start := 0
+	if token != nil {
+		fmt.Sscanf(*token, "%d", &start)
+	}
+	pageSize := m.pageSize
+	if pageSize <= 0 {
+		pageSize = total
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	var next *string
+	if end < total {
+		tok := fmt.Sprintf("%d", end)
+		next = &tok
+	}
+	return start, end, next
+}
+
+func (m *mockPaginatedAppMeshClient) ListVirtualRouters(_ context.Context, input *appmesh.ListVirtualRoutersInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualRoutersOutput, error) {
+	m.listRoutersCalls++
+	start, end, next := m.pageBounds(len(m.routers), input.NextToken)
+	return &appmesh.ListVirtualRoutersOutput{
+		VirtualRouters: m.routers[start:end],
+		NextToken:      next,
+	}, nil
+}
+
+func (m *mockPaginatedAppMeshClient) ListRoutes(_ context.Context, input *appmesh.ListRoutesInput, _ ...func(*appmesh.Options)) (*appmesh.ListRoutesOutput, error) {
+	m.listRoutesCalls++
+	start, end, next := m.pageBounds(len(m.routes), input.NextToken)
+	return &appmesh.ListRoutesOutput{
+		Routes:    m.routes[start:end],
+		NextToken: next,
+	}, nil
+}
+
+func (m *mockPaginatedAppMeshClient) DescribeRoute(_ context.Context, params *appmesh.DescribeRouteInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeRouteOutput, error) {
+	return &appmesh.DescribeRouteOutput{
+		Route: &types.RouteData{
+			MeshName:          params.MeshName,
+			RouteName:         params.RouteName,
+			VirtualRouterName: params.VirtualRouterName,
+			Spec:              &types.RouteSpec{},
+		},
+	}, nil
+}
+
+func (m *mockPaginatedAppMeshClient) ListVirtualNodes(_ context.Context, input *appmesh.ListVirtualNodesInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualNodesOutput, error) {
+	m.listNodesCalls++
+	start, end, next := m.pageBounds(len(m.nodes), input.NextToken)
+	return &appmesh.ListVirtualNodesOutput{
+		VirtualNodes: m.nodes[start:end],
+		NextToken:    next,
+	}, nil
+}
+
+func (m *mockPaginatedAppMeshClient) DescribeVirtualNode(_ context.Context, params *appmesh.DescribeVirtualNodeInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualNodeOutput, error) {
+	return &appmesh.DescribeVirtualNodeOutput{
+		VirtualNode: &types.VirtualNodeData{
+			MeshName:        params.MeshName,
+			VirtualNodeName: params.VirtualNodeName,
+			Spec:            &types.VirtualNodeSpec{},
+		},
+	}, nil
+}
+
+func (m *mockPaginatedAppMeshClient) ListVirtualServices(_ context.Context, input *appmesh.ListVirtualServicesInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualServicesOutput, error) {
+	m.listServicesCalls++
+	start, end, next := m.pageBounds(len(m.services), input.NextToken)
+	return &appmesh.ListVirtualServicesOutput{
+		VirtualServices: m.services[start:end],
+		NextToken:       next,
+	}, nil
+}
+
+func (m *mockPaginatedAppMeshClient) DescribeVirtualService(_ context.Context, params *appmesh.DescribeVirtualServiceInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualServiceOutput, error) {
+	return &appmesh.DescribeVirtualServiceOutput{
+		VirtualService: &types.VirtualServiceData{
+			MeshName:           params.MeshName,
+			VirtualServiceName: params.VirtualServiceName,
+			Spec:               &types.VirtualServiceSpec{},
+		},
+	}, nil
+}
+
+func makeRouterRefs(meshName string, n int) []types.VirtualRouterRef {
+	refs := make([]types.VirtualRouterRef, n)
+	for i := 0; i < n; i++ {
+		refs[i] = types.VirtualRouterRef{
+			MeshName:          aws.String(meshName),
+			VirtualRouterName: aws.String(fmt.Sprintf("router-%03d", i)),
+		}
+	}
+	return refs
+}
+
+func makeRouteRefs(meshName, routerName string, n int) []types.RouteRef {
+	refs := make([]types.RouteRef, n)
+	for i := 0; i < n; i++ {
+		refs[i] = types.RouteRef{
+			MeshName:          aws.String(meshName),
+			VirtualRouterName: aws.String(routerName),
+			RouteName:         aws.String(fmt.Sprintf("route-%03d", i)),
+		}
+	}
+	return refs
+}
+
+func makeNodeRefs(meshName string, n int) []types.VirtualNodeRef {
+	refs := make([]types.VirtualNodeRef, n)
+	for i := 0; i < n; i++ {
+		refs[i] = types.VirtualNodeRef{
+			MeshName:        aws.String(meshName),
+			VirtualNodeName: aws.String(fmt.Sprintf("node-%03d", i)),
+		}
+	}
+	return refs
+}
+
+func makeServiceRefs(meshName string, n int) []types.VirtualServiceRef {
+	refs := make([]types.VirtualServiceRef, n)
+	for i := 0; i < n; i++ {
+		refs[i] = types.VirtualServiceRef{
+			MeshName:           aws.String(meshName),
+			VirtualServiceName: aws.String(fmt.Sprintf("service-%03d", i)),
+		}
+	}
+	return refs
+}
+
+// TestGetAllAppMeshRoutes_Pagination verifies that both ListVirtualRouters
+// and ListRoutes walk every page. Before the fix the helper only issued
+// one call per operation, so large meshes saw truncated route lists.
+func TestGetAllAppMeshRoutes_Pagination(t *testing.T) {
+	meshName := "test-mesh"
+	mock := &mockPaginatedAppMeshClient{
+		routers:  makeRouterRefs(meshName, 5),
+		routes:   makeRouteRefs(meshName, "router-000", 5),
+		pageSize: 2, // forces 3 pages per list
+	}
+
+	result := getAllAppMeshRoutes(aws.String(meshName), mock)
+
+	// Each of the 5 routers sees the same 5 routes in this fixture, so we
+	// expect 25 total routes once pagination is walked fully.
+	wantRoutes := 25
+	if len(result) != wantRoutes {
+		t.Fatalf("getAllAppMeshRoutes returned %d routes, want %d (pagination bug: routes truncated)", len(result), wantRoutes)
+	}
+
+	if mock.listRoutersCalls < 3 {
+		t.Errorf("ListVirtualRouters called %d times, want at least 3 (pagination bug: NextToken not followed)", mock.listRoutersCalls)
+	}
+	// ListRoutes is called once per router and each call paginates 3 times.
+	if mock.listRoutesCalls < 3*len(mock.routers) {
+		t.Errorf("ListRoutes called %d times, want at least %d (pagination bug: NextToken not followed)", mock.listRoutesCalls, 3*len(mock.routers))
+	}
+}
+
+// TestGetAllAppMeshNodes_Pagination verifies that ListVirtualNodes walks
+// every page. Before the fix the helper only returned the first page of
+// nodes.
+func TestGetAllAppMeshNodes_Pagination(t *testing.T) {
+	meshName := "test-mesh"
+	total := 7
+	mock := &mockPaginatedAppMeshClient{
+		nodes:    makeNodeRefs(meshName, total),
+		pageSize: 3, // forces 3 pages: [0..2], [3..5], [6]
+	}
+
+	result := getAllAppMeshNodes(aws.String(meshName), mock)
+
+	if len(result) != total {
+		t.Fatalf("getAllAppMeshNodes returned %d nodes, want %d (pagination bug: nodes truncated)", len(result), total)
+	}
+	if mock.listNodesCalls < 3 {
+		t.Errorf("ListVirtualNodes called %d times, want at least 3 (pagination bug: NextToken not followed)", mock.listNodesCalls)
+	}
+	for i, node := range result {
+		want := fmt.Sprintf("node-%03d", i)
+		if aws.ToString(node.VirtualNodeName) != want {
+			t.Errorf("result[%d].VirtualNodeName = %q, want %q", i, aws.ToString(node.VirtualNodeName), want)
+		}
+	}
+}
+
+// TestGetAllAppMeshVirtualServices_Pagination verifies that
+// ListVirtualServices walks every page. Before the fix only the first page
+// of services was returned.
+func TestGetAllAppMeshVirtualServices_Pagination(t *testing.T) {
+	meshName := "test-mesh"
+	total := 5
+	mock := &mockPaginatedAppMeshClient{
+		services: makeServiceRefs(meshName, total),
+		pageSize: 2, // forces 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := getAllAppMeshVirtualServices(aws.String(meshName), mock)
+
+	if len(result) != total {
+		t.Fatalf("getAllAppMeshVirtualServices returned %d services, want %d (pagination bug: services truncated)", len(result), total)
+	}
+	if mock.listServicesCalls < 3 {
+		t.Errorf("ListVirtualServices called %d times, want at least 3 (pagination bug: NextToken not followed)", mock.listServicesCalls)
+	}
+	for i, svc := range result {
+		want := fmt.Sprintf("service-%03d", i)
+		if aws.ToString(svc.VirtualServiceName) != want {
+			t.Errorf("result[%d].VirtualServiceName = %q, want %q", i, aws.ToString(svc.VirtualServiceName), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `getAllAppMeshRoutes`, `getAllAppMeshNodes`, and `getAllAppMeshVirtualServices` in `helpers/appmesh.go` issued single-page `ListVirtualRouters` / `ListRoutes` / `ListVirtualNodes` / `ListVirtualServices` calls, silently discarding `NextToken`. Large meshes saw truncated inventory and `GetAllUnservicedAppMeshNodes` produced false dangling-node reports.
- Switched each helper to the matching SDK paginator (`NewListVirtualRoutersPaginator`, `NewListRoutesPaginator`, `NewListVirtualNodesPaginator`, `NewListVirtualServicesPaginator`). The existing `AppMeshAPI` interface already declares the methods those paginators need, so public signatures are unchanged.
- Added regression tests in `helpers/appmesh_pagination_test.go` using an APIClient-style mock that paginates by page size, matching the pattern used for TGW/VPC/ENI pagination tests.
- Added `docs/agent-notes/appmesh-helpers.md` documenting the helpers, pagination pattern, and the pitfall that `GetAllUnservicedAppMeshNodes` is highly sensitive to missing pages.

## Root Cause

Pagination was never applied when these helpers were written. Unlike the IAM/VPC/TGW/ENI helpers, App Mesh was not refactored to the paginator pattern — `NextToken` was discarded so anything beyond the first page was dropped.

## Test plan

- [x] `go test ./helpers/ -run 'TestGetAllAppMesh.*_Pagination'` passes (tests failed before the fix — confirmed via TDD checkpoint commit).
- [x] `go test ./...` full suite passes.
- [x] `make lint` clean (golangci-lint reports 0 issues).
- [x] `go fmt ./...` / `go vet ./...` clean.