### PR TITLE
Fix T-1124: Skip Empty TGW Blackhole Destinations In Graph Output

### DIFF
--- a/cmd/tgwroutes_test.go
+++ b/cmd/tgwroutes_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/ArjenSchwarz/awstools/helpers"
+)
+
+// TestFilterGatewaySkipsBlackholeRoutes is the regression test for T-1124.
+//
+// `tgw routetables` full graph mode calls filterGateway, which iterates over
+// TransitGatewayRouteTable.Routes. The helpers append active routes plus
+// blackhole routes, and blackhole routes have no attachment, so their
+// Attachment.ResourceID is the empty string. The bug was that filterGateway
+// appended that empty string to the route table destinations and created an
+// attachedresources[""] entry, which rendered a blank destination/resource row
+// and produced bad Draw.io edges.
+//
+// Expected behaviour: blackhole routes (empty attachment resource IDs) are
+// skipped, so neither the route table destinations nor the attached resources
+// contain an empty string.
+func TestFilterGatewaySkipsBlackholeRoutes(t *testing.T) {
+	// Ensure no resource-id filter is applied for this test.
+	originalResourceID := tgwresourceid
+	tgwresourceid = ""
+	t.Cleanup(func() { tgwresourceid = originalResourceID })
+
+	const (
+		routeTableID  = "tgw-rtb-test"
+		activeVPCID   = "vpc-active"
+		gatewayID     = "tgw-test"
+		blackholeCIDR = "10.0.0.0/8"
+	)
+
+	gateways := []helpers.TransitGateway{
+		{
+			ID: gatewayID,
+			RouteTables: map[string]helpers.TransitGatewayRouteTable{
+				routeTableID: {
+					ID: routeTableID,
+					Routes: []helpers.TransitGatewayRoute{
+						{
+							// Active route with a real attachment.
+							State:     "active",
+							RouteType: "static",
+							Attachment: helpers.TransitGatewayAttachment{
+								ID:           "tgw-attach-active",
+								ResourceID:   activeVPCID,
+								ResourceType: vpcResourceType,
+							},
+						},
+						{
+							// Blackhole route: no attachment, so ResourceID is "".
+							State:     "blackhole",
+							RouteType: "static",
+							CIDR:      blackholeCIDR,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	attachedresources, tgwrts := filterGateway(gateways)
+
+	destinations, ok := tgwrts[routeTableID]
+	if !ok {
+		t.Fatalf("expected route table %q to be present in destinations map", routeTableID)
+	}
+
+	if slices.Contains(destinations, "") {
+		t.Errorf("route table destinations must not contain an empty string; got %#v", destinations)
+	}
+	if !slices.Contains(destinations, activeVPCID) {
+		t.Errorf("route table destinations should contain the active VPC %q; got %#v", activeVPCID, destinations)
+	}
+
+	if _, exists := attachedresources[""]; exists {
+		t.Errorf("attached resources must not contain an empty resource ID entry; got %#v", attachedresources)
+	}
+	if _, exists := attachedresources[activeVPCID]; !exists {
+		t.Errorf("attached resources should contain the active VPC %q; got %#v", activeVPCID, attachedresources)
+	}
+}


### PR DESCRIPTION
## Summary

`awstools tgw routetables` full graph mode calls `filterGateway`, which iterates over `TransitGatewayRouteTable.Routes` (active routes plus blackhole routes). Blackhole routes have no attachment, so their `Attachment.ResourceID` is empty. Without a guard, `filterGateway` would append that empty string to the route-table destinations and create an `attachedresources[""]` entry, rendering a blank destination/resource row and bad Draw.io edges.

## Root Cause

`helpers.parseBlackholeRoute` does not populate `Attachment`, so blackhole routes carry an empty `Attachment.ResourceID`. The original loop appended that ID unconditionally.

## Fix

The production guard (skip routes where `route.Attachment.ResourceID == ""`) is already present in `filterGateway`. This PR adds the regression test requested by the ticket to lock the behaviour in:

`cmd/tgwroutes_test.go::TestFilterGatewaySkipsBlackholeRoutes` builds a route table with one active route and one blackhole route, then asserts that neither the route-table destinations nor the attached resources contain "".

## Verification

- Red: with the guard temporarily removed, the new test fails (`got []string{"vpc-active", ""}` plus an `attachedresources[""]` entry).
- Green: with the guard restored, the test passes.
- `go test ./...` passes for the whole module.

Note: T-1393 separately handles the analogous issue in `tgw dangling`; this PR does not touch `tgwdangling`.