### PR TITLE
fix: Organizations child formatting can still panic on nil metadata (T-901)

### DIFF
--- a/helpers/organizations.go
+++ b/helpers/organizations.go
@@ -123,11 +123,14 @@ func formatChild(raw types.Child, svc OrganizationsAPI) (OrganizationEntry, erro
 		if err != nil {
 			return OrganizationEntry{}, fmt.Errorf("failed to describe OU %s: %w", *raw.Id, err)
 		}
+		if details.OrganizationalUnit == nil {
+			return OrganizationEntry{}, fmt.Errorf("OU metadata is nil for %s", *raw.Id)
+		}
 		return OrganizationEntry{
-			Name:     *details.OrganizationalUnit.Name,
-			ID:       *details.OrganizationalUnit.Id,
+			Name:     aws.ToString(details.OrganizationalUnit.Name),
+			ID:       aws.ToString(details.OrganizationalUnit.Id),
 			Type:     string(raw.Type),
-			Arn:      *details.OrganizationalUnit.Arn,
+			Arn:      aws.ToString(details.OrganizationalUnit.Arn),
 			Children: []OrganizationEntry{},
 		}, nil
 	}
@@ -138,11 +141,14 @@ func formatChild(raw types.Child, svc OrganizationsAPI) (OrganizationEntry, erro
 	if err != nil {
 		return OrganizationEntry{}, fmt.Errorf("failed to describe account %s: %w", *raw.Id, err)
 	}
+	if details.Account == nil {
+		return OrganizationEntry{}, fmt.Errorf("account metadata is nil for %s", *raw.Id)
+	}
 	return OrganizationEntry{
-		Name:     *details.Account.Name,
-		ID:       *details.Account.Id,
+		Name:     aws.ToString(details.Account.Name),
+		ID:       aws.ToString(details.Account.Id),
 		Type:     string(raw.Type),
-		Arn:      *details.Account.Arn,
+		Arn:      aws.ToString(details.Account.Arn),
 		Children: []OrganizationEntry{},
 	}, nil
 }

--- a/helpers/organizations_test.go
+++ b/helpers/organizations_test.go
@@ -384,3 +384,41 @@ func TestFindChildren_DescribeOUErrorDuringTraversal_ReturnsError(t *testing.T) 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OU describe failed")
 }
+
+// Regression tests for T-901: formatChild must not panic on nil metadata
+
+func TestFormatChild_NilOUMetadata_ReturnsError(t *testing.T) {
+	mock := &mockOrganizationsClient{
+		DescribeOrganizationalUnitFunc: func(_ context.Context, _ *organizations.DescribeOrganizationalUnitInput, _ ...func(*organizations.Options)) (*organizations.DescribeOrganizationalUnitOutput, error) {
+			return &organizations.DescribeOrganizationalUnitOutput{
+				OrganizationalUnit: nil,
+			}, nil
+		},
+	}
+	child := orgtypes.Child{
+		Id:   aws.String("ou-abc123"),
+		Type: orgtypes.ChildType(orgtypes.TargetTypeOrganizationalUnit),
+	}
+
+	_, err := formatChild(child, mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OU metadata is nil")
+}
+
+func TestFormatChild_NilAccountMetadata_ReturnsError(t *testing.T) {
+	mock := &mockOrganizationsClient{
+		DescribeAccountFunc: func(_ context.Context, _ *organizations.DescribeAccountInput, _ ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error) {
+			return &organizations.DescribeAccountOutput{
+				Account: nil,
+			}, nil
+		},
+	}
+	child := orgtypes.Child{
+		Id:   aws.String("123456789012"),
+		Type: orgtypes.ChildType(orgtypes.TargetTypeAccount),
+	}
+
+	_, err := formatChild(child, mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account metadata is nil")
+}


### PR DESCRIPTION
Fixes Transit ticket T-901: Organizations child formatting can still panic on nil metadata