### PR TITLE
fix: TGW route-table overview omits non-VPC attachments (T-924)

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -10,4 +10,5 @@ const (
 // Resource type constants
 const (
 	vpcResourceType = "vpc"
+	tgwResourceType = "tgw"
 )

--- a/cmd/tgwoverview.go
+++ b/cmd/tgwoverview.go
@@ -47,12 +47,18 @@ func tgwoverview(_ *cobra.Command, _ []string) {
 	} else {
 		for _, gateway := range gateways {
 			for _, routetable := range gateway.RouteTables {
+				// Track which resources appear as route targets so we can
+				// identify source attachments that are otherwise invisible.
+				routeTargets := make(map[string]bool)
 				for _, route := range routetable.Routes {
 					if excludeRouteTarget == route.Attachment.ResourceID {
 						continue
 					}
 					if !includeBlackhole && route.State == "blackhole" {
 						continue
+					}
+					if route.Attachment.ResourceID != "" {
+						routeTargets[route.Attachment.ResourceID] = true
 					}
 					content := make(map[string]any)
 					content["Transit Gateway Account"] = getNameWithID(gateway.AccountID)
@@ -74,6 +80,23 @@ func tgwoverview(_ *cobra.Command, _ []string) {
 						}
 					}
 					content["State"] = state
+					holder := format.OutputHolder{Contents: content}
+					output.AddHolder(holder)
+				}
+				// Show source attachments (associations) that don't already
+				// appear as route targets so non-VPC attachments are visible.
+				for _, attachment := range routetable.SourceAttachments {
+					if attachment.ResourceID == "" || routeTargets[attachment.ResourceID] {
+						continue
+					}
+					content := make(map[string]any)
+					content["Transit Gateway Account"] = getNameWithID(gateway.AccountID)
+					content["Transit Gateway"] = getNameWithID(gateway.ID)
+					content["Route Table"] = getNameWithID(routetable.ID)
+					content["CIDR"] = "-"
+					content["Target"] = getNameWithID(attachment.ResourceID)
+					content["Target Type"] = attachment.ResourceType
+					content["State"] = "associated"
 					holder := format.OutputHolder{Contents: content}
 					output.AddHolder(holder)
 				}
@@ -129,6 +152,10 @@ func createTgwOverviewDrawIO(output *format.OutputArray, gateways []helpers.Tran
 				image = drawio.AWSShape("Network Content Delivery", "VPC")
 			case "vpn":
 				image = drawio.AWSShape("Network Content Delivery", "Site-to-Site VPN")
+			case "dxgw":
+				image = drawio.AWSShape("Network Content Delivery", "Direct Connect Gateway")
+			case tgwResourceType:
+				image = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
 			}
 			targetTgwMapping[resourceid] = targetTgwMap{
 				ID:           resourceid,

--- a/cmd/tgwoverview_test.go
+++ b/cmd/tgwoverview_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/ArjenSchwarz/awstools/helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFilterGateway_IncludesNonVPCAttachments verifies that filterGateway
+// returns non-VPC resources (VPN, DX gateway, peering) from both route
+// destinations and source attachments. This is the regression test for T-924.
+func TestFilterGateway_IncludesNonVPCAttachments(t *testing.T) {
+	// Reset global filter state
+	tgwresourceid = ""
+
+	gateways := []helpers.TransitGateway{
+		{
+			ID:        "tgw-00000001",
+			AccountID: "123456789012",
+			Name:      "test-tgw",
+			RouteTables: map[string]helpers.TransitGatewayRouteTable{
+				"tgw-rtb-00000001": {
+					ID:   "tgw-rtb-00000001",
+					Name: "rt1",
+					Routes: []helpers.TransitGatewayRoute{
+						{
+							State: "active",
+							CIDR:  "10.0.0.0/16",
+							Attachment: helpers.TransitGatewayAttachment{
+								ID:         "tgw-attach-vpc",
+								ResourceID: "vpc-00000001",
+							},
+						},
+						{
+							State: "active",
+							CIDR:  "192.168.0.0/16",
+							Attachment: helpers.TransitGatewayAttachment{
+								ID:         "tgw-attach-vpn",
+								ResourceID: "vpn-00000001",
+							},
+						},
+					},
+					SourceAttachments: []helpers.TransitGatewayAttachment{
+						{
+							ID:           "tgw-attach-dxgw",
+							ResourceID:   "dxgw-00000001",
+							ResourceType: "direct-connect-gateway",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	attachedresources, tgwrts := filterGateway(gateways)
+
+	// Route table should list both VPC and VPN as destinations
+	assert.Contains(t, tgwrts["tgw-rtb-00000001"], "vpc-00000001")
+	assert.Contains(t, tgwrts["tgw-rtb-00000001"], "vpn-00000001")
+
+	// All resource types should appear in attachedresources
+	assert.Contains(t, attachedresources, "vpc-00000001", "VPC should be in attached resources")
+	assert.Contains(t, attachedresources, "vpn-00000001", "VPN should be in attached resources")
+	assert.Contains(t, attachedresources, "dxgw-00000001", "DX gateway should be in attached resources")
+
+	// DX gateway (source attachment only) should have its route table set
+	assert.Equal(t, "tgw-rtb-00000001", attachedresources["dxgw-00000001"])
+}
+
+// TestFilterGateway_NonVPCSourceAttachmentNotDuplicated verifies that a
+// resource appearing as both a route target and a source attachment is not
+// duplicated and retains its route table association.
+func TestFilterGateway_NonVPCSourceAttachmentNotDuplicated(t *testing.T) {
+	tgwresourceid = ""
+
+	gateways := []helpers.TransitGateway{
+		{
+			ID:        "tgw-00000001",
+			AccountID: "123456789012",
+			RouteTables: map[string]helpers.TransitGatewayRouteTable{
+				"tgw-rtb-00000001": {
+					ID: "tgw-rtb-00000001",
+					Routes: []helpers.TransitGatewayRoute{
+						{
+							State: "active",
+							CIDR:  "172.16.0.0/12",
+							Attachment: helpers.TransitGatewayAttachment{
+								ID:         "tgw-attach-vpn",
+								ResourceID: "vpn-00000001",
+							},
+						},
+					},
+					SourceAttachments: []helpers.TransitGatewayAttachment{
+						{
+							ID:           "tgw-attach-vpn",
+							ResourceID:   "vpn-00000001",
+							ResourceType: "vpn",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	attachedresources, _ := filterGateway(gateways)
+
+	// VPN appears in both routes and source attachments — should have route table set
+	assert.Equal(t, "tgw-rtb-00000001", attachedresources["vpn-00000001"])
+}

--- a/cmd/tgwroutes.go
+++ b/cmd/tgwroutes.go
@@ -16,12 +16,11 @@ var tgwroutetablesCmd = &cobra.Command{
 	Use:   "routetables",
 	Short: "Get an overview of connections between Transit Gateway Route Tables and attached resources",
 	Long: `Get an overview of connections between Transit Gateway Route Tables and attached resources
-	This is currently limited to showing VPC attachments only, but that will be fixed soon.
 
 	Using the --resource-id (-r) flag, you can limit the output to the provided resource.
-	For a route table that means all the VPCs it connects to,
+	For a route table that means all the resources it connects to,
 	while for a VPC that means all the route tables it connects
-	to and through them what other VPCs can reach it or it can reach.
+	to and through them what other resources can reach it or it can reach.
 
 	Supports a Draw.io output`,
 	Run: tgwroutes,
@@ -87,6 +86,10 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 				content["Image"] = drawio.AWSShape("Network Content Delivery", "VPC")
 			case "vpn":
 				content["Image"] = drawio.AWSShape("Network Content Delivery", "Site-to-Site VPN")
+			case "dxgw":
+				content["Image"] = drawio.AWSShape("Network Content Delivery", "Direct Connect Gateway")
+			case tgwResourceType:
+				content["Image"] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
 			}
 		}
 		holder := format.OutputHolder{Contents: content}
@@ -136,7 +139,7 @@ func filterGateway(gateways []helpers.TransitGateway) (map[string]string, map[st
 
 	for _, gateway := range gateways {
 		// only add relevant gateway if filtered by gateway
-		if limitertype == "tgw" && gateway.ID != tgwresourceid {
+		if limitertype == tgwResourceType && gateway.ID != tgwresourceid {
 			continue
 		}
 		for _, routetable := range gateway.RouteTables {


### PR DESCRIPTION
Fixes Transit ticket T-924: TGW route-table overview omits non-VPC attachments