### PR TITLE
Fix T-1093: S3 absent configurations render as warnings or unknowns

### DIFF
--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -9,7 +10,38 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 )
+
+// S3 error codes that represent a normal "no configuration present"
+// answer rather than a failed read. When S3 returns one of these, the
+// corresponding optional configuration simply does not exist for the
+// bucket; this is a definitive absence answer, not an access/transport
+// failure, so callers set the empty/false state instead of leaving it
+// "unknown" and emitting a warning.
+const (
+	s3ErrNoSuchTagSet                              = "NoSuchTagSet"
+	s3ErrNoSuchBucketPolicy                        = "NoSuchBucketPolicy"
+	s3ErrReplicationConfigurationNotFound          = "ReplicationConfigurationNotFoundError"
+	s3ErrServerSideEncryptionConfigurationNotFound = "ServerSideEncryptionConfigurationNotFoundError"
+)
+
+// isS3AbsenceError reports whether err is a smithy API error whose error
+// code matches one of the provided codes. These codes mean S3 gave a
+// definitive "configuration absent" answer, not a failed read.
+func isS3AbsenceError(err error, codes ...string) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	code := apiErr.ErrorCode()
+	for _, c := range codes {
+		if code == c {
+			return true
+		}
+	}
+	return false
+}
 
 // S3API defines the subset of the S3 client used by helpers.GetBucketDetails.
 // It exists so tests can inject per-call failures when exercising the
@@ -211,24 +243,29 @@ func GetBucketDetails(svc S3API) []S3Bucket {
 
 		params := &s3.GetBucketEncryptionInput{Bucket: bucket.Name}
 		resp, err := svc.GetBucketEncryption(context.TODO(), params)
-		if err != nil {
+		switch {
+		case isS3AbsenceError(err, s3ErrServerSideEncryptionConfigurationNotFound):
+			// No bucket-level encryption configuration exists. This is a
+			// definitive "not encrypted" answer, not a failed read, so
+			// record false rather than leaving the state unknown.
+			bucketObject.HasEncryption = boolPtr(false)
+		case err != nil:
 			warnS3DetailError(bucketName, "GetBucketEncryption", err)
-		} else {
-			if resp != nil && resp.ServerSideEncryptionConfiguration != nil {
-				bucketObject.EncryptionRules = resp.ServerSideEncryptionConfiguration.Rules
-				bucketObject.HasEncryption = boolPtr(true)
-			} else {
-				bucketObject.HasEncryption = boolPtr(false)
-			}
+		case resp != nil && resp.ServerSideEncryptionConfiguration != nil:
+			bucketObject.EncryptionRules = resp.ServerSideEncryptionConfiguration.Rules
+			bucketObject.HasEncryption = boolPtr(true)
+		default:
+			bucketObject.HasEncryption = boolPtr(false)
 		}
 
 		tagsResp, err := svc.GetBucketTagging(context.TODO(), &s3.GetBucketTaggingInput{Bucket: bucket.Name})
-		if err != nil {
-			// Tag retrieval commonly fails (NoSuchTagSet) for buckets
-			// with no tags; treat as "no tags" rather than an error.
-			// Other failures are logged but not fatal.
+		switch {
+		case isS3AbsenceError(err, s3ErrNoSuchTagSet):
+			// NoSuchTagSet is the normal response for an untagged bucket,
+			// not a failure. Leave Tags empty without a warning.
+		case err != nil:
 			warnS3DetailError(bucketName, "GetBucketTagging", err)
-		} else if tagsResp != nil {
+		case tagsResp != nil:
 			for _, tag := range tagsResp.TagSet {
 				tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
 			}
@@ -236,16 +273,24 @@ func GetBucketDetails(svc S3API) []S3Bucket {
 		bucketObject.Tags = tags
 
 		policyResp, err := svc.GetBucketPolicy(context.TODO(), &s3.GetBucketPolicyInput{Bucket: bucket.Name})
-		if err != nil {
+		switch {
+		case isS3AbsenceError(err, s3ErrNoSuchBucketPolicy):
+			// NoSuchBucketPolicy means no policy is attached, a definitive
+			// "not configured" state. Leave Policy empty without a warning.
+		case err != nil:
 			warnS3DetailError(bucketName, "GetBucketPolicy", err)
-		} else if policyResp != nil && policyResp.Policy != nil {
+		case policyResp != nil && policyResp.Policy != nil:
 			bucketObject.Policy = *policyResp.Policy
 		}
 
 		replicationResp, err := svc.GetBucketReplication(context.TODO(), &s3.GetBucketReplicationInput{Bucket: bucket.Name})
-		if err != nil {
+		switch {
+		case isS3AbsenceError(err, s3ErrReplicationConfigurationNotFound):
+			// No replication configuration exists, a definitive empty
+			// state. Leave Replication zero-valued without a warning.
+		case err != nil:
 			warnS3DetailError(bucketName, "GetBucketReplication", err)
-		} else if replicationResp != nil && replicationResp.ReplicationConfiguration != nil {
+		case replicationResp != nil && replicationResp.ReplicationConfiguration != nil:
 			bucketObject.Replication = *replicationResp.ReplicationConfiguration
 		}
 

--- a/helpers/s3_absence_test.go
+++ b/helpers/s3_absence_test.go
@@ -1,0 +1,157 @@
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
+)
+
+// s3APIErr builds a smithy API error with the given code, matching what
+// the AWS S3 SDK surfaces for absence states such as NoSuchTagSet.
+func s3APIErr(code string) error {
+	return &smithy.GenericAPIError{Code: code, Message: code}
+}
+
+// TestIsS3AbsenceError verifies the error classifier matches known
+// absence codes via smithy.APIError and rejects everything else.
+func TestIsS3AbsenceError(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		codes []string
+		want  bool
+	}{
+		{
+			name:  "matching single code",
+			err:   s3APIErr(s3ErrNoSuchTagSet),
+			codes: []string{s3ErrNoSuchTagSet},
+			want:  true,
+		},
+		{
+			name:  "matching one of several codes",
+			err:   s3APIErr(s3ErrNoSuchBucketPolicy),
+			codes: []string{s3ErrNoSuchTagSet, s3ErrNoSuchBucketPolicy},
+			want:  true,
+		},
+		{
+			name:  "non-matching API error code",
+			err:   s3APIErr("AccessDenied"),
+			codes: []string{s3ErrNoSuchTagSet},
+			want:  false,
+		},
+		{
+			name:  "non-API (transport) error",
+			err:   errBoomAbsence{},
+			codes: []string{s3ErrNoSuchTagSet},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isS3AbsenceError(tt.err, tt.codes...); got != tt.want {
+				t.Errorf("isS3AbsenceError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type errBoomAbsence struct{}
+
+func (errBoomAbsence) Error() string { return "connection refused" }
+
+// TestGetBucketDetails_AbsenceErrorsAreDefiniteState is the regression
+// test for T-1093. When S3 reports a known "configuration absent" error
+// code, the corresponding state must be a definite empty/false value
+// (not "unknown"), and no warning behaviour should apply.
+func TestGetBucketDetails_AbsenceErrorsAreDefiniteState(t *testing.T) {
+	const bucketName = "absent-config-bucket"
+
+	t.Run("encryption absent => HasEncryption false", func(t *testing.T) {
+		silenceStderr(t)
+		mock := healthyS3Mock(bucketName)
+		mock.getBucketEncryption = func(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+			return nil, s3APIErr(s3ErrServerSideEncryptionConfigurationNotFound)
+		}
+
+		buckets := GetBucketDetails(mock)
+		if len(buckets) != 1 {
+			t.Fatalf("expected 1 bucket, got %d", len(buckets))
+		}
+		b := buckets[0]
+		if b.HasEncryption == nil {
+			t.Fatal("HasEncryption is nil (unknown), want definite false")
+		}
+		if *b.HasEncryption {
+			t.Errorf("HasEncryption = true, want false")
+		}
+	})
+
+	t.Run("tags absent => Tags empty, no warning path", func(t *testing.T) {
+		silenceStderr(t)
+		mock := healthyS3Mock(bucketName)
+		mock.getBucketTagging = func(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error) {
+			return nil, s3APIErr(s3ErrNoSuchTagSet)
+		}
+
+		buckets := GetBucketDetails(mock)
+		if len(buckets) != 1 {
+			t.Fatalf("expected 1 bucket, got %d", len(buckets))
+		}
+		if len(buckets[0].Tags) != 0 {
+			t.Errorf("Tags = %v, want empty", buckets[0].Tags)
+		}
+	})
+
+	t.Run("policy absent => Policy empty", func(t *testing.T) {
+		silenceStderr(t)
+		mock := healthyS3Mock(bucketName)
+		mock.getBucketPolicy = func(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+			return nil, s3APIErr(s3ErrNoSuchBucketPolicy)
+		}
+
+		buckets := GetBucketDetails(mock)
+		if len(buckets) != 1 {
+			t.Fatalf("expected 1 bucket, got %d", len(buckets))
+		}
+		if buckets[0].Policy != "" {
+			t.Errorf("Policy = %q, want empty", buckets[0].Policy)
+		}
+	})
+
+	t.Run("replication absent => no rules", func(t *testing.T) {
+		silenceStderr(t)
+		mock := healthyS3Mock(bucketName)
+		mock.getBucketReplication = func(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error) {
+			return nil, s3APIErr(s3ErrReplicationConfigurationNotFound)
+		}
+
+		buckets := GetBucketDetails(mock)
+		if len(buckets) != 1 {
+			t.Fatalf("expected 1 bucket, got %d", len(buckets))
+		}
+		if len(buckets[0].Replication.Rules) != 0 {
+			t.Errorf("Replication.Rules = %v, want none", buckets[0].Replication.Rules)
+		}
+	})
+}
+
+// TestGetBucketDetails_RealEncryptionErrorStaysUnknown verifies that a
+// genuine (non-absence) error on the encryption call still leaves
+// HasEncryption nil so the renderer reports it as Unknown.
+func TestGetBucketDetails_RealEncryptionErrorStaysUnknown(t *testing.T) {
+	silenceStderr(t)
+	mock := healthyS3Mock("real-error-bucket")
+	mock.getBucketEncryption = func(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+		return nil, s3APIErr("AccessDenied")
+	}
+
+	buckets := GetBucketDetails(mock)
+	if len(buckets) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(buckets))
+	}
+	if buckets[0].HasEncryption != nil {
+		t.Errorf("HasEncryption = %v, want nil (unknown) on a real error", *buckets[0].HasEncryption)
+	}
+}


### PR DESCRIPTION
## Summary

`helpers.GetBucketDetails` treated every S3 detail-call error as an unknown failure. Several S3 detail calls return a specific error code when an optional configuration is simply absent, and those normal absence states were emitted as warnings via `warnS3DetailError`. For encryption specifically, the error branch left `HasEncryption` nil, which renders as `Unknown` instead of a definite "not configured" state.

## Root Cause

Each detail call in `GetBucketDetails` had a single error branch that warned for any error, with no distinction between "configuration absent" and "read failed".

## Fix

Added `isS3AbsenceError(err, codes...)` (using `smithy.APIError` via `errors.As`) and known absence-code constants. The encryption, tagging, policy, and replication calls now classify these codes separately and set a definite empty/false state without warning:

- `NoSuchTagSet` -> empty Tags
- `NoSuchBucketPolicy` -> empty Policy
- `ReplicationConfigurationNotFoundError` -> no replication rules
- `ServerSideEncryptionConfigurationNotFoundError` -> `HasEncryption=false` (was nil/Unknown)

Real access/transport/API errors still warn and leave the tri-state field nil (rendered as `Unknown`).

## Testing

- New regression tests in `helpers/s3_absence_test.go` build smithy API errors for each absence code and assert the definite empty/false state, plus a real-error case (`AccessDenied`) that must stay `Unknown`, and unit tests for `isS3AbsenceError`.
- `go test ./...` and `make test` pass.