### PR TITLE
Fix T-835: Paginate S3 Bucket Inventory Listing

### DIFF
--- a/docs/agent-notes/s3-helpers.md
+++ b/docs/agent-notes/s3-helpers.md
@@ -6,8 +6,14 @@ Scope: `helpers/s3.go` plus its consumers in `cmd/s3list.go` and
 ## Architecture
 
 - `GetBucketDetails(svc S3API) []S3Bucket` is the single entry point
-  used by the CLI. It calls `ListBuckets` once and then issues a
+  used by the CLI. It calls `GetAllBuckets` and then issues a
   sequence of per-bucket detail calls.
+- `GetAllBuckets` walks every page of `ListBuckets` using the
+  `ContinuationToken` on `ListBucketsInput`/`ListBucketsOutput`
+  (T-835). AWS now paginates `ListBuckets` for accounts above the
+  default 10k bucket quota, so a single call is no longer enough.
+  Owner is captured from the first page (it's returned on every page
+  but doesn't change).
 - `S3API` is a helper-owned interface (added for T-714). It lists
   only the S3 SDK methods used inside the helper so tests can inject
   per-call failures with a `mockS3Client`.
@@ -85,3 +91,7 @@ legitimate values.
   `TestGetBucketDetails_UnknownOnDetailErrors`,
   `TestGetBucketDetails_HealthyPathSetsPointers`,
   `TestComputeBucketIsPublic`.
+- Regression tests for T-835 pagination:
+  `TestGetAllBuckets_Pagination` (asserts every page is walked) and
+  `TestGetAllBuckets_SinglePage` (asserts the loop stops after one
+  call when no `ContinuationToken` is returned).

--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -94,16 +94,35 @@ func warnS3DetailError(bucket, call string, err error) {
 }
 
 // GetAllBuckets retrieves all S3 buckets and returns them along with
-// the owner name.
+// the owner name. S3 ListBuckets supports ContinuationToken pagination,
+// so the full list is assembled by walking every page. Owner is taken
+// from the first page (the API returns it on every page, but its value
+// is invariant across pages).
 func GetAllBuckets(svc S3API) ([]types.Bucket, string) {
-	params := &s3.ListBucketsInput{}
-	resp, err := svc.ListBuckets(context.TODO(), params)
+	var (
+		buckets []types.Bucket
+		owner   string
+		token   *string
+	)
 
-	if err != nil {
-		panic(err)
+	for i := 0; ; i++ {
+		resp, err := svc.ListBuckets(context.TODO(), &s3.ListBucketsInput{
+			ContinuationToken: token,
+		})
+		if err != nil {
+			panic(err)
+		}
+		if i == 0 {
+			owner = resolveOwnerName(resp.Owner)
+		}
+		buckets = append(buckets, resp.Buckets...)
+		if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+			break
+		}
+		token = resp.ContinuationToken
 	}
 
-	return resp.Buckets, resolveOwnerName(resp.Owner)
+	return buckets, owner
 }
 
 // GetBucketDetails retrieves detailed information for all S3 buckets

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -909,6 +910,95 @@ func TestComputeBucketIsPublic(t *testing.T) {
 				t.Fatalf("got=%v, want=%v", *got, *tt.expected)
 			}
 		})
+	}
+}
+
+// TestGetAllBuckets_Pagination is the regression test for T-835.
+// S3 ListBuckets supports ContinuationToken pagination, and accounts with
+// more buckets than fit on a single page must have every page walked.
+// Before this fix, GetAllBuckets issued a single call and silently dropped
+// any buckets on subsequent pages.
+func TestGetAllBuckets_Pagination(t *testing.T) {
+	// Build three pages worth of buckets, each served from the mock by
+	// using ContinuationToken as a decimal offset into the slice.
+	all := []types.Bucket{
+		{Name: aws.String("bucket-0")},
+		{Name: aws.String("bucket-1")},
+		{Name: aws.String("bucket-2")},
+		{Name: aws.String("bucket-3")},
+		{Name: aws.String("bucket-4")},
+	}
+	const pageSize = 2
+
+	calls := 0
+	mock := &mockS3Client{
+		listBuckets: func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			calls++
+			start := 0
+			if params.ContinuationToken != nil {
+				if _, err := fmt.Sscanf(*params.ContinuationToken, "%d", &start); err != nil {
+					return nil, err
+				}
+			}
+			end := start + pageSize
+			if end > len(all) {
+				end = len(all)
+			}
+			out := &s3.ListBucketsOutput{
+				Buckets: all[start:end],
+				Owner:   &types.Owner{DisplayName: aws.String("owner"), ID: aws.String("owner-id")},
+			}
+			if end < len(all) {
+				tok := fmt.Sprintf("%d", end)
+				out.ContinuationToken = &tok
+			}
+			return out, nil
+		},
+	}
+
+	buckets, owner := GetAllBuckets(mock)
+
+	if owner != "owner" {
+		t.Errorf("owner = %q, want %q", owner, "owner")
+	}
+	if len(buckets) != len(all) {
+		t.Fatalf("expected %d buckets after pagination, got %d", len(all), len(buckets))
+	}
+	for i, b := range buckets {
+		want := fmt.Sprintf("bucket-%d", i)
+		if aws.ToString(b.Name) != want {
+			t.Errorf("buckets[%d].Name = %q, want %q", i, aws.ToString(b.Name), want)
+		}
+	}
+	if calls < 3 {
+		t.Errorf("expected at least 3 ListBuckets calls for pagination, got %d", calls)
+	}
+}
+
+// TestGetAllBuckets_SinglePage verifies that accounts with a single page
+// of buckets still work correctly after the pagination change — no
+// ContinuationToken means the loop stops after one call.
+func TestGetAllBuckets_SinglePage(t *testing.T) {
+	calls := 0
+	mock := &mockS3Client{
+		listBuckets: func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			calls++
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{{Name: aws.String("only-bucket")}},
+				Owner:   &types.Owner{DisplayName: aws.String("owner"), ID: aws.String("owner-id")},
+			}, nil
+		},
+	}
+
+	buckets, owner := GetAllBuckets(mock)
+	if owner != "owner" {
+		t.Errorf("owner = %q, want %q", owner, "owner")
+	}
+	if len(buckets) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(buckets))
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 ListBuckets call, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `helpers/s3.go` `GetAllBuckets` now loops on `ListBucketsInput.ContinuationToken` so every page is collected, instead of silently dropping buckets on later pages. Owner is captured from the first page (invariant across pages).
- Added `TestGetAllBuckets_Pagination` and `TestGetAllBuckets_SinglePage` regression tests using the existing `S3API` / `mockS3Client` pattern from T-693/T-714.
- Updated `docs/agent-notes/s3-helpers.md` to document the pagination loop.

## Root Cause

`GetAllBuckets` predates AWS adding pagination to `ListBuckets`. When accounts exceed the default 10,000-bucket page size (or use `MaxBuckets`/quota limits), the continuation token was ignored and later pages were dropped from `awstools s3 list` and `GetBucketDetails`.

## Test plan

- [x] `go test ./helpers/ -run TestGetAllBuckets` — both new tests pass
- [x] `go test ./...` — full suite passes
- [x] `go fmt ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make lint` — 0 issues

Closes T-835.