### PR TITLE
fix: Generated sso_session profiles omit account and role fields (T-887)

### DIFF
--- a/helpers/aws_config_file.go
+++ b/helpers/aws_config_file.go
@@ -742,14 +742,13 @@ func (p *Profile) ToConfigString() string {
 
 	if p.SSOSession != "" {
 		fmt.Fprintf(&config, "sso_session = %s\n", p.SSOSession)
-	} else {
-		// Legacy format
-		if p.SSOAccountID != "" {
-			fmt.Fprintf(&config, "sso_account_id = %s\n", p.SSOAccountID)
-		}
-		if p.SSORoleName != "" {
-			fmt.Fprintf(&config, "sso_role_name = %s\n", p.SSORoleName)
-		}
+	}
+
+	if p.SSOAccountID != "" {
+		fmt.Fprintf(&config, "sso_account_id = %s\n", p.SSOAccountID)
+	}
+	if p.SSORoleName != "" {
+		fmt.Fprintf(&config, "sso_role_name = %s\n", p.SSORoleName)
 	}
 
 	if p.Output != "" {

--- a/helpers/profile_generator_types.go
+++ b/helpers/profile_generator_types.go
@@ -189,6 +189,8 @@ func (gp *GeneratedProfile) Validate() error {
 //	sso_start_url = https://my-org.awsapps.com/start
 //	sso_region = us-east-1
 //	sso_session = my-session
+//	sso_account_id = 123456789012
+//	sso_role_name = AdministratorAccess
 //
 // The output includes a trailing newline for proper file formatting.
 func (gp *GeneratedProfile) ToConfigString() string {
@@ -208,6 +210,8 @@ func (gp *GeneratedProfile) ToConfigString() string {
 		fmt.Fprintf(&config, "sso_role_name = %s\n", gp.SSORoleName)
 	} else {
 		fmt.Fprintf(&config, "sso_session = %s\n", gp.SSOSession)
+		fmt.Fprintf(&config, "sso_account_id = %s\n", gp.SSOAccountID)
+		fmt.Fprintf(&config, "sso_role_name = %s\n", gp.SSORoleName)
 	}
 
 	return config.String()


### PR DESCRIPTION
Fixes Transit ticket T-887: Generated sso_session profiles omit account and role fields