### PR TITLE
Fix T-1234: VPC Overview Summary Overflows With Multiple IPv6 Subnets

### DIFF
--- a/cmd/vpcoverview.go
+++ b/cmd/vpcoverview.go
@@ -131,35 +131,11 @@ func vpcOverview(_ *cobra.Command, _ []string) {
 	summaryOutput := format.OutputArray{Keys: summaryKeys, Settings: settings.NewOutputSettings()}
 	summaryOutput.Settings.SeparateTables = true
 
-	// Calculate summary for filtered VPCs
-	var filteredSummary struct {
-		totalVPCs      int
-		totalSubnets   int
-		totalIPs       int
-		usedIPs        int
-		awsReservedIPs int
-		serviceIPs     int
-		availableIPs   int
-	}
-
-	for _, vpc := range filteredVPCs {
-		filteredSummary.totalVPCs++
-		for _, subnet := range vpc.Subnets {
-			filteredSummary.totalSubnets++
-			filteredSummary.totalIPs += subnet.TotalIPs
-			filteredSummary.usedIPs += subnet.UsedIPs
-			filteredSummary.availableIPs += subnet.AvailableIPs
-
-			// Count AWS reserved IPs and service IPs from IP details
-			for _, ipDetail := range subnet.IPDetails {
-				if ipDetail.UsageType == "RESERVED BY AWS" {
-					filteredSummary.awsReservedIPs++
-				} else {
-					filteredSummary.serviceIPs++
-				}
-			}
-		}
-	}
+	// Calculate summary for filtered VPCs. SummarizeVPCUsage uses saturating
+	// addition so VPCs with multiple IPv6-only subnets (each reporting a
+	// math.MaxInt "effectively unlimited" sentinel) cannot overflow the totals
+	// into negative values (T-1234).
+	filteredSummary := helpers.SummarizeVPCUsage(filteredVPCs)
 
 	// Set title based on filter
 	if vpcIDFilter != "" {
@@ -176,13 +152,13 @@ func vpcOverview(_ *cobra.Command, _ []string) {
 		metric string
 		count  int
 	}{
-		{"Total VPCs", filteredSummary.totalVPCs},
-		{"Total Subnets", filteredSummary.totalSubnets},
-		{"Total IP Addresses", filteredSummary.totalIPs},
-		{"Used IP Addresses", filteredSummary.usedIPs},
-		{"  - AWS Reserved IPs", filteredSummary.awsReservedIPs},
-		{"  - Service IPs", filteredSummary.serviceIPs},
-		{"Available IP Addresses", filteredSummary.availableIPs},
+		{"Total VPCs", filteredSummary.TotalVPCs},
+		{"Total Subnets", filteredSummary.TotalSubnets},
+		{"Total IP Addresses", filteredSummary.TotalIPs},
+		{"Used IP Addresses", filteredSummary.UsedIPs},
+		{"  - AWS Reserved IPs", filteredSummary.AWSReservedIPs},
+		{"  - Service IPs", filteredSummary.ServiceIPs},
+		{"Available IP Addresses", filteredSummary.AvailableIPs},
 	}
 
 	for _, item := range summaryData {

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -1083,10 +1083,13 @@ func GetVPCUsageOverview(svc *ec2.Client) VPCOverview {
 				}
 				vpcSubnets = append(vpcSubnets, subnetInfo)
 
-				// Update summary
-				summary.TotalIPs += totalIPs
-				summary.UsedIPs += usedIPs
-				summary.AvailableIPs += availableIPs
+				// Update summary. Use saturating addition for the IP-count
+				// totals so two or more IPv6-only subnets (each reporting a
+				// math.MaxInt "effectively unlimited" sentinel) cannot overflow
+				// into a negative aggregate (T-1234).
+				summary.TotalIPs = saturatingAdd(summary.TotalIPs, totalIPs)
+				summary.UsedIPs = saturatingAdd(summary.UsedIPs, usedIPs)
+				summary.AvailableIPs = saturatingAdd(summary.AvailableIPs, availableIPs)
 				summary.AWSReservedIPs += awsReservedIPs
 				summary.ServiceIPs += serviceIPs
 			}
@@ -1363,6 +1366,51 @@ func calculateSubnetStats(cidr string) (int, int, error) {
 	availableIPs := max(totalIPs-5, 0)
 
 	return totalIPs, availableIPs, nil
+}
+
+// saturatingAdd adds two non-negative IP counts, clamping at math.MaxInt
+// instead of overflowing into a negative value. IPv6-only subnets report
+// math.MaxInt as an "effectively unlimited" sentinel (T-774); summing two or
+// more such values with naive integer addition wraps to a negative number,
+// producing nonsensical negative summary totals (T-1234). Saturating addition
+// keeps the aggregate at the sentinel, preserving its "effectively unlimited"
+// meaning.
+func saturatingAdd(a, b int) int {
+	if a > math.MaxInt-b {
+		return math.MaxInt
+	}
+	return a + b
+}
+
+// SummarizeVPCUsage computes aggregate usage statistics across the supplied
+// VPCs using saturating addition so that IPv6-only subnets (which report a
+// math.MaxInt "effectively unlimited" sentinel) cannot overflow the totals.
+//
+// AWS-reserved and service IP counts are derived from each subnet's per-address
+// IPDetails: any address classified as "RESERVED BY AWS" is counted as reserved
+// and every other detailed address is counted as a service IP. IPv6-only
+// subnets have no per-address details, so they contribute nothing to these two
+// counts.
+func SummarizeVPCUsage(vpcs []VPCUsageInfo) VPCUsageSummary {
+	var summary VPCUsageSummary
+	summary.TotalVPCs = len(vpcs)
+	for _, vpc := range vpcs {
+		for _, subnet := range vpc.Subnets {
+			summary.TotalSubnets++
+			summary.TotalIPs = saturatingAdd(summary.TotalIPs, subnet.TotalIPs)
+			summary.UsedIPs = saturatingAdd(summary.UsedIPs, subnet.UsedIPs)
+			summary.AvailableIPs = saturatingAdd(summary.AvailableIPs, subnet.AvailableIPs)
+
+			for _, ipDetail := range subnet.IPDetails {
+				if ipDetail.UsageType == "RESERVED BY AWS" {
+					summary.AWSReservedIPs++
+				} else {
+					summary.ServiceIPs++
+				}
+			}
+		}
+	}
+	return summary
 }
 
 // sortIPAddresses sorts IP addresses in ascending numerical order

--- a/helpers/ec2_vpc_summary_overflow_test.go
+++ b/helpers/ec2_vpc_summary_overflow_test.go
@@ -1,0 +1,148 @@
+package helpers
+
+import (
+	"math"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestSaturatingAdd_DoesNotOverflow verifies that summing two "effectively
+// unlimited" sentinel values (math.MaxInt, used for IPv6-only subnet capacity
+// per T-774) does not wrap to a negative number. Naive integer addition of two
+// math.MaxInt values overflows and produces a negative result (T-1234).
+func TestSaturatingAdd_DoesNotOverflow(t *testing.T) {
+	tests := []struct {
+		name string
+		a    int
+		b    int
+		want int
+	}{
+		{"two sentinels saturate", math.MaxInt, math.MaxInt, math.MaxInt},
+		{"sentinel plus normal saturates", math.MaxInt, 256, math.MaxInt},
+		{"normal plus sentinel saturates", 256, math.MaxInt, math.MaxInt},
+		{"normal addition unchanged", 100, 200, 300},
+		{"zero values", 0, 0, 0},
+		{"just below overflow", math.MaxInt - 5, 5, math.MaxInt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := saturatingAdd(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("saturatingAdd(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+			if got < 0 {
+				t.Errorf("saturatingAdd(%d, %d) = %d is negative; sentinel summation overflowed", tt.a, tt.b, got)
+			}
+		})
+	}
+}
+
+// TestSummarizeVPCUsage_TwoIPv6OnlySubnetsNoOverflow reproduces the T-1234 bug:
+// a VPC with two IPv6-only subnets, each reporting math.MaxInt total/available
+// IPs, must not produce a negative aggregate summary. Before the fix the inline
+// `summary.TotalIPs += totalIPs` arithmetic wrapped to a negative value.
+func TestSummarizeVPCUsage_TwoIPv6OnlySubnetsNoOverflow(t *testing.T) {
+	vpcs := []VPCUsageInfo{
+		{
+			ID:   "vpc-ipv6",
+			Name: "ipv6-vpc",
+			CIDR: "2001:db8::/56",
+			Subnets: []SubnetUsageInfo{
+				{
+					ID:           "subnet-ipv6-a",
+					CIDR:         "2001:db8:0:1::/64",
+					TotalIPs:     math.MaxInt,
+					AvailableIPs: math.MaxInt - 5,
+					UsedIPs:      5,
+				},
+				{
+					ID:           "subnet-ipv6-b",
+					CIDR:         "2001:db8:0:2::/64",
+					TotalIPs:     math.MaxInt,
+					AvailableIPs: math.MaxInt - 5,
+					UsedIPs:      5,
+				},
+			},
+		},
+	}
+
+	summary := SummarizeVPCUsage(vpcs)
+
+	if summary.TotalIPs < 0 {
+		t.Errorf("TotalIPs = %d is negative; two IPv6-only subnets overflowed the summary", summary.TotalIPs)
+	}
+	if summary.AvailableIPs < 0 {
+		t.Errorf("AvailableIPs = %d is negative; two IPv6-only subnets overflowed the summary", summary.AvailableIPs)
+	}
+	if summary.TotalIPs != math.MaxInt {
+		t.Errorf("TotalIPs = %d, want math.MaxInt (effectively unlimited)", summary.TotalIPs)
+	}
+	if summary.AvailableIPs != math.MaxInt {
+		t.Errorf("AvailableIPs = %d, want math.MaxInt (effectively unlimited)", summary.AvailableIPs)
+	}
+	if summary.TotalVPCs != 1 {
+		t.Errorf("TotalVPCs = %d, want 1", summary.TotalVPCs)
+	}
+	if summary.TotalSubnets != 2 {
+		t.Errorf("TotalSubnets = %d, want 2", summary.TotalSubnets)
+	}
+	if summary.UsedIPs != 10 {
+		t.Errorf("UsedIPs = %d, want 10", summary.UsedIPs)
+	}
+}
+
+// TestSummarizeVPCUsage_NormalIPv4Unchanged ensures the saturating summary
+// computes ordinary IPv4 totals exactly as before for non-sentinel values.
+func TestSummarizeVPCUsage_NormalIPv4Unchanged(t *testing.T) {
+	vpcs := []VPCUsageInfo{
+		{
+			ID: "vpc-ipv4",
+			Subnets: []SubnetUsageInfo{
+				{
+					ID:           "subnet-a",
+					CIDR:         "10.0.0.0/28", // 16 IPs
+					TotalIPs:     16,
+					AvailableIPs: 11,
+					UsedIPs:      5,
+					IPDetails: []IPAddressInfo{
+						{IPAddress: "10.0.0.0", UsageType: "RESERVED BY AWS"},
+						{IPAddress: "10.0.0.1", UsageType: "RESERVED BY AWS"},
+						{IPAddress: "10.0.0.5", UsageType: "EC2 Instance"},
+					},
+				},
+				{
+					ID:           "subnet-b",
+					CIDR:         "10.0.1.0/28", // 16 IPs
+					TotalIPs:     16,
+					AvailableIPs: 11,
+					UsedIPs:      5,
+				},
+			},
+		},
+	}
+
+	summary := SummarizeVPCUsage(vpcs)
+
+	if summary.TotalIPs != 32 {
+		t.Errorf("TotalIPs = %d, want 32", summary.TotalIPs)
+	}
+	if summary.AvailableIPs != 22 {
+		t.Errorf("AvailableIPs = %d, want 22", summary.AvailableIPs)
+	}
+	if summary.UsedIPs != 10 {
+		t.Errorf("UsedIPs = %d, want 10", summary.UsedIPs)
+	}
+	if summary.AWSReservedIPs != 2 {
+		t.Errorf("AWSReservedIPs = %d, want 2", summary.AWSReservedIPs)
+	}
+	if summary.ServiceIPs != 1 {
+		t.Errorf("ServiceIPs = %d, want 1", summary.ServiceIPs)
+	}
+}
+
+// compile-time guard that the types referenced above are the real ones.
+var _ = types.Tag{}
+var _ = aws.String


### PR DESCRIPTION
## Summary

`vpc overview` reported negative "Total IP Addresses" and "Available IP Addresses" in its summary for any account with more than one IPv6-only subnet.

## Root Cause

IPv6-only subnets report `math.MaxInt` as an "effectively unlimited" capacity sentinel (introduced in T-774). The summary aggregation summed these capped values with plain integer addition in two places (`helpers.GetVPCUsageOverview` and the inline filtered summary in `cmd/vpcoverview.go`). Adding two `math.MaxInt` values overflows and wraps to a negative number.

## Fix

- Added `saturatingAdd(a, b int) int` in `helpers/ec2.go` that clamps at `math.MaxInt` instead of overflowing.
- Added `SummarizeVPCUsage([]VPCUsageInfo) VPCUsageSummary` that aggregates usage with saturating addition and derives reserved/service counts from per-address `IPDetails`.
- `GetVPCUsageOverview` now uses `saturatingAdd` for the IP-count totals.
- `cmd/vpcoverview.go` now calls `helpers.SummarizeVPCUsage`, removing the duplicated inline summation that had the same overflow bug.

The `math.MaxInt` sentinel semantics are preserved: saturating addition keeps the aggregate at the sentinel rather than wrapping.

## Tests

New regression tests in `helpers/ec2_vpc_summary_overflow_test.go`:
- `TestSaturatingAdd_DoesNotOverflow` (table test incl. two sentinels and the boundary)
- `TestSummarizeVPCUsage_TwoIPv6OnlySubnetsNoOverflow` (reproduces the reported bug)
- `TestSummarizeVPCUsage_NormalIPv4Unchanged` (guards IPv4 behaviour)

Red/green confirmed: with naive addition the IPv6 test fails with `TotalIPs = -2`; with the fix all tests pass. `go test ./...`, `go vet ./...`, and `gofmt` are clean.