### PR TITLE
fix: Avoid per-ENI AWS config/client initialization in vpc enis attachment resolution (T-727)

### DIFF
--- a/cmd/vpcenis.go
+++ b/cmd/vpcenis.go
@@ -12,19 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// eniAttachmentLookupClient is the minimum EC2 API surface required by
-// getAttachment to resolve ENI attachment metadata. Combining the three
-// Describe* API client interfaces here keeps production callers passing a
-// single *ec2.Client while letting tests supply a mock that paginates.
-// Pagination for each underlying Describe call lives in helpers/ec2.go
-// (T-657); this interface just pins the command-side path to those
-// paginated helpers.
-type eniAttachmentLookupClient interface {
-	ec2.DescribeVpcEndpointsAPIClient
-	ec2.DescribeNatGatewaysAPIClient
-	ec2.DescribeTransitGatewayVpcAttachmentsAPIClient
-}
-
 // peeringsCmd represents the peerings command
 var enisCmd = &cobra.Command{
 	Use:   "enis",
@@ -63,7 +50,7 @@ func enis(_ *cobra.Command, _ []string) {
 	output.Write()
 }
 
-func printENIs(interfaces []types.NetworkInterface, names map[string]string, resultTitle string, split bool, svc eniAttachmentLookupClient) {
+func printENIs(interfaces []types.NetworkInterface, names map[string]string, resultTitle string, split bool, svc *ec2.Client) {
 	keys := []string{"ENI", "Type", "Attachment", "IPs", "VPC", "Subnet"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
@@ -74,6 +61,9 @@ func printENIs(interfaces []types.NetworkInterface, names map[string]string, res
 		output.Settings.SeparateTables = true
 		output.Settings.SortKey = "Attachment"
 	}
+
+	// Build cache once for all ENIs to avoid per-ENI API calls (T-727).
+	cache := helpers.NewENILookupCache(svc, interfaces)
 
 	for _, netinterface := range interfaces {
 		content := make(map[string]any)
@@ -88,7 +78,7 @@ func printENIs(interfaces []types.NetworkInterface, names map[string]string, res
 		}
 		content["ENI"] = aws.ToString(netinterface.NetworkInterfaceId)
 		content["Type"] = netinterface.InterfaceType
-		content["Attachment"] = getNameAndIDFromMap(getAttachment(netinterface, svc), names)
+		content["Attachment"] = getNameAndIDFromMap(helpers.GetAttachmentFromCache(netinterface, cache), names)
 		content["IPs"] = iparray
 		content["VPC"] = getNameAndIDFromMap(aws.ToString(netinterface.VpcId), names)
 		content["Subnet"] = getNameAndIDFromMap(aws.ToString(netinterface.SubnetId), names)
@@ -104,35 +94,6 @@ func splitBySubnet(interfaces []types.NetworkInterface) map[string][]types.Netwo
 		result[subnetID] = append(result[subnetID], netinterface)
 	}
 	return result
-}
-
-// getAttachment resolves the attachment label for a given ENI. For instance
-// ENIs it returns the instance ID directly; for TGW/NAT/VPC-endpoint ENIs it
-// dispatches to the matching paginated helper (T-657 fixed those helpers to
-// walk every page). The svc parameter is the composite client interface so
-// tests can supply a paginating mock without a real *ec2.Client.
-func getAttachment(netinterface types.NetworkInterface, svc eniAttachmentLookupClient) string {
-	if netinterface.Attachment != nil && netinterface.Attachment.InstanceId != nil {
-		return *netinterface.Attachment.InstanceId
-	}
-	if netinterface.InterfaceType == types.NetworkInterfaceTypeTransitGateway {
-		return helpers.GetTransitGatewayFromNetworkInterface(netinterface, svc)
-	}
-	if netinterface.InterfaceType == types.NetworkInterfaceTypeNatGateway || netinterface.InterfaceType == "nat_gateway" {
-		natgw := helpers.GetNatGatewayFromNetworkInterface(netinterface, svc)
-		if natgw != nil {
-			return aws.ToString(natgw.NatGatewayId)
-		}
-		return ""
-	}
-	if netinterface.InterfaceType == types.NetworkInterfaceTypeVpcEndpoint {
-		endpoint := helpers.GetVPCEndpointFromNetworkInterface(netinterface, svc)
-		if endpoint != nil {
-			return fmt.Sprintf("%s (%s)", aws.ToString(endpoint.ServiceName), aws.ToString(endpoint.VpcEndpointId))
-		}
-		return ""
-	}
-	return ""
 }
 
 func getNameAndIDFromMap(id string, names map[string]string) string {

--- a/cmd/vpcenis_test.go
+++ b/cmd/vpcenis_test.go
@@ -5,10 +5,48 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ArjenSchwarz/awstools/helpers"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
+
+// eniAttachmentLookupClient is the minimum EC2 API surface used by
+// getAttachment (below) to resolve ENI attachment metadata via the paginated
+// helpers. Kept in the test file after T-727 moved production code to use
+// ENILookupCache; these tests still validate the per-ENI paginated helpers.
+type eniAttachmentLookupClient interface {
+	ec2.DescribeVpcEndpointsAPIClient
+	ec2.DescribeNatGatewaysAPIClient
+	ec2.DescribeTransitGatewayVpcAttachmentsAPIClient
+}
+
+// getAttachment resolves the attachment label for a given ENI by dispatching
+// to the paginated helpers. Retained in the test file to validate those helpers
+// still paginate correctly (T-657/T-705 regression coverage).
+func getAttachment(netinterface types.NetworkInterface, svc eniAttachmentLookupClient) string {
+	if netinterface.Attachment != nil && netinterface.Attachment.InstanceId != nil {
+		return *netinterface.Attachment.InstanceId
+	}
+	if netinterface.InterfaceType == types.NetworkInterfaceTypeTransitGateway {
+		return helpers.GetTransitGatewayFromNetworkInterface(netinterface, svc)
+	}
+	if netinterface.InterfaceType == types.NetworkInterfaceTypeNatGateway || netinterface.InterfaceType == "nat_gateway" {
+		natgw := helpers.GetNatGatewayFromNetworkInterface(netinterface, svc)
+		if natgw != nil {
+			return aws.ToString(natgw.NatGatewayId)
+		}
+		return ""
+	}
+	if netinterface.InterfaceType == types.NetworkInterfaceTypeVpcEndpoint {
+		endpoint := helpers.GetVPCEndpointFromNetworkInterface(netinterface, svc)
+		if endpoint != nil {
+			return fmt.Sprintf("%s (%s)", aws.ToString(endpoint.ServiceName), aws.ToString(endpoint.VpcEndpointId))
+		}
+		return ""
+	}
+	return ""
+}
 
 // Regression tests for T-705: the vpc enis command resolves ENI attachment
 // labels via getAttachment, which dispatches to the paginated helpers fixed

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -1951,6 +1951,35 @@ func (cache *ENILookupCache) batchFetchTransitGateways(svc *ec2.Client, vpcIDs m
 	}
 }
 
+// GetAttachmentFromCache resolves the attachment label for an ENI using a
+// pre-populated cache. This avoids per-ENI API calls — the caller should build
+// the cache once via NewENILookupCache and reuse it for every ENI.
+// The returned string matches the format expected by the vpc enis command
+// (raw IDs/labels suitable for name-mapping).
+func GetAttachmentFromCache(eni types.NetworkInterface, cache *ENILookupCache) string {
+	if eni.Attachment != nil && eni.Attachment.InstanceId != nil {
+		return *eni.Attachment.InstanceId
+	}
+	eniID := aws.ToString(eni.NetworkInterfaceId)
+	switch eni.InterfaceType {
+	case types.NetworkInterfaceTypeTransitGateway:
+		if eni.VpcId != nil {
+			if tgwID, exists := cache.TransitGateways[*eni.VpcId]; exists {
+				return tgwID
+			}
+		}
+	case types.NetworkInterfaceTypeNatGateway, "nat_gateway":
+		if natgw, exists := cache.NATGatewaysByENI[eniID]; exists {
+			return aws.ToString(natgw.NatGatewayId)
+		}
+	case types.NetworkInterfaceTypeVpcEndpoint:
+		if endpoint, exists := cache.EndpointsByENI[eniID]; exists {
+			return fmt.Sprintf("%s (%s)", aws.ToString(endpoint.ServiceName), aws.ToString(endpoint.VpcEndpointId))
+		}
+	}
+	return ""
+}
+
 // IPFinderResult contains the result of IP address search
 type IPFinderResult struct {
 	IPAddress      string                  `json:"ip_address"`

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -1624,6 +1624,63 @@ func TestENILookupCache_NATGatewaysByENI_DistinctEntries(t *testing.T) {
 	}
 }
 
+func TestGetAttachmentFromCache_T727(t *testing.T) {
+	cache := &ENILookupCache{
+		VPCEndpoints:     make(map[string]*types.VpcEndpoint),
+		InstanceNames:    make(map[string]string),
+		TransitGateways:  map[string]string{"vpc-aaa": "tgw-attach-123"},
+		NATGateways:      make(map[string]*types.NatGateway),
+		EndpointsByENI:   map[string]*types.VpcEndpoint{"eni-ep": {VpcEndpointId: aws.String("vpce-456"), ServiceName: aws.String("com.amazonaws.region.s3")}},
+		NATGatewaysByENI: map[string]*types.NatGateway{"eni-nat": {NatGatewayId: aws.String("nat-789")}},
+	}
+
+	tests := []struct {
+		name string
+		eni  types.NetworkInterface
+		want string
+	}{
+		{
+			name: "instance attached",
+			eni:  types.NetworkInterface{Attachment: &types.NetworkInterfaceAttachment{InstanceId: aws.String("i-abc")}},
+			want: "i-abc",
+		},
+		{
+			name: "transit gateway",
+			eni:  types.NetworkInterface{NetworkInterfaceId: aws.String("eni-tgw"), VpcId: aws.String("vpc-aaa"), InterfaceType: types.NetworkInterfaceTypeTransitGateway},
+			want: "tgw-attach-123",
+		},
+		{
+			name: "nat gateway",
+			eni:  types.NetworkInterface{NetworkInterfaceId: aws.String("eni-nat"), VpcId: aws.String("vpc-aaa"), InterfaceType: types.NetworkInterfaceTypeNatGateway},
+			want: "nat-789",
+		},
+		{
+			name: "nat gateway legacy type",
+			eni:  types.NetworkInterface{NetworkInterfaceId: aws.String("eni-nat"), VpcId: aws.String("vpc-aaa"), InterfaceType: "nat_gateway"},
+			want: "nat-789",
+		},
+		{
+			name: "vpc endpoint",
+			eni:  types.NetworkInterface{NetworkInterfaceId: aws.String("eni-ep"), VpcId: aws.String("vpc-aaa"), InterfaceType: types.NetworkInterfaceTypeVpcEndpoint},
+			want: "com.amazonaws.region.s3 (vpce-456)",
+		},
+		{
+			name: "unknown returns empty",
+			eni:  types.NetworkInterface{NetworkInterfaceId: aws.String("eni-unknown"), InterfaceType: types.NetworkInterfaceTypeInterface},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAttachmentFromCache(tt.eni, cache)
+			if got != tt.want {
+				t.Errorf("GetAttachmentFromCache() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetSubnetRouteTable_ExplicitAssociation(t *testing.T) {
 	routeTables := []types.RouteTable{
 		{


### PR DESCRIPTION
Fixes Transit ticket T-727: Avoid per-ENI AWS config/client initialization in vpc enis attachment resolution