### PR TITLE
Fix T-1222: vpc ip-finder search-all-regions flag is ignored

### DIFF
--- a/cmd/vpcipfinder.go
+++ b/cmd/vpcipfinder.go
@@ -21,10 +21,14 @@ var ipFinderCmd = &cobra.Command{
 	and return comprehensive information about the resource associated with that IP address.
 	
 	The search includes both primary and secondary IP addresses on ENIs.
-	
+
+	The search is limited to a single region. Use the --region flag to target a
+	specific region. Searching across all regions is not yet supported.
+
 	Examples:
 	  awstools vpc ip-finder 10.0.1.100
-	  awstools vpc ip-finder 10.0.1.100 --output json`,
+	  awstools vpc ip-finder 10.0.1.100 --output json
+	  awstools vpc ip-finder 10.0.1.100 --region eu-west-1`,
 	Args: cobra.ExactArgs(1),
 	Run:  findIPAddress,
 }
@@ -35,15 +39,34 @@ var (
 
 func init() {
 	vpcCmd.AddCommand(ipFinderCmd)
-	ipFinderCmd.Flags().BoolVar(&searchAllRegions, "search-all-regions", false, "Search across all regions (future enhancement)")
+	ipFinderCmd.Flags().BoolVar(&searchAllRegions, "search-all-regions", false, "Search across all regions (not yet supported)")
+}
+
+// validateIPFinderFlags validates the command arguments and flags before any
+// AWS calls are made. It is kept separate from findIPAddress so the flag logic
+// can be unit tested without AWS configuration or credentials.
+//
+// The --search-all-regions flag is rejected because multi-region search is not
+// implemented. Previously the flag was accepted and silently ignored, so the
+// single-region search would run anyway and a user could receive a false
+// "not found" result that looked like an all-region search had been performed
+// (T-1222).
+func validateIPFinderFlags(ipAddress string, allRegions bool) error {
+	if !helpers.IsValidIPAddress(ipAddress) {
+		return fmt.Errorf("invalid IP address format: %s\n\nPlease provide a valid IPv4 or IPv6 address.\nExamples:\n  - IPv4: 192.168.1.1\n  - IPv6: 2001:db8::1", ipAddress)
+	}
+	if allRegions {
+		return fmt.Errorf("--search-all-regions is not yet supported\n\nThe search is limited to a single region. Use the --region flag to target a specific region instead")
+	}
+	return nil
 }
 
 func findIPAddress(_ *cobra.Command, args []string) {
 	ipAddress := args[0]
 
-	// Validate IP address format with helpful error message
-	if !helpers.IsValidIPAddress(ipAddress) {
-		panic(fmt.Errorf("invalid IP address format: %s\n\nPlease provide a valid IPv4 or IPv6 address.\nExamples:\n  - IPv4: 192.168.1.1\n  - IPv6: 2001:db8::1", ipAddress))
+	// Validate arguments and flags before any AWS calls.
+	if err := validateIPFinderFlags(ipAddress, searchAllRegions); err != nil {
+		panic(err)
 	}
 
 	// Load AWS configuration

--- a/cmd/vpcipfinder_test.go
+++ b/cmd/vpcipfinder_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateIPFinderFlags_SearchAllRegionsRejected is the regression test for
+// T-1222: the --search-all-regions flag was registered but never read, so the
+// command silently ignored it and only searched the current region. A user
+// passing the flag would get a false negative ("not found") that looked like a
+// multi-region search had occurred.
+//
+// Expected behaviour: until multi-region search is implemented, passing the flag
+// must produce a clear error rather than a silent no-op.
+func TestValidateIPFinderFlags_SearchAllRegionsRejected(t *testing.T) {
+	err := validateIPFinderFlags("10.0.1.100", true)
+	if err == nil {
+		t.Fatal("expected an error when --search-all-regions is used, got nil (flag was silently ignored)")
+	}
+	if !strings.Contains(err.Error(), "search-all-regions") {
+		t.Errorf("expected error to mention search-all-regions, got: %v", err)
+	}
+}
+
+// TestValidateIPFinderFlags_ValidIPNoFlag confirms the normal path (valid IP,
+// flag not set) is accepted without error.
+func TestValidateIPFinderFlags_ValidIPNoFlag(t *testing.T) {
+	if err := validateIPFinderFlags("10.0.1.100", false); err != nil {
+		t.Errorf("expected no error for valid IP without flag, got: %v", err)
+	}
+}
+
+// TestValidateIPFinderFlags_InvalidIP confirms invalid IP addresses are rejected
+// with a descriptive error.
+func TestValidateIPFinderFlags_InvalidIP(t *testing.T) {
+	err := validateIPFinderFlags("not-an-ip", false)
+	if err == nil {
+		t.Fatal("expected an error for an invalid IP address, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid IP address") {
+		t.Errorf("expected error to mention invalid IP address, got: %v", err)
+	}
+}

--- a/specs/bugfixes/vpc-ipfinder-all-regions-flag/decision_log.md
+++ b/specs/bugfixes/vpc-ipfinder-all-regions-flag/decision_log.md
@@ -1,0 +1,59 @@
+# Decision Log: vpc-ipfinder-all-regions-flag
+
+## Decision 1: Reject --search-all-regions instead of implementing multi-region search
+
+**Date**: 2026-06-01
+**Status**: accepted
+
+### Context
+
+`cmd/vpcipfinder.go` registered a `--search-all-regions` flag bound to the
+`searchAllRegions` variable, but the variable was never read. The command always
+searched only the current region, so passing the flag produced a silent no-op
+and could give users a false "not found" result. T-1222 asks to either implement
+the multi-region search or remove/disable the flag, choosing the simpler correct
+option and documenting the choice.
+
+### Decision
+
+Reject the `--search-all-regions` flag with a clear error until multi-region
+search is implemented, rather than implementing the multi-region search now. The
+flag remains registered (for discoverability and forward compatibility) but
+returns an explanatory error when used. Help text and the command long
+description are updated to state the search is single-region.
+
+### Rationale
+
+Implementing a correct multi-region search is a non-trivial change: enumerate
+all enabled regions, create a per-region EC2 client, run the existing lookup in
+each, aggregate and de-duplicate results, and handle partial failures and the
+extra API cost. That is well beyond a bug fix in scope and risk. Rejecting the
+flag is small, removes the false-negative immediately, and gives the user an
+actionable message (use `--region`). The flag's own help text already labelled
+it a "future enhancement", confirming the feature was never delivered.
+
+### Alternatives Considered
+
+- **Implement multi-region search**: Make the flag actually search every region
+  and aggregate results - Rejected for this ticket because it is a sizeable
+  feature (region enumeration, per-region clients, aggregation, error handling,
+  AWS-call cost) that exceeds the scope and risk appropriate for a bug fix.
+- **Remove the flag entirely**: Delete the flag registration and variable -
+  Rejected because an unknown-flag error is less helpful than an explicit "not
+  yet supported" message, and keeping the flag preserves discoverability and a
+  stable surface for when the feature lands.
+
+### Consequences
+
+**Positive:**
+- No more silent no-op; users get a clear, actionable error.
+- Flag validation is extracted into a pure function and unit tested without AWS
+  credentials.
+- The path to a real implementation stays open (flag already exists).
+
+**Negative:**
+- The flag still cannot perform a multi-region search; that work is deferred.
+- A user who scripted around the (previously ignored) flag will now get an error
+  instead of single-region results. This is the intended correction.
+
+---


### PR DESCRIPTION
## Summary

`awstools vpc ip-finder <ip> --search-all-regions` accepted the --search-all-regions flag but never read it, so the command silently searched only the current region. A user passing the flag could get a false "not found" result that looked like a multi-region search had run.

## Root cause

cmd/vpcipfinder.go bound the flag to searchAllRegions but findIPAddress never read the variable. There is no multi-region code path; the flag help text described it as a future enhancement.

## Fix

Per T-1222 guidance to choose the simpler correct option, multi-region search is not implemented. The flag is now rejected with a clear error directing users to --region, removing the false negative. Flag validation was extracted into validateIPFinderFlags so it can be unit tested without AWS credentials; help text and long description updated.

The choice is documented in specs/bugfixes/vpc-ipfinder-all-regions-flag/decision_log.md.

## Tests

New regression tests in cmd/vpcipfinder_test.go (red before fix: undefined validateIPFinderFlags; green after). Full go test ./... and go vet pass.
