### PR TITLE
fix: S3 bucket listing still starts with an unpaginated ListBuckets request (T-1055)

### DIFF
--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -107,6 +107,7 @@ func GetAllBuckets(svc S3API) ([]types.Bucket, string) {
 
 	for i := 0; ; i++ {
 		resp, err := svc.ListBuckets(context.TODO(), &s3.ListBucketsInput{
+			MaxBuckets:        aws.Int32(10000),
 			ContinuationToken: token,
 		})
 		if err != nil {

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -934,6 +934,9 @@ func TestGetAllBuckets_Pagination(t *testing.T) {
 	mock := &mockS3Client{
 		listBuckets: func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
 			calls++
+			if params.MaxBuckets == nil || *params.MaxBuckets != 10000 {
+				return nil, fmt.Errorf("expected MaxBuckets=10000 on every call, got %v", params.MaxBuckets)
+			}
 			start := 0
 			if params.ContinuationToken != nil {
 				if _, err := fmt.Sscanf(*params.ContinuationToken, "%d", &start); err != nil {


### PR DESCRIPTION
Fixes Transit ticket T-1055: S3 bucket listing still starts with an unpaginated ListBuckets request