### PR TITLE
Fix T-1391: S3 Public-State Logic Misreads Public Access Block

### DIFF
--- a/helpers/s3.go
+++ b/helpers/s3.go
@@ -270,45 +270,52 @@ func boolPtr(v bool) *bool {
 
 // computeBucketIsPublic returns the bucket's overall public state
 // based on policy status, ACL state, and Public Access Block
-// configuration. The result is nil ("unknown") whenever a contributing
-// input is unknown and could flip the answer:
+// configuration. The PAB fields are modelled by their effect on
+// CURRENT access, not on future writes:
+//   - RestrictPublicBuckets restricts access granted by public bucket
+//     policies, so it neutralises an existing public policy.
+//   - IgnorePublicAcls causes S3 to ignore existing public ACLs, so it
+//     neutralises a public ACL.
+//   - BlockPublicAcls and BlockPublicPolicy only reject FUTURE public
+//     ACL/policy writes; they do not affect existing exposure and are
+//     therefore intentionally ignored here.
+//
+// The result is nil ("unknown") whenever a contributing input is
+// unknown and could flip the answer:
 //   - If either the policy status or ACL state is unknown, the only
-//     way to claim "not public" is if the Public Access Block both
-//     restricts public buckets AND either ignores public ACLs or is
-//     irrelevant because the ACLs are known-clean.
-//   - A confirmed public input (policy or ACL) always makes the
-//     bucket public unless the PAB restricts public buckets AND
-//     blocks the corresponding path (IgnorePublicAcls for ACLs,
-//     BlockPublicPolicy for the policy).
+//     way to claim "not public" is if the PAB neutralises both paths
+//     (RestrictPublicBuckets for policies AND IgnorePublicAcls for
+//     ACLs).
+//   - A confirmed public input (policy or ACL) makes the bucket public
+//     unless the PAB neutralises the corresponding path.
 func computeBucketIsPublic(policyIsPublic, openACLs *bool, pab *types.PublicAccessBlockConfiguration) *bool {
 	// Extract the PAB booleans once. A missing PAB means "no block
 	// applied" for the purposes of this computation.
 	restrictPublicBuckets := false
 	ignorePublicAcls := false
-	blockPublicPolicy := false
 	if pab != nil {
 		restrictPublicBuckets = aws.ToBool(pab.RestrictPublicBuckets)
 		ignorePublicAcls = aws.ToBool(pab.IgnorePublicAcls)
-		blockPublicPolicy = aws.ToBool(pab.BlockPublicPolicy)
 	}
 
-	// When PAB fully locks the bucket down we can answer "not public"
-	// regardless of policy/ACL state, even if they are unknown.
-	if restrictPublicBuckets && ignorePublicAcls && blockPublicPolicy {
+	// When PAB neutralises both the policy and ACL paths we can answer
+	// "not public" regardless of policy/ACL state, even if they are
+	// unknown.
+	if restrictPublicBuckets && ignorePublicAcls {
 		return boolPtr(false)
 	}
 
 	// Otherwise, evaluate each source and factor in the PAB.
 	policyContribution := policyIsPublic
-	if policyContribution != nil && *policyContribution && restrictPublicBuckets && blockPublicPolicy {
-		// PAB neutralises a public policy.
+	if policyContribution != nil && *policyContribution && restrictPublicBuckets {
+		// RestrictPublicBuckets neutralises a public policy.
 		f := false
 		policyContribution = &f
 	}
 
 	aclContribution := openACLs
-	if aclContribution != nil && *aclContribution && restrictPublicBuckets && ignorePublicAcls {
-		// PAB neutralises public ACLs.
+	if aclContribution != nil && *aclContribution && ignorePublicAcls {
+		// IgnorePublicAcls neutralises public ACLs.
 		f := false
 		aclContribution = &f
 	}

--- a/helpers/s3_test.go
+++ b/helpers/s3_test.go
@@ -896,6 +896,59 @@ func TestComputeBucketIsPublic(t *testing.T) {
 			},
 			expected: aws.Bool(false),
 		},
+		{
+			// Regression for T-1391: RestrictPublicBuckets restricts access
+			// granted by a public bucket policy, so it neutralises an existing
+			// public policy on its own. BlockPublicPolicy only blocks FUTURE
+			// public-policy writes and is irrelevant here (set to false).
+			name:   "restrict public buckets neutralises policy without block policy",
+			policy: aws.Bool(true),
+			acls:   aws.Bool(false),
+			pab: &types.PublicAccessBlockConfiguration{
+				BlockPublicPolicy:     aws.Bool(false),
+				RestrictPublicBuckets: aws.Bool(true),
+			},
+			expected: aws.Bool(false),
+		},
+		{
+			// Regression for T-1391: IgnorePublicAcls causes S3 to ignore
+			// existing public ACLs, so it neutralises a public ACL on its own.
+			// RestrictPublicBuckets is not required (set to false).
+			name:   "ignore public acls neutralises acl without restrict buckets",
+			policy: aws.Bool(false),
+			acls:   aws.Bool(true),
+			pab: &types.PublicAccessBlockConfiguration{
+				IgnorePublicAcls:      aws.Bool(true),
+				RestrictPublicBuckets: aws.Bool(false),
+			},
+			expected: aws.Bool(false),
+		},
+		{
+			// Regression for T-1391: BlockPublicPolicy alone does NOT
+			// neutralise an existing public policy; it only blocks future
+			// writes. The bucket remains public.
+			name:   "block public policy alone does not neutralise existing policy",
+			policy: aws.Bool(true),
+			acls:   aws.Bool(false),
+			pab: &types.PublicAccessBlockConfiguration{
+				BlockPublicPolicy:     aws.Bool(true),
+				RestrictPublicBuckets: aws.Bool(false),
+			},
+			expected: aws.Bool(true),
+		},
+		{
+			// Regression for T-1391: BlockPublicAcls alone does NOT neutralise
+			// an existing public ACL; it only blocks future writes. The bucket
+			// remains public.
+			name:   "block public acls alone does not neutralise existing acl",
+			policy: aws.Bool(false),
+			acls:   aws.Bool(true),
+			pab: &types.PublicAccessBlockConfiguration{
+				BlockPublicAcls:  aws.Bool(true),
+				IgnorePublicAcls: aws.Bool(false),
+			},
+			expected: aws.Bool(true),
+		},
 	}
 
 	for _, tt := range tests {

--- a/specs/bugfixes/s3-public-access-block-logic/report.md
+++ b/specs/bugfixes/s3-public-access-block-logic/report.md
@@ -1,0 +1,118 @@
+# Bugfix Report: S3 public-state logic misreads Public Access Block
+
+**Date:** 2026-06-01
+**Status:** Fixed
+**Ticket:** T-1391
+
+## Description of the Issue
+
+`awstools s3 list` could misreport a bucket's public/private state ("Is Private").
+`helpers/s3.go:computeBucketIsPublic` modelled the four S3 Public Access Block
+(PAB) fields by their *write-prevention* effect instead of their *current-access*
+effect.
+
+**Reproduction steps:**
+1. Create a bucket with a public bucket policy and a Public Access Block where
+   `RestrictPublicBuckets=true` but `BlockPublicPolicy=false`.
+2. Run `awstools s3 list`.
+3. Observe the bucket is reported as public, although access granted by the
+   public policy is actually restricted (effectively private).
+
+A second variant: a bucket with a public ACL and `IgnorePublicAcls=true`,
+`RestrictPublicBuckets=false` is reported public even though S3 ignores the ACL.
+
+**Impact:** Incorrect security reporting for S3 buckets. Medium severity: the
+tool is used to audit public exposure, so false positives (and the inverse risk
+of false negatives) undermine its purpose.
+
+## Investigation Summary
+
+- **Symptoms examined:** Reported public/private state for buckets with partial
+  PAB settings.
+- **Code inspected:** `helpers/s3.go` (`computeBucketIsPublic`, lines ~283-332)
+  and `helpers/s3_test.go` (`TestComputeBucketIsPublic`).
+- **Hypotheses tested:** Confirmed against the AWS
+  `PublicAccessBlockConfiguration` semantics that the function required the wrong
+  combination of PAB fields to neutralise existing exposure.
+
+## Discovered Root Cause
+
+The function used write-prevention fields to neutralise existing access:
+
+- A public **policy** was only neutralised when both `RestrictPublicBuckets` AND
+  `BlockPublicPolicy` were true. `BlockPublicPolicy` only rejects *future*
+  public bucket-policy writes; `RestrictPublicBuckets` is what restricts access
+  granted by existing public policies.
+- A public **ACL** was only neutralised when both `RestrictPublicBuckets` AND
+  `IgnorePublicAcls` were true. `IgnorePublicAcls` alone causes S3 to ignore
+  existing public ACLs.
+- The "fully locked down" shortcut required `BlockPublicPolicy`, which is not the
+  field that neutralises policy-based access.
+
+**Defect type:** Logic error (wrong model of AWS PAB semantics).
+
+**Why it occurred:** The fields were modelled by their write-prevention names
+rather than their documented effect on current access.
+
+**Contributing factors:** The four PAB fields have similar names and subtly
+different effects, making the mismodelling easy to introduce.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `helpers/s3.go` (`computeBucketIsPublic`) - neutralise public **policy**
+  exposure with `RestrictPublicBuckets` alone; neutralise public **ACL** exposure
+  with `IgnorePublicAcls` alone; treat the bucket as fully locked down when
+  `RestrictPublicBuckets && IgnorePublicAcls`; stop reading `BlockPublicPolicy`
+  and `BlockPublicAcls`.
+
+**Approach rationale:** Models the PAB fields by their effect on current access,
+matching the AWS documentation. The tri-state ("unknown" = nil) behaviour from
+prior tickets is preserved.
+
+**Alternatives considered:**
+- Keep reading the block-* fields as a secondary signal - rejected: they have no
+  bearing on existing exposure and would re-introduce the bug.
+
+## Regression Test
+
+**Test file:** `helpers/s3_test.go`
+**Test name:** `TestComputeBucketIsPublic`
+
+**What it verifies:** Added four cases:
+- `RestrictPublicBuckets=true, BlockPublicPolicy=false` + public policy -> not public.
+- `IgnorePublicAcls=true, RestrictPublicBuckets=false` + public ACL -> not public.
+- `BlockPublicPolicy=true, RestrictPublicBuckets=false` + public policy -> still public.
+- `BlockPublicAcls=true, IgnorePublicAcls=false` + public ACL -> still public.
+
+The two ticket-mandated cases fail against the pre-fix code (`got=true,
+want=false`) and pass after the fix.
+
+**Run command:** `go test ./helpers/ -run TestComputeBucketIsPublic -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `helpers/s3.go` | Corrected PAB modelling in `computeBucketIsPublic` |
+| `helpers/s3_test.go` | Added regression and documentation test cases |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+- [x] Linters/validators pass (`go vet`, `gofmt`)
+
+**Manual verification:**
+- Confirmed red/green: regression cases fail pre-fix, pass post-fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Model AWS feature flags by their documented runtime effect, not their names.
+- Keep per-field table-driven tests that isolate each PAB field's effect.
+
+## Related
+
+- Ticket T-1391


### PR DESCRIPTION
## Summary

Fixes T-1391. `helpers/s3.go:computeBucketIsPublic` modelled the S3 Public Access Block (PAB) fields by their *write-prevention* effect rather than their *current-access* effect, so `awstools s3 list` could misreport a bucket's public/private state.

## Root cause

Per the AWS `PublicAccessBlockConfiguration` documentation:
- `BlockPublicPolicy` only rejects *future* public bucket-policy writes; it does not affect access granted by an existing policy.
- `IgnorePublicAcls` (not `RestrictPublicBuckets`) is what causes S3 to ignore existing public ACLs.

The old code required `RestrictPublicBuckets && BlockPublicPolicy` to neutralise a public policy and `RestrictPublicBuckets && IgnorePublicAcls` to neutralise a public ACL.

## Fix

- `RestrictPublicBuckets=true` now neutralises existing public **policy** exposure on its own.
- `IgnorePublicAcls=true` now neutralises existing public **ACL** exposure on its own.
- `BlockPublicPolicy` and `BlockPublicAcls` are no longer consulted (they only block future writes).
- The tri-state ("unknown" = nil) behaviour is preserved.

## Tests

`TestComputeBucketIsPublic` gains the two ticket-mandated regression cases (`RestrictPublicBuckets=true, BlockPublicPolicy=false` and `IgnorePublicAcls=true, RestrictPublicBuckets=false`) plus cases proving block-only flags do not neutralise existing exposure.

- Red: the two regression cases fail against the pre-fix code (`got=true, want=false`).
- Green: after the fix, `TestComputeBucketIsPublic` and `go test ./...` pass.

See `specs/bugfixes/s3-public-access-block-logic/report.md` for details.