### PR TITLE
Fix T-784: Paginate CloudFormation Resources Command

### DIFF
--- a/docs/agent-notes/cloudformation.md
+++ b/docs/agent-notes/cloudformation.md
@@ -5,12 +5,35 @@
 - `cmd/cfn.go` — parent `cfn` cobra command.
 - `cmd/cfnresources.go` — `cfn resources` subcommand; lists resources in a
   stack and its nested stacks.
-- `helpers/cfn.go` — thin wrappers around `DescribeStackResources`:
-  - `GetResourcesByStackName(stackname, svc)` returns the resources for one
-    stack. Panics on API error (legacy pattern; do not copy into new code).
+- `helpers/cfn.go` — pagination-aware wrappers around the CloudFormation
+  listing APIs:
+  - `GetResourcesByStackName(stackname, svc)` returns every resource for one
+    stack by walking `NewListStackResourcesPaginator`. Panics on API error
+    (legacy pattern; do not copy into new code).
   - `GetNestedCloudFormationResources(stackname, svc)` recursively expands
     `AWS::CloudFormation::Stack` entries by calling itself with the nested
     stack's `PhysicalResourceId`.
+- `helpers/cfn_pagination_test.go` — regression tests for T-784 using a
+  mock `cloudformation.ListStackResourcesAPIClient`.
+
+## Why ListStackResources, not DescribeStackResources
+
+The older `DescribeStackResources` API caps responses at 100 resources and
+does not expose a `NextToken`, so it cannot be paginated. The AWS SDK's
+`ListStackResources` exposes `NewListStackResourcesPaginator` and has no
+such cap. We use it and convert each `StackResourceSummary` to the existing
+`types.StackResource` shape so consumers (notably `cmd/cfnresources.go`)
+stay unchanged. `StackName` is filled in from the input because summaries
+do not repeat it per row (T-784).
+
+## Testable interface pattern
+
+The public helpers take `*cloudformation.Client`, but the actual work is
+done in private functions that take `cloudformation.ListStackResourcesAPIClient`.
+This matches the pattern used for TGW and ENI helpers and lets tests provide
+a paginated mock without a real SDK client. See
+`helpers/cfn_pagination_test.go` and `helpers/tgw_pagination_test.go` for
+reference implementations of the mock.
 
 ## Gotchas
 
@@ -18,12 +41,10 @@
   returns nil while a resource is still in `CREATE_IN_PROGRESS` without a
   physical id yet, and for some resource types it stays nil. Always guard
   before dereferencing (T-733).
-- `GetNestedCloudFormationResources` passes `resource.PhysicalResourceId`
-  directly into the recursive call. For `AWS::CloudFormation::Stack`
-  resources this is usually set once the nested stack has been created, but
-  if it is nil the recursive `DescribeStackResources` call would re-describe
-  the top-level stack (since `StackName` defaults to the current stack when
-  the pointer is nil). Worth tightening if a regression is reported.
+- `getNestedCloudFormationResources` skips nested-stack entries whose
+  `PhysicalResourceId` is nil or empty. Without that guard, `ListStackResources`
+  would treat a nil `StackName` as a reference to the parent and re-describe
+  it, duplicating resources or causing runaway recursion.
 
 ## Testable conversion pattern
 

--- a/helpers/cfn.go
+++ b/helpers/cfn.go
@@ -8,31 +8,93 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 )
 
-// GetResourcesByStackName returns a slice of the Stack Resources in the provided stack
+// GetResourcesByStackName returns every resource in the provided stack. It
+// walks the ListStackResources paginator so stacks with more than 100
+// resources are handled correctly; DescribeStackResources silently caps its
+// response at 100 and offers no continuation token (T-784).
 func GetResourcesByStackName(stackname *string, svc *cloudformation.Client) []types.StackResource {
-	params := &cloudformation.DescribeStackResourcesInput{
-		StackName: stackname,
-	}
-	resp, err := svc.DescribeStackResources(context.TODO(), params)
-
-	if err != nil {
-		panic(err)
-	}
-
-	// Pretty-print the response data.
-	return resp.StackResources
+	return getResourcesByStackName(stackname, svc)
 }
 
-// GetNestedCloudFormationResources retrieves a slice of the Stack Resources that
-// are in the provided stack or in one of its children
+// GetNestedCloudFormationResources retrieves every resource in the provided
+// stack plus those of any nested stacks it contains. Each level is paginated
+// independently.
 func GetNestedCloudFormationResources(stackname *string, svc *cloudformation.Client) []types.StackResource {
-	resources := GetResourcesByStackName(stackname, svc)
-	result := make([]types.StackResource, 0, len(resources))
-	for _, resource := range resources {
-		result = append(result, resource)
-		if aws.ToString(resource.ResourceType) == "AWS::CloudFormation::Stack" {
-			result = append(result, GetNestedCloudFormationResources(resource.PhysicalResourceId, svc)...)
+	return getNestedCloudFormationResources(stackname, svc)
+}
+
+// getResourcesByStackName is the testable implementation behind
+// GetResourcesByStackName. It takes the narrow ListStackResourcesAPIClient
+// interface so tests can provide a paginated mock without a real SDK client.
+//
+// ListStackResources returns StackResourceSummary values, which omit the
+// StackName field; the helper backfills it from the input so downstream
+// consumers (notably cmd/cfnresources.go's buildCfnResource) keep the
+// originating stack name for each resource.
+func getResourcesByStackName(stackname *string, svc cloudformation.ListStackResourcesAPIClient) []types.StackResource {
+	paginator := cloudformation.NewListStackResourcesPaginator(svc, &cloudformation.ListStackResourcesInput{
+		StackName: stackname,
+	})
+	var result []types.StackResource
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		for _, summary := range page.StackResourceSummaries {
+			result = append(result, stackResourceFromSummary(summary, stackname))
 		}
 	}
 	return result
+}
+
+// getNestedCloudFormationResources is the testable implementation behind
+// GetNestedCloudFormationResources. A nested-stack entry with a nil
+// PhysicalResourceId is skipped rather than recursed into — passing a nil
+// StackName to ListStackResources would otherwise re-describe the parent
+// stack, leading to duplicates or infinite recursion.
+func getNestedCloudFormationResources(stackname *string, svc cloudformation.ListStackResourcesAPIClient) []types.StackResource {
+	resources := getResourcesByStackName(stackname, svc)
+	result := make([]types.StackResource, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, resource)
+		if aws.ToString(resource.ResourceType) != "AWS::CloudFormation::Stack" {
+			continue
+		}
+		if resource.PhysicalResourceId == nil || aws.ToString(resource.PhysicalResourceId) == "" {
+			continue
+		}
+		result = append(result, getNestedCloudFormationResources(resource.PhysicalResourceId, svc)...)
+	}
+	return result
+}
+
+// stackResourceFromSummary converts a ListStackResources summary into the
+// StackResource shape the rest of the codebase already consumes. StackName is
+// taken from the input because ListStackResources does not repeat it per row.
+func stackResourceFromSummary(summary types.StackResourceSummary, stackname *string) types.StackResource {
+	return types.StackResource{
+		StackName:            stackname,
+		LogicalResourceId:    summary.LogicalResourceId,
+		PhysicalResourceId:   summary.PhysicalResourceId,
+		ResourceType:         summary.ResourceType,
+		ResourceStatus:       summary.ResourceStatus,
+		Timestamp:            summary.LastUpdatedTimestamp,
+		ResourceStatusReason: summary.ResourceStatusReason,
+		DriftInformation:     driftInfoFromSummary(summary.DriftInformation),
+		ModuleInfo:           summary.ModuleInfo,
+	}
+}
+
+// driftInfoFromSummary converts the summary-shaped drift information into the
+// resource-shaped drift information expected by StackResource. Returns nil
+// when there is nothing to convert.
+func driftInfoFromSummary(summary *types.StackResourceDriftInformationSummary) *types.StackResourceDriftInformation {
+	if summary == nil {
+		return nil
+	}
+	return &types.StackResourceDriftInformation{
+		StackResourceDriftStatus: summary.StackResourceDriftStatus,
+		LastCheckTimestamp:       summary.LastCheckTimestamp,
+	}
 }

--- a/helpers/cfn_pagination_test.go
+++ b/helpers/cfn_pagination_test.go
@@ -1,0 +1,219 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+// Regression tests for T-784: `helpers.GetResourcesByStackName` previously
+// issued a single `DescribeStackResources` call. The AWS API caps that
+// response at 100 resources and the SDK exposes no paginator for it, so
+// stacks with more than 100 resources were silently truncated — both for the
+// top-level stack and for any nested stack discovered through
+// `GetNestedCloudFormationResources`. The fix is to switch to
+// `ListStackResources`, which paginates via `NextToken`.
+
+// mockListStackResourcesAPIClient implements
+// cloudformation.ListStackResourcesAPIClient and paginates the provided
+// resource summaries using a fixed page size. It records how many pages
+// were served per stack so tests can prove the helper walks every page.
+type mockListStackResourcesAPIClient struct {
+	// pages maps a stack name to the full slice of summaries for that stack.
+	pages map[string][]types.StackResourceSummary
+	// pageSize controls how many summaries are returned per response. A
+	// value of 0 means "return everything in one page".
+	pageSize int
+	// callsByStack records the number of ListStackResources calls made per
+	// stack name so tests can assert multi-page traversal.
+	callsByStack map[string]int
+}
+
+func newMockListStackResourcesAPIClient(pageSize int) *mockListStackResourcesAPIClient {
+	return &mockListStackResourcesAPIClient{
+		pages:        map[string][]types.StackResourceSummary{},
+		pageSize:     pageSize,
+		callsByStack: map[string]int{},
+	}
+}
+
+func (m *mockListStackResourcesAPIClient) ListStackResources(_ context.Context, input *cloudformation.ListStackResourcesInput, _ ...func(*cloudformation.Options)) (*cloudformation.ListStackResourcesOutput, error) {
+	stack := aws.ToString(input.StackName)
+	m.callsByStack[stack]++
+	summaries, ok := m.pages[stack]
+	if !ok {
+		return &cloudformation.ListStackResourcesOutput{}, nil
+	}
+	start := 0
+	if input.NextToken != nil {
+		if _, err := fmt.Sscanf(*input.NextToken, "%d", &start); err != nil {
+			return nil, err
+		}
+	}
+	pageSize := m.pageSize
+	if pageSize == 0 {
+		pageSize = len(summaries)
+	}
+	end := start + pageSize
+	if end > len(summaries) {
+		end = len(summaries)
+	}
+	out := &cloudformation.ListStackResourcesOutput{
+		StackResourceSummaries: summaries[start:end],
+	}
+	if end < len(summaries) {
+		token := fmt.Sprintf("%d", end)
+		out.NextToken = &token
+	}
+	return out, nil
+}
+
+// makeStackResourceSummaries generates n synthetic resource summaries with
+// predictable logical and physical ids so tests can assert completeness
+// across pages.
+func makeStackResourceSummaries(n int) []types.StackResourceSummary {
+	result := make([]types.StackResourceSummary, n)
+	for i := 0; i < n; i++ {
+		result[i] = types.StackResourceSummary{
+			LogicalResourceId:  aws.String(fmt.Sprintf("Logical%04d", i)),
+			PhysicalResourceId: aws.String(fmt.Sprintf("physical-%04d", i)),
+			ResourceType:       aws.String("AWS::S3::Bucket"),
+			ResourceStatus:     types.ResourceStatusCreateComplete,
+		}
+	}
+	return result
+}
+
+// TestGetResourcesByStackName_Pagination proves that the helper walks every
+// page of ListStackResources. Before the fix it called DescribeStackResources
+// once and returned at most 100 resources regardless of how many the stack
+// actually contained.
+func TestGetResourcesByStackName_Pagination(t *testing.T) {
+	const stack = "test-stack"
+	// 250 resources forces three pages at page size 100 — analogous to the
+	// real-world 100-resource AWS cap that triggered the bug.
+	total := 250
+	mock := newMockListStackResourcesAPIClient(100)
+	mock.pages[stack] = makeStackResourceSummaries(total)
+
+	name := stack
+	result := getResourcesByStackName(&name, mock)
+
+	if len(result) != total {
+		t.Fatalf("getResourcesByStackName() returned %d resources, want %d (pagination bug: only first page returned)", len(result), total)
+	}
+	if mock.callsByStack[stack] != 3 {
+		t.Errorf("ListStackResources called %d times for %q, want 3 (one per page)", mock.callsByStack[stack], stack)
+	}
+	for i, resource := range result {
+		wantLogical := fmt.Sprintf("Logical%04d", i)
+		wantPhysical := fmt.Sprintf("physical-%04d", i)
+		if aws.ToString(resource.LogicalResourceId) != wantLogical {
+			t.Errorf("result[%d].LogicalResourceId = %s, want %s", i, aws.ToString(resource.LogicalResourceId), wantLogical)
+		}
+		if aws.ToString(resource.PhysicalResourceId) != wantPhysical {
+			t.Errorf("result[%d].PhysicalResourceId = %s, want %s", i, aws.ToString(resource.PhysicalResourceId), wantPhysical)
+		}
+		// StackName is populated from the input so callers and the
+		// `cfn resources` output retain the originating stack for each
+		// resource (StackResourceSummary itself has no StackName field).
+		if aws.ToString(resource.StackName) != stack {
+			t.Errorf("result[%d].StackName = %q, want %q", i, aws.ToString(resource.StackName), stack)
+		}
+	}
+}
+
+// TestGetNestedCloudFormationResources_PaginatesNested proves that
+// GetNestedCloudFormationResources paginates both the parent stack and any
+// nested stacks it discovers. Previously the recursion truncated each level
+// at 100 resources.
+func TestGetNestedCloudFormationResources_PaginatesNested(t *testing.T) {
+	const parent = "parent-stack"
+	const nested = "nested-stack"
+
+	mock := newMockListStackResourcesAPIClient(100)
+
+	// Build a parent with 150 regular resources plus one nested-stack
+	// resource pointing at `nested`.
+	parentResources := makeStackResourceSummaries(150)
+	parentResources = append(parentResources, types.StackResourceSummary{
+		LogicalResourceId:  aws.String("NestedChild"),
+		PhysicalResourceId: aws.String(nested),
+		ResourceType:       aws.String("AWS::CloudFormation::Stack"),
+		ResourceStatus:     types.ResourceStatusCreateComplete,
+	})
+	mock.pages[parent] = parentResources
+
+	// Build a nested stack with 150 resources of its own.
+	mock.pages[nested] = makeStackResourceSummaries(150)
+
+	name := parent
+	result := getNestedCloudFormationResources(&name, mock)
+
+	// Expect every resource from both levels: 150 + 1 (nested marker) + 150.
+	wantTotal := 150 + 1 + 150
+	if len(result) != wantTotal {
+		t.Fatalf("getNestedCloudFormationResources() returned %d resources, want %d", len(result), wantTotal)
+	}
+
+	// Count resources by stack to make sure each level was fully walked.
+	byStack := map[string]int{}
+	for _, r := range result {
+		byStack[aws.ToString(r.StackName)]++
+	}
+	if byStack[parent] != 151 {
+		t.Errorf("parent stack contributed %d resources, want 151", byStack[parent])
+	}
+	if byStack[nested] != 150 {
+		t.Errorf("nested stack contributed %d resources, want 150", byStack[nested])
+	}
+
+	// Parent needs 2 pages (150 items at pageSize 100 = pages of 100 + 50 +
+	// the nested marker on the second page), nested needs 2 pages.
+	if mock.callsByStack[parent] != 2 {
+		t.Errorf("ListStackResources for parent called %d times, want 2", mock.callsByStack[parent])
+	}
+	if mock.callsByStack[nested] != 2 {
+		t.Errorf("ListStackResources for nested called %d times, want 2", mock.callsByStack[nested])
+	}
+}
+
+// TestGetNestedCloudFormationResources_SkipsNestedWithoutPhysicalID ensures a
+// nested stack entry missing its PhysicalResourceId does not trigger a
+// recursive call (which would otherwise re-describe the parent because a nil
+// StackName defaults to the current stack on the AWS side).
+func TestGetNestedCloudFormationResources_SkipsNestedWithoutPhysicalID(t *testing.T) {
+	const parent = "parent-stack"
+	mock := newMockListStackResourcesAPIClient(0)
+	mock.pages[parent] = []types.StackResourceSummary{
+		{
+			LogicalResourceId: aws.String("OrphanNested"),
+			// PhysicalResourceId intentionally nil.
+			ResourceType:   aws.String("AWS::CloudFormation::Stack"),
+			ResourceStatus: types.ResourceStatusCreateInProgress,
+		},
+	}
+
+	name := parent
+	result := getNestedCloudFormationResources(&name, mock)
+
+	if len(result) != 1 {
+		t.Fatalf("expected only the orphan nested entry, got %d resources", len(result))
+	}
+	if mock.callsByStack[parent] != 1 {
+		t.Errorf("parent stack called %d times, want 1 (no recursion for nil PhysicalResourceId)", mock.callsByStack[parent])
+	}
+	// Ensure no attempt was made to recurse using an empty string key either.
+	for stack, calls := range mock.callsByStack {
+		if stack != parent && calls > 0 {
+			if strings.TrimSpace(stack) == "" {
+				t.Errorf("helper recursed with empty stack name")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `awstools cfn resources` used `DescribeStackResources`, which AWS caps at 100 resources per response with no continuation token. Stacks with more than 100 resources (or nested stacks past that boundary) were silently truncated.
- Switch `helpers.GetResourcesByStackName` to `ListStackResources` via `NewListStackResourcesPaginator`, converting each `StackResourceSummary` back into the existing `types.StackResource` shape so `cmd/cfnresources.go` (and `buildCfnResource` from T-733) keep working unchanged.
- Introduce private helpers that take the narrow `cloudformation.ListStackResourcesAPIClient` interface so pagination can be tested with a mock. Guard the nested-stack recursion against nil / empty `PhysicalResourceId` to avoid re-describing the parent stack.

## Test plan

- [x] `go test ./helpers/ -run 'TestGetResourcesByStackName_Pagination|TestGetNestedCloudFormationResources_PaginatesNested|TestGetNestedCloudFormationResources_SkipsNestedWithoutPhysicalID'`
- [x] `make test`
- [x] `make lint`
- [x] `go fmt ./...` / `go vet ./...`