### PR TITLE
Fix T-805: Paginate Route Table Display Lookup in VPC Overview

### DIFF
--- a/cmd/vpcoverview.go
+++ b/cmd/vpcoverview.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/ArjenSchwarz/awstools/config"
 	"github.com/ArjenSchwarz/awstools/helpers"
 	format "github.com/ArjenSchwarz/go-output"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/spf13/cobra"
 )
@@ -42,15 +39,13 @@ func vpcOverview(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	accountName := getName(helpers.GetAccountID(awsConfig.StsClient()))
 
-	overview := helpers.GetVPCUsageOverview(awsConfig.Ec2Client())
-
-	// Get raw route tables for route information
 	ec2Client := awsConfig.Ec2Client()
-	routeTablesResp, err := ec2Client.DescribeRouteTables(context.TODO(), &ec2.DescribeRouteTablesInput{})
-	if err != nil {
-		panic(err)
-	}
-	routeTables := routeTablesResp.RouteTables
+	overview := helpers.GetVPCUsageOverview(ec2Client)
+
+	// Fetch the raw route tables used for display formatting. GetAllRouteTables
+	// walks every page of DescribeRouteTables so accounts with more route
+	// tables than fit in a single response still render correctly (T-805).
+	routeTables := helpers.GetAllRouteTables(ec2Client)
 
 	// Filter VPCs if vpc flag is provided
 	filteredVPCs := overview.VPCs

--- a/docs/agent-notes/ec2-helpers.md
+++ b/docs/agent-notes/ec2-helpers.md
@@ -26,8 +26,17 @@ All callers must pass the subnet's VPC ID. The VPC ID is available from:
 - `DescribeRouteTables` without filters returns route tables across all VPCs
 - `DescribeRouteTables` is paginated (default page size 100). Always walk
   `ec2.NewDescribeRouteTablesPaginator`; a single `DescribeRouteTables` call
-  truncates results in large accounts. `GetAllVPCRouteTables`, `retrieveRouteTables`,
-  and `addAllRouteTableNames` all follow the paginator pattern.
+  truncates results in large accounts. `GetAllVPCRouteTables`,
+  `GetAllRouteTables`, `retrieveRouteTables`, and `addAllRouteTableNames` all
+  follow the paginator pattern.
+- `GetAllRouteTables(svc *ec2.Client) []types.RouteTable` (T-805) is the
+  exported entry point when you need the raw SDK type (e.g. for
+  `GetSubnetRouteTable` / `FormatRouteTableInfo` in display code). It wraps
+  the unexported `getAllRouteTables(ec2.DescribeRouteTablesAPIClient)` so
+  the pagination is unit-testable — `retrieveRouteTables` is now a thin
+  alias over the same implementation. Prefer this helper over an inline
+  `DescribeRouteTables` call in `cmd/` — the bug T-805 fixed was exactly
+  such a single-page call in `cmd/vpcoverview.go`.
 - `types.NatGatewayAddress.NetworkInterfaceId` is `*string` and AWS may omit it (e.g. for addresses in transitional states). Always guard for nil or use `aws.ToString` before comparing.
 
 ## Transit Gateway Route Parsing

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -1109,8 +1109,19 @@ func retrieveSubnetData(svc *ec2.Client) []types.Subnet {
 	return result
 }
 
-// retrieveRouteTables fetches all route tables using DescribeRouteTables API
-func retrieveRouteTables(svc *ec2.Client) []types.RouteTable {
+// GetAllRouteTables returns every route table in the account/region as the
+// raw AWS SDK type, walking all pages of DescribeRouteTables. Callers that
+// need the internal VPCRouteTable projection should use GetAllVPCRouteTables
+// instead; this helper exists for command-layer code that formats route
+// tables directly (e.g. the vpc overview display).
+func GetAllRouteTables(svc *ec2.Client) []types.RouteTable {
+	return getAllRouteTables(svc)
+}
+
+// getAllRouteTables implements GetAllRouteTables against the minimal
+// DescribeRouteTablesAPIClient interface so the pagination logic can be
+// unit tested without a real *ec2.Client.
+func getAllRouteTables(svc ec2.DescribeRouteTablesAPIClient) []types.RouteTable {
 	var result []types.RouteTable
 	paginator := ec2.NewDescribeRouteTablesPaginator(svc, &ec2.DescribeRouteTablesInput{})
 	for paginator.HasMorePages() {
@@ -1121,6 +1132,13 @@ func retrieveRouteTables(svc *ec2.Client) []types.RouteTable {
 		result = append(result, page.RouteTables...)
 	}
 	return result
+}
+
+// retrieveRouteTables fetches all route tables using DescribeRouteTables API.
+// Retained as a thin wrapper over getAllRouteTables so existing internal
+// callers keep their current signature.
+func retrieveRouteTables(svc *ec2.Client) []types.RouteTable {
+	return getAllRouteTables(svc)
 }
 
 // GetSubnetRouteTable finds the route table associated with a specific subnet.

--- a/helpers/vpc_routetable_display_pagination_test.go
+++ b/helpers/vpc_routetable_display_pagination_test.go
@@ -1,0 +1,84 @@
+package helpers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// associationForSubnet returns a route table association linking the given
+// subnet ID (for regression-test setup).
+func associationForSubnet(subnetID string) types.RouteTableAssociation {
+	return types.RouteTableAssociation{SubnetId: aws.String(subnetID)}
+}
+
+// TestGetAllRouteTables_Pagination verifies that GetAllRouteTables walks every
+// page of DescribeRouteTables. Before T-805 the vpc overview command called
+// DescribeRouteTables directly without pagination, so subnets whose route
+// table landed on a later page rendered as "No route table". This test drives
+// the paginated helper that the command now relies on.
+func TestGetAllRouteTables_Pagination(t *testing.T) {
+	totalTables := 5
+	mock := &mockDescribeRouteTablesClient{
+		routeTables: makeRouteTables(totalTables),
+		pageSize:    2, // force 3 pages: [0,1], [2,3], [4]
+	}
+
+	result := getAllRouteTables(mock)
+
+	if len(result) != totalTables {
+		t.Errorf("getAllRouteTables() returned %d route tables, want %d (pagination bug: only first page returned)", len(result), totalTables)
+	}
+
+	if mock.callCount < 3 {
+		t.Errorf("expected at least 3 DescribeRouteTables calls for %d tables at page size %d, got %d", totalTables, mock.pageSize, mock.callCount)
+	}
+
+	for i, rt := range result {
+		expectedID := fmt.Sprintf("rtb-%08d", i)
+		if rt.RouteTableId == nil || *rt.RouteTableId != expectedID {
+			got := ""
+			if rt.RouteTableId != nil {
+				got = *rt.RouteTableId
+			}
+			t.Errorf("result[%d].RouteTableId = %q, want %q", i, got, expectedID)
+		}
+	}
+}
+
+// TestGetAllRouteTables_UsedBySubnetLookupAcrossPages simulates the bug scenario
+// where a subnet's route table only appears on a later page of the
+// DescribeRouteTables response. Before T-805 the vpc overview command pulled
+// the raw route table list with a single API call, so GetSubnetRouteTable
+// returned nil for any subnet whose route table was not on page 1.
+func TestGetAllRouteTables_UsedBySubnetLookupAcrossPages(t *testing.T) {
+	// Build 5 route tables; the target (index 4) is on page 3 with page size 2.
+	tables := makeRouteTables(5)
+
+	// Make the last route table the explicit association for a specific subnet
+	// in the same VPC as that route table.
+	targetSubnetID := "subnet-target"
+	targetVPCID := *tables[4].VpcId
+	tables[4].Associations = append(tables[4].Associations, associationForSubnet(targetSubnetID))
+
+	mock := &mockDescribeRouteTablesClient{
+		routeTables: tables,
+		pageSize:    2,
+	}
+
+	allTables := getAllRouteTables(mock)
+
+	rt := GetSubnetRouteTable(targetSubnetID, targetVPCID, allTables)
+	if rt == nil {
+		t.Fatalf("GetSubnetRouteTable returned nil for subnet %q; expected the route table on page 3 to be found", targetSubnetID)
+	}
+	if rt.RouteTableId == nil || *rt.RouteTableId != *tables[4].RouteTableId {
+		got := ""
+		if rt.RouteTableId != nil {
+			got = *rt.RouteTableId
+		}
+		t.Errorf("GetSubnetRouteTable returned route table %q, want %q", got, *tables[4].RouteTableId)
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/vpcoverview.go` issued a single `DescribeRouteTables` call to populate the display-side route table / routes columns, so in accounts with more route tables than fit in one page, subnets whose route table landed on a later page rendered as `No route table`. `GetVPCUsageOverview` already paginates internally, but that data is not exposed to the command for display formatting.
- Exposes the already-paginated `retrieveRouteTables` as a new `helpers.GetAllRouteTables` (exported wrapper over `getAllRouteTables(ec2.DescribeRouteTablesAPIClient)` so it is unit-testable), following the same split pattern used by `GetAllVPCRouteTables`, `GetAllVpcPeers`, and the ENI lookup helpers. `cmd/vpcoverview.go` now calls this helper and drops the direct `DescribeRouteTables` call.
- Adds `helpers/vpc_routetable_display_pagination_test.go` with two regression tests: one asserts that `getAllRouteTables` walks every page, and one exercises the realistic end-to-end path where a route table on page 3 is still found by `GetSubnetRouteTable`.

## Root Cause

T-668 paginated the internal route-table helpers but the command layer kept a separate non-paginated `DescribeRouteTables` call for display formatting. The fix routes the display lookup through a paginated helper so it behaves identically in large accounts.

## Test plan

- [x] `go test ./helpers/ -run TestGetAllRouteTables_` passes (regression tests)
- [x] `go test ./...` passes
- [x] `make check` passes
- [x] `make compile` succeeds

Resolves T-805.