### PR TITLE
Fix T-774: Prevent IPv6 subnet enumeration in vpc overview

### DIFF
--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -116,6 +116,30 @@ table. The blackhole-route helper just logs a warning on overflow because
 blackhole routes are normally few. Never rely on a single unfiltered
 `SearchTransitGatewayRoutes` call in a large account.
 
+## VPC Overview IP Analysis (T-774)
+
+`GetVPCUsageOverview` and its `analyzeSubnetIPUsage` helper enumerate every
+IPv4 address in each subnet's CIDR for per-IP analysis. **Never call the
+underlying `generateIPRange` with an IPv6 CIDR** — a default /64 contains 2^64
+addresses. After T-774:
+
+- `generateIPRange` rejects IPv6 CIDRs with an explicit error.
+- `calculateSubnetStats` caps totals at `math.MaxInt` for prefixes where
+  `2^hostBits` would overflow a signed int (host bits >= 63).
+- `analyzeSubnetIPUsage` returns empty results without error when
+  `subnet.CidrBlock` is empty (IPv6-only subnets). The caller previously
+  panicked.
+- `GetVPCUsageOverview` uses `firstIPv6CIDR(subnet)` as a display fallback when
+  no IPv4 CIDR exists, so IPv6-only subnets still appear in the overview with
+  their CIDR but no per-address breakdown.
+
+Dual-stack subnets continue to have their IPv4 portion analysed; the IPv6
+block is shown separately by the caller logic only when no IPv4 CIDR exists.
+
+Tests live in `helpers/ec2_ipv6_subnet_test.go` and use a 2 s timeout guard so
+a regression that re-introduces IPv6 enumeration fails loudly rather than
+hanging the test process.
+
 ## VPN Connections API
 
 `DescribeVpnConnections` is **not** a paginated AWS API — the input/output

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"os"
 	"regexp"
@@ -997,16 +998,43 @@ func GetVPCUsageOverview(svc *ec2.Client) VPCOverview {
 			if aws.ToString(subnet.VpcId) == vpcID {
 				subnetCidr := aws.ToString(subnet.CidrBlock)
 				subnetID := aws.ToString(subnet.SubnetId)
+
+				// IPv6-only subnets have no IPv4 CidrBlock. Fall back to the
+				// first associated IPv6 CIDR for display and stats so the
+				// subnet still appears in the overview. Per-address analysis
+				// is skipped for IPv6 because the address space is too large
+				// to enumerate (T-774).
+				statsCidr := subnetCidr
+				if statsCidr == "" {
+					statsCidr = firstIPv6CIDR(subnet)
+				}
+				if subnetCidr == "" {
+					subnetCidr = statsCidr
+				}
+
 				// Calculate total IPs
-				totalIPs, _, err := calculateSubnetStats(subnetCidr)
-				if err != nil {
-					panic(err)
+				var totalIPs int
+				if statsCidr != "" {
+					computedTotal, _, err := calculateSubnetStats(statsCidr)
+					if err != nil {
+						panic(err)
+					}
+					totalIPs = computedTotal
 				}
 
 				// Analyze detailed IP usage
 				ipDetails, usedIPs, availableIPs, awsReservedIPs, serviceIPs, err := analyzeSubnetIPUsage(subnet, networkInterfaces, svc)
 				if err != nil {
 					panic(err)
+				}
+
+				// For IPv6-only subnets analyzeSubnetIPUsage returns zero
+				// counts. Use the mathematically-computed available count so
+				// the summary reflects the subnet size rather than 0.
+				if aws.ToString(subnet.CidrBlock) == "" {
+					if _, computedAvailable, err := calculateSubnetStats(statsCidr); err == nil {
+						availableIPs = computedAvailable
+					}
 				}
 
 				subnetInfo := SubnetUsageInfo{
@@ -1199,11 +1227,39 @@ func parseCIDR(cidr string) (*net.IPNet, error) {
 	return ipnet, err
 }
 
-// generateIPRange generates all IP addresses in a subnet CIDR block
+// firstIPv6CIDR returns the first associated IPv6 CIDR block for the subnet,
+// or an empty string if none exists. Used as a fallback when a subnet has no
+// IPv4 CidrBlock (IPv6-only subnets).
+func firstIPv6CIDR(subnet types.Subnet) string {
+	for _, assoc := range subnet.Ipv6CidrBlockAssociationSet {
+		if assoc.Ipv6CidrBlock != nil && *assoc.Ipv6CidrBlock != "" {
+			return *assoc.Ipv6CidrBlock
+		}
+	}
+	return ""
+}
+
+// isIPv6CIDR reports whether the given parsed CIDR is IPv6. An IPv4 CIDR parsed
+// by net.ParseCIDR has a 4-byte IP; IPv6 CIDRs have 16-byte IPs and cannot be
+// reduced via To4.
+func isIPv6CIDR(ipnet *net.IPNet) bool {
+	if ipnet == nil {
+		return false
+	}
+	return ipnet.IP.To4() == nil
+}
+
+// generateIPRange generates all IP addresses in a subnet CIDR block.
+// IPv6 CIDRs are rejected: a default /64 contains 2^64 addresses which cannot
+// be materialized in memory. Callers that need to report IPv6 subnets should
+// do so without per-address enumeration (T-774).
 func generateIPRange(cidr string) ([]net.IP, error) {
 	ipnet, err := parseCIDR(cidr)
 	if err != nil {
 		return nil, err
+	}
+	if isIPv6CIDR(ipnet) {
+		return nil, fmt.Errorf("IPv6 CIDR enumeration is not supported: %s", cidr)
 	}
 
 	var ips []net.IP
@@ -1224,7 +1280,16 @@ func incrementIP(ip net.IP) {
 	}
 }
 
-// calculateSubnetStats calculates total and available IP counts for a subnet
+// calculateSubnetStats calculates total and available IP counts for a subnet.
+//
+// For IPv4 subnets AWS reserves the first 4 addresses (network, VPC router,
+// DNS, future use) and the broadcast address.
+//
+// For IPv6 subnets the address space is effectively unlimited (a /64 has 2^64
+// addresses, which does not fit in an int). Rather than overflow with a naive
+// `1 << uint(bits-ones)` shift, we cap the returned total at math.MaxInt and
+// compute available IPs via the same 5-address AWS reservation rule. The cap
+// signals "effectively unlimited" without panicking or returning 0 (T-774).
 func calculateSubnetStats(cidr string) (int, int, error) {
 	ipnet, err := parseCIDR(cidr)
 	if err != nil {
@@ -1232,9 +1297,20 @@ func calculateSubnetStats(cidr string) (int, int, error) {
 	}
 
 	ones, bits := ipnet.Mask.Size()
-	totalIPs := 1 << uint(bits-ones)
+	hostBits := bits - ones
 
-	// AWS reserves first 4 and last IP in each subnet
+	// For any prefix where 2^hostBits would overflow a signed int, cap at
+	// math.MaxInt. On 64-bit platforms int is 64-bit, so the overflow point
+	// is hostBits >= 63 (signed-bit).
+	var totalIPs int
+	if hostBits >= 63 {
+		totalIPs = math.MaxInt
+	} else {
+		totalIPs = 1 << uint(hostBits)
+	}
+
+	// AWS reserves 5 addresses per subnet. For a cap'd total, subtracting 5
+	// is still meaningful ("effectively unlimited minus reserved").
 	availableIPs := max(totalIPs-5, 0)
 
 	return totalIPs, availableIPs, nil
@@ -1511,12 +1587,21 @@ func getENIAttachmentDetailsOptimized(eni types.NetworkInterface, cache *ENILook
 //   - serviceIPs: Count of IPs allocated to AWS services or EC2 instances
 //   - error: Any error encountered during analysis
 //
+// IPv6-only subnets (Ipv6Native=true, no IPv4 CidrBlock) return empty results
+// without error: IPv6 per-address analysis is not supported because the default
+// /64 prefix contains 2^64 addresses. Dual-stack subnets are analysed using
+// their IPv4 CIDR only (T-774).
+//
 // Note: This function uses optimized batch API calls via ENILookupCache to avoid N+1 queries
 // when analyzing large numbers of network interfaces.
 func analyzeSubnetIPUsage(subnet types.Subnet, networkInterfaces []types.NetworkInterface, svc *ec2.Client) ([]IPAddressInfo, int, int, int, int, error) {
 	cidr := aws.ToString(subnet.CidrBlock)
 	if cidr == "" {
-		return nil, 0, 0, 0, 0, fmt.Errorf("subnet has no CIDR block")
+		// IPv6-only / IPv6-native subnet: no IPv4 CIDR to enumerate. Per-IP
+		// analysis is skipped because the IPv6 address space is too large to
+		// materialize. The subnet is still reported by the caller using its
+		// IPv6 CIDR.
+		return nil, 0, 0, 0, 0, nil
 	}
 
 	// Get all IPs in the subnet

--- a/helpers/ec2_ipv6_subnet_test.go
+++ b/helpers/ec2_ipv6_subnet_test.go
@@ -1,0 +1,166 @@
+package helpers
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestGenerateIPRange_IPv6CIDRRejected verifies that generateIPRange refuses
+// to enumerate IPv6 CIDRs. Prior to T-774 it would attempt to iterate every
+// address — for a /64 that is 2^64 addresses, which exhausts memory.
+func TestGenerateIPRange_IPv6CIDRRejected(t *testing.T) {
+	done := make(chan struct{})
+	var ips []net.IP
+	var err error
+
+	go func() {
+		defer close(done)
+		ips, err = generateIPRange("2001:db8::/64")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("generateIPRange did not return within 2s — likely enumerating the full IPv6 range")
+	}
+
+	if err == nil {
+		t.Fatalf("expected an error for IPv6 CIDR, got nil (returned %d IPs)", len(ips))
+	}
+}
+
+// TestGenerateIPRange_IPv4StillWorks ensures the IPv4 code path is unchanged.
+func TestGenerateIPRange_IPv4StillWorks(t *testing.T) {
+	ips, err := generateIPRange("10.0.0.0/30")
+	if err != nil {
+		t.Fatalf("unexpected error for IPv4 /30: %v", err)
+	}
+	// /30 has 4 addresses
+	if len(ips) != 4 {
+		t.Fatalf("expected 4 IPs, got %d", len(ips))
+	}
+	expected := []string{"10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3"}
+	for i, want := range expected {
+		if ips[i].String() != want {
+			t.Errorf("ip[%d] = %s, want %s", i, ips[i].String(), want)
+		}
+	}
+}
+
+// TestCalculateSubnetStats_IPv6DoesNotOverflow verifies that calculateSubnetStats
+// returns a sensible (non-panicking, non-overflowing) result for IPv6 CIDRs.
+// Prior to T-774 it used `1 << uint(bits-ones)` which is undefined for shifts
+// >= 64 and produces 0 on 64-bit platforms.
+func TestCalculateSubnetStats_IPv6DoesNotOverflow(t *testing.T) {
+	total, available, err := calculateSubnetStats("2001:db8::/64")
+	if err != nil {
+		t.Fatalf("unexpected error for IPv6 /64: %v", err)
+	}
+	if total <= 0 {
+		t.Errorf("expected total IPs > 0 for IPv6 /64, got %d", total)
+	}
+	if available < 0 {
+		t.Errorf("available IPs should not be negative, got %d", available)
+	}
+}
+
+// TestAnalyzeSubnetIPUsage_IPv6NativeSubnetDoesNotPanic verifies that an
+// IPv6-native subnet (no IPv4 CIDR) is handled gracefully. Prior to T-774
+// analyzeSubnetIPUsage returned "subnet has no CIDR block" which the caller
+// turned into a panic.
+func TestAnalyzeSubnetIPUsage_IPv6NativeSubnetDoesNotPanic(t *testing.T) {
+	subnet := types.Subnet{
+		SubnetId:   aws.String("subnet-ipv6-only"),
+		VpcId:      aws.String("vpc-12345"),
+		Ipv6Native: aws.Bool(true),
+		Ipv6CidrBlockAssociationSet: []types.SubnetIpv6CidrBlockAssociation{
+			{
+				Ipv6CidrBlock: aws.String("2001:db8::/64"),
+				Ipv6CidrBlockState: &types.SubnetCidrBlockState{
+					State: types.SubnetCidrBlockStateCodeAssociated,
+				},
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	var err error
+	var panicValue any
+
+	go func() {
+		defer close(done)
+		defer func() {
+			panicValue = recover()
+		}()
+		_, _, _, _, _, err = analyzeSubnetIPUsage(subnet, nil, nil)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("analyzeSubnetIPUsage did not return within 2s — likely enumerating the full IPv6 range")
+	}
+
+	if panicValue != nil {
+		t.Fatalf("analyzeSubnetIPUsage panicked on IPv6-native subnet: %v", panicValue)
+	}
+	if err != nil {
+		t.Errorf("IPv6-native subnet should be handled without error, got: %v", err)
+	}
+}
+
+// TestAnalyzeSubnetIPUsage_DualStackOnlyEnumeratesIPv4 verifies that a subnet
+// with both an IPv4 CIDR and an IPv6 CIDR association enumerates only IPv4
+// addresses. IPv6 is too large to enumerate and should be ignored for per-IP
+// analysis.
+func TestAnalyzeSubnetIPUsage_DualStackOnlyEnumeratesIPv4(t *testing.T) {
+	subnet := types.Subnet{
+		SubnetId:  aws.String("subnet-dual"),
+		VpcId:     aws.String("vpc-12345"),
+		CidrBlock: aws.String("10.0.0.0/28"), // 16 IPs
+		Ipv6CidrBlockAssociationSet: []types.SubnetIpv6CidrBlockAssociation{
+			{
+				Ipv6CidrBlock: aws.String("2001:db8::/64"),
+				Ipv6CidrBlockState: &types.SubnetCidrBlockState{
+					State: types.SubnetCidrBlockStateCodeAssociated,
+				},
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	var usedIPs, availableIPs, awsReserved, serviceIPs int
+	var err error
+
+	go func() {
+		defer close(done)
+		_, usedIPs, availableIPs, awsReserved, serviceIPs, err = analyzeSubnetIPUsage(subnet, nil, nil)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("analyzeSubnetIPUsage did not return within 2s — likely enumerating IPv6 addresses")
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// /28 has 16 IPs; 5 are AWS-reserved (first 4 + broadcast), 0 are service.
+	if usedIPs != 5 {
+		t.Errorf("expected 5 used IPs for /28 reserved, got %d", usedIPs)
+	}
+	if availableIPs != 11 {
+		t.Errorf("expected 11 available IPs, got %d", availableIPs)
+	}
+	if awsReserved != 5 {
+		t.Errorf("expected 5 AWS-reserved IPs, got %d", awsReserved)
+	}
+	if serviceIPs != 0 {
+		t.Errorf("expected 0 service IPs, got %d", serviceIPs)
+	}
+}


### PR DESCRIPTION
## Summary

`awstools vpc overview` enumerated every address in each subnet's CIDR for per-IP analysis, which broke for IPv6:
- IPv6-native subnets (no IPv4 `CidrBlock`) panicked with `subnet has no CIDR block`.
- Any future call passing an IPv6 CIDR to `generateIPRange` would hang trying to allocate 2^64 IPs, and `calculateSubnetStats` would silently return 0 from a shift overflow.

## Changes

- `helpers/ec2.go` — `generateIPRange` rejects IPv6 CIDRs explicitly.
- `helpers/ec2.go` — `calculateSubnetStats` caps totals at `math.MaxInt` for prefixes where `2^hostBits` would overflow a signed int (host bits >= 63).
- `helpers/ec2.go` — `analyzeSubnetIPUsage` treats an empty IPv4 `CidrBlock` as IPv6-only and returns empty results without error.
- `helpers/ec2.go` — `GetVPCUsageOverview` falls back to the first associated IPv6 CIDR so IPv6-only subnets still appear in the overview (with their CIDR but no per-address breakdown).
- `helpers/ec2_ipv6_subnet_test.go` — new regression tests with a 2 s timeout guard so a re-introduced IPv6 enumeration fails loudly rather than hanging.
- `docs/agent-notes/ec2-helpers.md` — captured the IPv6 handling rules for future agents.

IPv4 behaviour is unchanged.

## Test plan

- [x] `go test ./helpers/ -run "IPv6|DualStack" -timeout 30s`
- [x] `go test ./...`
- [x] `make check` (fmt, vet, golangci-lint, tests)