### PR TITLE
Fix T-848: Preserve Case When Resolving AWS Profile Names

### DIFF
--- a/config/awsconfig.go
+++ b/config/awsconfig.go
@@ -29,8 +29,11 @@ type AWSConfig struct {
 }
 
 // resolveProfile returns the AWS profile name from configuration, or empty if none is set.
+// AWS profile names are case-sensitive (they are matched verbatim against the
+// [profile ...] section headers in ~/.aws/config), so the raw value is returned
+// via GetString rather than the case-normalising GetLCString.
 func resolveProfile(config Config) string {
-	return config.GetLCString("aws.profile")
+	return config.GetString("aws.profile")
 }
 
 // DefaultAwsConfig loads default AWS Config

--- a/config/awsconfig_test.go
+++ b/config/awsconfig_test.go
@@ -118,7 +118,7 @@ func TestDefaultAwsConfig_ProfileHandling(t *testing.T) {
 }
 
 // Regression test for T-405: aws.profile was checked but not passed to WithSharedConfigProfile.
-// The bug was that GetLCString("profile") was used instead of GetLCString("aws.profile"),
+// The bug was that the wrong viper key ("profile" instead of "aws.profile") was used,
 // meaning the profile value was always empty and the default profile was loaded.
 func TestDefaultAwsConfig_ProfileKeyConsistency(t *testing.T) {
 	config := Config{}
@@ -127,11 +127,11 @@ func TestDefaultAwsConfig_ProfileKeyConsistency(t *testing.T) {
 	defer viper.Reset()
 
 	// "aws.profile" is the key set by the --profile flag and config file
-	assert.Equal(t, "my-test-profile", config.GetLCString("aws.profile"),
+	assert.Equal(t, "my-test-profile", config.GetString("aws.profile"),
 		"aws.profile should return the configured profile name")
 
 	// "profile" (without aws. prefix) is never set — using it was the bug
-	assert.Empty(t, config.GetLCString("profile"),
+	assert.Empty(t, config.GetString("profile"),
 		"profile (without aws. prefix) should be empty; using this key loses the profile value")
 }
 
@@ -156,6 +156,35 @@ func TestDefaultAwsConfig_NoProfileReturnsEmpty(t *testing.T) {
 	profile := resolveProfile(config)
 	assert.Empty(t, profile,
 		"resolveProfile should return empty when no profile is configured")
+}
+
+// Regression test for T-848: resolveProfile lowercased the profile name via
+// GetLCString, but AWS profile names are case-sensitive. A profile named
+// "MyCompany-prod" in ~/.aws/config is not the same as "mycompany-prod"
+// and lowering the case causes the shared config loader to miss the profile.
+func TestDefaultAwsConfig_ProfilePreservesCase(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile string
+	}{
+		{"mixed case", "MyCompany-prod"},
+		{"upper case", "PROD"},
+		{"camel case", "ProdAccount"},
+		{"mixed with digits", "Team1-Dev"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := Config{}
+			viper.Reset()
+			viper.Set("aws.profile", tc.profile)
+			defer viper.Reset()
+
+			profile := resolveProfile(config)
+			assert.Equal(t, tc.profile, profile,
+				"resolveProfile must preserve the exact case of the configured profile name")
+		})
+	}
 }
 
 func TestDefaultAwsConfig_RegionHandling(t *testing.T) {

--- a/docs/agent-notes/aws-config.md
+++ b/docs/agent-notes/aws-config.md
@@ -16,6 +16,10 @@ The same pattern applies to `helpers/sts.go:GetAccountID`, which uses `accountID
 
 `setAlias` uses `iam.ListAccountAliases` which is account-scoped (only returns the caller's own alias). If the call fails or returns no aliases, `AccountAlias` falls back to `AccountID`. For cross-account alias lookup see `docs/agent-notes/role-discovery.md` (uses SSO `ListAccounts` instead).
 
+## Profile Name Case Sensitivity
+
+AWS profile names are case-sensitive — they are matched verbatim against `[profile ...]` section headers in `~/.aws/config`. `resolveProfile` must read `aws.profile` via `Config.GetString`, never `Config.GetLCString`. `GetLCString` lowercases the value, which silently breaks mixed-case profile names (T-848). Same rule applies to any other case-sensitive identifier stored in viper (ARNs, resource IDs, file paths).
+
 ## Failure Modes
 
 - Invalid profile or missing credentials → `DefaultAwsConfig` panics (caught by CLI). Tests recover from this panic explicitly.


### PR DESCRIPTION
## Summary
- `resolveProfile` read `aws.profile` via `GetLCString`, which lowercases every value. AWS profile names are matched verbatim against the `[profile ...]` headers in `~/.aws/config`, so mixed-case profiles such as `MyCompany-prod` were treated as missing and the SDK silently fell back to the default profile.
- Switched to `GetString` so the value reaches `WithSharedConfigProfile` with its original case, and documented the case-sensitivity rule in `docs/agent-notes/aws-config.md`.
- Added a regression test that locks down case preservation across several profile-name shapes and updated the T-405 regression test to target `GetString`.

## Root Cause
`Config.GetLCString` is a case-normalising helper intended for values like output format. Reusing it for the profile name mis-applied that normalisation to a case-sensitive identifier.

## Test plan
- [x] `go test ./config/... -run TestDefaultAwsConfig_ProfilePreservesCase -v`
- [x] `go test ./...`
- [x] `make lint`
- [x] `make vet`