### PR TITLE
Fix T-1196: Cover All EC2 Route Targets In VPC Route Output

### DIFF
--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -406,6 +406,42 @@ func getAllVPCRouteTables(svc ec2.DescribeRouteTablesAPIClient) []VPCRouteTable 
 	return result
 }
 
+// routeTarget returns the target identifier for an EC2 route, covering every
+// target field exposed by types.Route. AWS populates at most one target field
+// per route in practice; if more than one is set the first match in the order
+// below wins. The order lists the most common/specific targets first and is the
+// single source of truth shared by parseVPCRoutes and FormatRouteTableInfo so
+// both commands report targets identically. Returns an empty string when no
+// target field is set (callers decide on any fallback such as "local").
+func routeTarget(route types.Route) string {
+	switch {
+	case route.GatewayId != nil:
+		return *route.GatewayId
+	case route.NatGatewayId != nil:
+		return *route.NatGatewayId
+	case route.TransitGatewayId != nil:
+		return *route.TransitGatewayId
+	case route.VpcPeeringConnectionId != nil:
+		return *route.VpcPeeringConnectionId
+	case route.NetworkInterfaceId != nil:
+		return *route.NetworkInterfaceId
+	case route.InstanceId != nil:
+		return *route.InstanceId
+	case route.EgressOnlyInternetGatewayId != nil:
+		return *route.EgressOnlyInternetGatewayId
+	case route.CarrierGatewayId != nil:
+		return *route.CarrierGatewayId
+	case route.LocalGatewayId != nil:
+		return *route.LocalGatewayId
+	case route.CoreNetworkArn != nil:
+		return *route.CoreNetworkArn
+	case route.OdbNetworkArn != nil:
+		return *route.OdbNetworkArn
+	default:
+		return ""
+	}
+}
+
 func parseVPCRoutes(routes []types.Route) []VPCRoute {
 	var result []VPCRoute
 	for _, route := range routes {
@@ -421,24 +457,7 @@ func parseVPCRoutes(routes []types.Route) []VPCRoute {
 		if route.DestinationPrefixListId != nil {
 			rt.DestinationCIDR = *route.DestinationPrefixListId
 		}
-		if route.VpcPeeringConnectionId != nil {
-			rt.DestinationTarget = *route.VpcPeeringConnectionId
-		}
-		if route.GatewayId != nil {
-			rt.DestinationTarget = *route.GatewayId
-		}
-		if route.NatGatewayId != nil {
-			rt.DestinationTarget = *route.NatGatewayId
-		}
-		if route.NetworkInterfaceId != nil {
-			rt.DestinationTarget = *route.NetworkInterfaceId
-		}
-		if route.EgressOnlyInternetGatewayId != nil {
-			rt.DestinationTarget = *route.EgressOnlyInternetGatewayId
-		}
-		if route.TransitGatewayId != nil {
-			rt.DestinationTarget = *route.TransitGatewayId
-		}
+		rt.DestinationTarget = routeTarget(route)
 		result = append(result, rt)
 	}
 	return result
@@ -1226,21 +1245,10 @@ func FormatRouteTableInfo(routeTable *types.RouteTable) (string, []string) {
 			destCIDR = *route.DestinationPrefixListId
 		}
 
-		target := ""
-		switch {
-		case route.GatewayId != nil:
-			target = *route.GatewayId
-		case route.NatGatewayId != nil:
-			target = *route.NatGatewayId
-		case route.VpcPeeringConnectionId != nil:
-			target = *route.VpcPeeringConnectionId
-		case route.NetworkInterfaceId != nil:
-			target = *route.NetworkInterfaceId
-		case route.TransitGatewayId != nil:
-			target = *route.TransitGatewayId
-		case route.EgressOnlyInternetGatewayId != nil:
-			target = *route.EgressOnlyInternetGatewayId
-		default:
+		// Cover all EC2 route target fields (T-1196). Fall back to "local"
+		// only when the route carries no target field at all.
+		target := routeTarget(route)
+		if target == "" {
 			target = "local"
 		}
 

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -2199,3 +2199,198 @@ func TestGetResourceNameAndID_TransitGateway(t *testing.T) {
 		})
 	}
 }
+
+// TestParseVPCRoutesTargetFields verifies that parseVPCRoutes maps every
+// EC2 route target field exposed by types.Route into DestinationTarget.
+// Regression test for T-1196: routes whose target is an InstanceId
+// (NAT instance), CarrierGatewayId, LocalGatewayId, CoreNetworkArn, or
+// OdbNetworkArn previously produced an empty DestinationTarget.
+func TestParseVPCRoutesTargetFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		route types.Route
+		want  string
+	}{
+		{
+			name:  "VpcPeeringConnectionId",
+			route: types.Route{VpcPeeringConnectionId: aws.String("pcx-123")},
+			want:  "pcx-123",
+		},
+		{
+			name:  "GatewayId",
+			route: types.Route{GatewayId: aws.String("igw-123")},
+			want:  "igw-123",
+		},
+		{
+			name:  "NatGatewayId",
+			route: types.Route{NatGatewayId: aws.String("nat-123")},
+			want:  "nat-123",
+		},
+		{
+			name:  "NetworkInterfaceId",
+			route: types.Route{NetworkInterfaceId: aws.String("eni-123")},
+			want:  "eni-123",
+		},
+		{
+			name:  "EgressOnlyInternetGatewayId",
+			route: types.Route{EgressOnlyInternetGatewayId: aws.String("eigw-123")},
+			want:  "eigw-123",
+		},
+		{
+			name:  "TransitGatewayId",
+			route: types.Route{TransitGatewayId: aws.String("tgw-123")},
+			want:  "tgw-123",
+		},
+		{
+			name:  "InstanceId",
+			route: types.Route{InstanceId: aws.String("i-123")},
+			want:  "i-123",
+		},
+		{
+			name:  "CarrierGatewayId",
+			route: types.Route{CarrierGatewayId: aws.String("cagw-123")},
+			want:  "cagw-123",
+		},
+		{
+			name:  "LocalGatewayId",
+			route: types.Route{LocalGatewayId: aws.String("lgw-123")},
+			want:  "lgw-123",
+		},
+		{
+			name:  "CoreNetworkArn",
+			route: types.Route{CoreNetworkArn: aws.String("arn:aws:networkmanager::123:core-network/core-network-123")},
+			want:  "arn:aws:networkmanager::123:core-network/core-network-123",
+		},
+		{
+			name:  "OdbNetworkArn",
+			route: types.Route{OdbNetworkArn: aws.String("arn:aws:odb:us-east-1:123:odb-network/odbnet-123")},
+			want:  "arn:aws:odb:us-east-1:123:odb-network/odbnet-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseVPCRoutes([]types.Route{tt.route})
+			if len(got) != 1 {
+				t.Fatalf("parseVPCRoutes() returned %d routes, want 1", len(got))
+			}
+			if got[0].DestinationTarget != tt.want {
+				t.Errorf("DestinationTarget = %q, want %q", got[0].DestinationTarget, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseVPCRoutesTargetPrecedence verifies the documented precedence when
+// more than one target field is set on a single route. The first field in the
+// documented ordering wins.
+func TestParseVPCRoutesTargetPrecedence(t *testing.T) {
+	route := types.Route{
+		GatewayId:              aws.String("igw-123"),
+		NatGatewayId:           aws.String("nat-123"),
+		TransitGatewayId:       aws.String("tgw-123"),
+		VpcPeeringConnectionId: aws.String("pcx-123"),
+		InstanceId:             aws.String("i-123"),
+	}
+	got := parseVPCRoutes([]types.Route{route})
+	if len(got) != 1 {
+		t.Fatalf("parseVPCRoutes() returned %d routes, want 1", len(got))
+	}
+	if got[0].DestinationTarget != "igw-123" {
+		t.Errorf("DestinationTarget = %q, want %q (GatewayId wins by precedence)", got[0].DestinationTarget, "igw-123")
+	}
+}
+
+// TestFormatRouteTableInfoTargetFields verifies that FormatRouteTableInfo maps
+// every EC2 route target field into the formatted target. Regression test for
+// T-1196: previously only a subset was handled and the rest fell back to "local".
+func TestFormatRouteTableInfoTargetFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		route types.Route
+		want  string
+	}{
+		{
+			name:  "GatewayId",
+			route: types.Route{GatewayId: aws.String("igw-123")},
+			want:  "igw-123",
+		},
+		{
+			name:  "NatGatewayId",
+			route: types.Route{NatGatewayId: aws.String("nat-123")},
+			want:  "nat-123",
+		},
+		{
+			name:  "TransitGatewayId",
+			route: types.Route{TransitGatewayId: aws.String("tgw-123")},
+			want:  "tgw-123",
+		},
+		{
+			name:  "VpcPeeringConnectionId",
+			route: types.Route{VpcPeeringConnectionId: aws.String("pcx-123")},
+			want:  "pcx-123",
+		},
+		{
+			name:  "NetworkInterfaceId",
+			route: types.Route{NetworkInterfaceId: aws.String("eni-123")},
+			want:  "eni-123",
+		},
+		{
+			name:  "EgressOnlyInternetGatewayId",
+			route: types.Route{EgressOnlyInternetGatewayId: aws.String("eigw-123")},
+			want:  "eigw-123",
+		},
+		{
+			name:  "InstanceId",
+			route: types.Route{InstanceId: aws.String("i-123")},
+			want:  "i-123",
+		},
+		{
+			name:  "CarrierGatewayId",
+			route: types.Route{CarrierGatewayId: aws.String("cagw-123")},
+			want:  "cagw-123",
+		},
+		{
+			name:  "LocalGatewayId",
+			route: types.Route{LocalGatewayId: aws.String("lgw-123")},
+			want:  "lgw-123",
+		},
+		{
+			name:  "CoreNetworkArn",
+			route: types.Route{CoreNetworkArn: aws.String("arn:aws:networkmanager::123:core-network/core-network-123")},
+			want:  "arn:aws:networkmanager::123:core-network/core-network-123",
+		},
+		{
+			name:  "OdbNetworkArn",
+			route: types.Route{OdbNetworkArn: aws.String("arn:aws:odb:us-east-1:123:odb-network/odbnet-123")},
+			want:  "arn:aws:odb:us-east-1:123:odb-network/odbnet-123",
+		},
+		{
+			name:  "local fallback when no target",
+			route: types.Route{},
+			want:  "local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// FormatRouteTableInfo only emits a route when it has a
+			// destination, so give every case the same destination CIDR and
+			// assert on the target portion after the ": " separator.
+			route := tt.route
+			route.DestinationCidrBlock = aws.String("10.0.0.0/16")
+			rt := &types.RouteTable{
+				RouteTableId: aws.String("rtb-123"),
+				Routes:       []types.Route{route},
+			}
+			_, routeList := FormatRouteTableInfo(rt)
+			if len(routeList) != 1 {
+				t.Fatalf("FormatRouteTableInfo() returned %d targets, want 1", len(routeList))
+			}
+			want := "10.0.0.0/16: " + tt.want
+			if routeList[0] != want {
+				t.Errorf("route = %q, want %q", routeList[0], want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`awstools vpc routes` / route-table output and the VPC overview / IP finder dropped the target for any route whose target is a NAT instance, carrier gateway, local gateway, Cloud WAN core network, or ODB network. Those routes showed a destination CIDR with an empty target (in `parseVPCRoutes`) or a misleading `local` (in `FormatRouteTableInfo`), hiding a real route attachment.

## Root cause

The EC2 SDK `types.Route` exposes 11 mutually-exclusive target fields. Both `helpers/ec2.go:parseVPCRoutes` and `helpers/ec2.go:FormatRouteTableInfo` handled only 6 of them (peering, gateway, NAT gateway, network interface, egress-only IGW, transit gateway). The two helpers also had inconsistent precedence (last-match vs first-match).

## Fix

- Added a shared `routeTarget(types.Route) string` helper covering all 11 target fields, used by both functions so they resolve targets identically.
- Precedence is explicit and documented: at most one target field is set per route in practice, but if multiple are set the first match in the documented ordering wins. `FormatRouteTableInfo` keeps its `local` fallback only when no target field is set.

## Testing

- Added table-driven regression tests covering every target field for both functions, plus precedence and the `local` fallback. Confirmed they fail before the fix and pass after.
- `go test ./...` passes.