### PR TITLE
Fix T-867: Allow long AWS config lines in profile parser

### DIFF
--- a/docs/agent-notes/aws-config.md
+++ b/docs/agent-notes/aws-config.md
@@ -21,3 +21,7 @@ The same pattern applies to `helpers/sts.go:GetAccountID`, which uses `accountID
 - Invalid profile or missing credentials → `DefaultAwsConfig` panics (caught by CLI). Tests recover from this panic explicitly.
 - STS call failure → `setCallerInfo` panics. Not graceful — consider error propagation if this ever becomes a common failure mode.
 - Partial STS response (nil fields) → handled via `resolveCallerIdentity`; identity fields become empty strings, no panic.
+
+## AWS Config File Parser
+
+`helpers/aws_config_file.go:parseConfigFileWithRecovery` reads `~/.aws/config` with `bufio.Scanner`. The default token size (64 KiB) is too small for configs with long `credential_process` commands or other oversized custom properties, so the parser calls `scanner.Buffer` with a 1 MiB cap (`maxConfigLineSize`). Without this, a single long line causes `bufio.ErrTooLong` and aborts the whole parse, bypassing the partial-recovery logic. This was the fix for T-867.

--- a/helpers/aws_config_file.go
+++ b/helpers/aws_config_file.go
@@ -201,9 +201,19 @@ func LoadAWSConfigFile(filePath string) (*AWSConfigFile, error) {
 	return configFile, nil
 }
 
+// maxConfigLineSize bounds how long a single line in an AWS config file may be.
+// bufio.Scanner's default token size is 64 KiB, which is not enough for configs
+// that contain long credential_process commands or other large custom
+// properties. 1 MiB leaves plenty of headroom for realistic entries while
+// still bounding memory use. See T-867.
+const maxConfigLineSize = 1 << 20 // 1 MiB
+
 // parseConfigFileWithRecovery parses the AWS config file with malformed section recovery
 func (cf *AWSConfigFile) parseConfigFileWithRecovery(file *os.File) error {
 	scanner := bufio.NewScanner(file)
+	// Allow lines larger than bufio.MaxScanTokenSize (64 KiB). The initial
+	// buffer stays small; Scanner grows it up to maxConfigLineSize on demand.
+	scanner.Buffer(make([]byte, 0, 64*1024), maxConfigLineSize)
 	var currentProfile *Profile
 	var currentSession *SSOSession
 	var parseErrors []error

--- a/helpers/aws_config_file_test.go
+++ b/helpers/aws_config_file_test.go
@@ -532,6 +532,47 @@ sso_role_name = ReadOnlyAccess
 	assert.Equal(t, "987654321098", legacyProfile.SSOAccountID)
 	assert.Equal(t, "ReadOnlyAccess", legacyProfile.SSORoleName)
 }
+
+// TestAWSConfigFile_ParseLongLine is a regression test for T-867: the parser
+// used bufio.Scanner with the default 64 KiB token size, so any AWS config line
+// larger than 64 KiB (for example a long credential_process or a large custom
+// property on an SSO session profile) made the scanner return
+// bufio.ErrTooLong, which caused LoadAWSConfigFile to fail outright instead of
+// recovering. The parser must now handle lines well beyond 64 KiB.
+func TestAWSConfigFile_ParseLongLine(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+
+	// Build a property value that is comfortably larger than the default
+	// bufio.Scanner token size (64 KiB). 128 KiB is well past the old limit
+	// while still representative of realistic long credential_process entries.
+	longValue := strings.Repeat("a", 128*1024)
+
+	configContent := "[profile long-profile]\n" +
+		"region = us-east-1\n" +
+		"credential_process = " + longValue + "\n" +
+		"\n" +
+		"[profile trailing-profile]\n" +
+		"region = us-west-2\n"
+
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0600))
+
+	configFile, err := LoadAWSConfigFile(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, configFile)
+
+	longProfile, exists := configFile.Profiles["long-profile"]
+	require.True(t, exists, "profile with long property must be parsed")
+	assert.Equal(t, "us-east-1", longProfile.Region)
+	assert.Equal(t, longValue, longProfile.OtherProperties["credential_process"])
+
+	// Profiles defined after the long line must still be parsed — this
+	// proves the scanner continues past the long line rather than aborting.
+	trailing, exists := configFile.Profiles["trailing-profile"]
+	require.True(t, exists, "profile after long line must be parsed")
+	assert.Equal(t, "us-west-2", trailing.Region)
+}
+
 func TestAWSConfigFile_FindProfilesByName(t *testing.T) {
 	configFile := &AWSConfigFile{
 		Profiles: map[string]Profile{


### PR DESCRIPTION
## Summary

`helpers/aws_config_file.go:parseConfigFileWithRecovery` parsed `~/.aws/config` with `bufio.NewScanner(file)` but never configured the scanner buffer. `bufio.Scanner`'s default token size is 64 KiB, so any config line longer than that — for example a long `credential_process` command or an oversized custom property on an SSO profile — caused `scanner.Err()` to return `bufio.Scanner: token too long`. `LoadAWSConfigFile` turned that into a `FileSystemError` and aborted outright, bypassing the parser's partial-recovery behaviour even when every other profile in the file was valid.

## Root cause

`bufio.Scanner` uses `bufio.MaxScanTokenSize` (64 KiB) when `Buffer` is not called. The parser never called `scanner.Buffer`, so a single long line made the whole file unreadable.

## Fix

Call `scanner.Buffer(make([]byte, 0, 64*1024), 1 << 20)` so the scanner can grow its buffer up to 1 MiB on demand. 1 MiB comfortably covers realistic long `credential_process` values while still bounding memory use. A new `maxConfigLineSize` constant documents the cap and cross-references T-867.

## Regression test

`TestAWSConfigFile_ParseLongLine` in `helpers/aws_config_file_test.go` writes a synthetic config with a 128 KiB `credential_process` value plus a trailing profile, and asserts that `LoadAWSConfigFile` returns both profiles successfully. Before the fix this test fails with `bufio.Scanner: token too long`; after the fix it passes.

## Test plan

- [x] `go test -run TestAWSConfigFile_ParseLongLine ./helpers/` passes
- [x] `go test ./...` passes
- [x] `go fmt ./...` / `go vet ./...` clean
- [x] `golangci-lint run ./helpers/` reports 0 issues