### PR TITLE
Fix T-891: Paginate SSO ListInstances Lookup

### DIFF
--- a/docs/agent-notes/sso-helpers.md
+++ b/docs/agent-notes/sso-helpers.md
@@ -18,17 +18,18 @@ SSOInstance
 
 - **SSOAdminAPI interface**: Introduced in T-479 to enable mock-based testing. All SSO helper functions accept this interface rather than `*ssoadmin.Client`.
 - **Error returns (not panics)**: The helpers return errors. The cmd-layer callers currently use `panic(err)` to handle these, matching the pattern elsewhere in the cmd package.
-- **Manual pagination**: Uses `for { ... NextToken ... break }` loops, consistent with `helpers/role_discovery.go`.
+- **Pagination mix**: The four `List*` calls inside permission-set traversal use manual `for { ... NextToken ... break }` loops for backward compatibility with T-479. `ListInstances` uses the SDK's `ssoadmin.NewListInstancesPaginator` (added in T-891) — the SSO SDK's `ListInstancesAPIClient` interface is satisfied by `SSOAdminAPI` because it only requires a single `ListInstances` method with the standard signature.
 
 ## Pagination
 
-Four listing APIs require pagination:
-1. `ListPermissionSets` — in `getPermissionSets()`
-2. `ListAccountsForProvisionedPermissionSet` — in `addAccountInfo()`
-3. `ListAccountAssignments` — in `addAccountInfo()` (nested per account)
-4. `ListManagedPoliciesInPermissionSet` — in `getPermissionSetDetails()`
+Five listing APIs require pagination:
+1. `ListInstances` — in `getSSOInstance()`, via `ssoadmin.NewListInstancesPaginator`
+2. `ListPermissionSets` — in `getPermissionSets()`
+3. `ListAccountsForProvisionedPermissionSet` — in `addAccountInfo()`
+4. `ListAccountAssignments` — in `addAccountInfo()` (nested per account)
+5. `ListManagedPoliciesInPermissionSet` — in `getPermissionSetDetails()`
 
-All use `MaxResults: 100` (AWS default max page size) and follow the NextToken pattern.
+Calls 2-5 use `MaxResults: 100` (AWS default max page size) and manual NextToken loops. `ListInstances` relies on the SDK paginator's defaults because the call has no tunable parameters.
 
 ## Testing
 

--- a/helpers/sso.go
+++ b/helpers/sso.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	ssotypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 )
 
 // SSOAdminAPI defines the subset of the SSO Admin client used by this package.
@@ -76,17 +77,22 @@ type SSOAccountAssignment struct {
 }
 
 func getSSOInstance(svc SSOAdminAPI) (SSOInstance, error) {
-	instances, err := svc.ListInstances(context.TODO(), &ssoadmin.ListInstancesInput{})
-	if err != nil {
-		return SSOInstance{}, fmt.Errorf("failed to list SSO instances: %w", err)
+	paginator := ssoadmin.NewListInstancesPaginator(svc, &ssoadmin.ListInstancesInput{})
+	var collected []ssotypes.InstanceMetadata
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return SSOInstance{}, fmt.Errorf("failed to list SSO instances: %w", err)
+		}
+		collected = append(collected, page.Instances...)
 	}
-	if len(instances.Instances) < 1 {
+	if len(collected) < 1 {
 		return SSOInstance{}, fmt.Errorf("no SSO instances found")
 	}
-	if len(instances.Instances) > 1 {
+	if len(collected) > 1 {
 		return SSOInstance{}, fmt.Errorf("found multiple SSO instances, expected exactly one")
 	}
-	inst := instances.Instances[0]
+	inst := collected[0]
 	if inst.IdentityStoreId == nil || inst.InstanceArn == nil {
 		return SSOInstance{}, fmt.Errorf("SSO instance has nil IdentityStoreId or InstanceArn")
 	}

--- a/helpers/sso_test.go
+++ b/helpers/sso_test.go
@@ -171,6 +171,47 @@ func TestSSOPermissionSet_WithManagedPolicies(t *testing.T) {
 	}
 }
 
+// Regression test for T-891: ListInstances must paginate across all pages.
+// AWS caps ListInstances at a small page size, so discovery must follow
+// NextToken to avoid silently dropping the caller's SSO instance when it
+// happens to appear on a later page.
+func TestListInstances_Pagination(t *testing.T) {
+	mock := newBasicMock()
+	listInstancesCalls := 0
+	mock.ListInstancesFunc = func(ctx context.Context, params *ssoadmin.ListInstancesInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListInstancesOutput, error) {
+		listInstancesCalls++
+		switch listInstancesCalls {
+		case 1:
+			assert.Nil(t, params.NextToken, "first call should not have NextToken")
+			return &ssoadmin.ListInstancesOutput{
+				Instances: []ssotypes.InstanceMetadata{},
+				NextToken: aws.String("page2"),
+			}, nil
+		case 2:
+			assert.Equal(t, "page2", *params.NextToken)
+			return &ssoadmin.ListInstancesOutput{
+				Instances: []ssotypes.InstanceMetadata{
+					{
+						IdentityStoreId: aws.String("d-laterpage"),
+						InstanceArn:     aws.String("arn:aws:sso:::instance/ssoins-laterpage"),
+					},
+				},
+				NextToken: nil,
+			}, nil
+		default:
+			t.Fatal("ListInstances called too many times")
+			return nil, nil
+		}
+	}
+
+	instance, err := GetSSOAccountInstance(mock)
+	require.NoError(t, err)
+	assert.Equal(t, 2, listInstancesCalls, "ListInstances should be called twice to follow NextToken")
+	assert.Equal(t, "d-laterpage", instance.IdentityStoreID,
+		"should find the SSO instance on the second page")
+	assert.Equal(t, "arn:aws:sso:::instance/ssoins-laterpage", instance.Arn)
+}
+
 // Regression tests for T-479: pagination must collect all pages
 
 // newBasicMock returns a mock with common defaults set for a single permission set.


### PR DESCRIPTION
## Summary
- `helpers/sso.go` now discovers the caller's SSO instance via `ssoadmin.NewListInstancesPaginator`, so instances that land on a later page are no longer silently dropped.
- Adds `TestListInstances_Pagination` using the existing `mockSSOAdminClient` to lock in the new pagination behaviour.

## Root Cause
`getSSOInstance` called `ListInstances` once and ignored `NextToken`. When AWS returned an empty first page (or split results), the helper bailed with "no SSO instances found" even though an instance existed.

## Fix
Iterate `paginator.HasMorePages()` / `NextPage`, collect all `InstanceMetadata`, then apply the existing "exactly one instance" validation against the full set. The `SSOAdminAPI` interface already satisfies the SDK's `ListInstancesAPIClient`, so no client plumbing changed.

## Test plan
- [x] `go test ./helpers/ -run TestListInstances_Pagination`
- [x] `go test ./...`
- [x] `make test`
- [x] `make lint`

Closes T-891