### PR TITLE
Fix T-1167: Profile Generator Silently Overwrites Duplicate Generated Names

### DIFF
--- a/helpers/profile_generator.go
+++ b/helpers/profile_generator.go
@@ -893,6 +893,25 @@ func (pg *ProfileGenerator) GenerateProfilesForNonConflictedRoles(nonConflictedR
 		return nil, err
 	}
 
+	// Load existing profiles from output file so that names generated here do not
+	// collide with profiles already present (falls back to default when empty).
+	configFile, err := LoadAWSConfigFile(pg.outputFile)
+	if err != nil {
+		return nil, NewFileSystemError("failed to load AWS config file", err)
+	}
+
+	// Seed the resolver with existing names so duplicates generated within this
+	// batch (e.g. a naming pattern that maps several roles to the same name) get
+	// unique names instead of silently overwriting each other.
+	resolver := NewProfileNameConflictResolver(configFile.GetProfileNames())
+
+	return pg.buildProfilesForRoles(templateProfile, nonConflictedRoles, resolver)
+}
+
+// buildProfilesForRoles generates profiles for the given roles, resolving any
+// naming conflicts via the supplied resolver. The resolver is updated for every
+// name it returns, so duplicate desired names within roles are made unique.
+func (pg *ProfileGenerator) buildProfilesForRoles(templateProfile *TemplateProfile, roles []DiscoveredRole, resolver *ProfileNameConflictResolver) ([]GeneratedProfile, error) {
 	// Create naming pattern
 	namingPattern, err := NewNamingPattern(pg.namingPattern)
 	if err != nil {
@@ -901,14 +920,14 @@ func (pg *ProfileGenerator) GenerateProfilesForNonConflictedRoles(nonConflictedR
 
 	var generatedProfiles []GeneratedProfile
 
-	for _, role := range nonConflictedRoles {
+	for _, role := range roles {
 		// Validate role before processing
 		if err := role.Validate(); err != nil {
 			return nil, err
 		}
 
 		// Generate profile name
-		profileName, err := namingPattern.GenerateProfileName(
+		desiredName, err := namingPattern.GenerateProfileName(
 			role.AccountID,
 			role.AccountName,
 			role.AccountAlias,
@@ -919,6 +938,12 @@ func (pg *ProfileGenerator) GenerateProfilesForNonConflictedRoles(nonConflictedR
 			return nil, NewValidationError("failed to generate profile name", err).
 				WithContext("account_id", role.AccountID).
 				WithContext("role_name", role.PermissionSetName)
+		}
+
+		// Resolve naming conflicts (against existing profiles and earlier roles in this batch)
+		profileName := desiredName
+		if resolver != nil {
+			profileName = resolver.ResolveConflict(desiredName)
 		}
 
 		// Create generated profile

--- a/helpers/profile_generator_duplicate_names_test.go
+++ b/helpers/profile_generator_duplicate_names_test.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+// TestGenerateProfilesForNonConflictedRoles_DuplicateNames is a regression test
+// for T-1167. With a naming pattern like {account_name}, two distinct
+// non-conflicted roles in the same account generate the same desired profile
+// name. Before the fix the conflict resolver was never applied on this path, so
+// both GeneratedProfile.Name values were identical and AppendProfiles silently
+// overwrote the first profile with the second, dropping a discovered role.
+//
+// Expected behaviour: each role yields a distinct generated name and no profile
+// is lost.
+func TestGenerateProfilesForNonConflictedRoles_DuplicateNames(t *testing.T) {
+	// Write a minimal AWS config file containing an SSO template profile so that
+	// ValidateTemplateProfile succeeds. Point AWS_CONFIG_FILE at it so both the
+	// template lookup and the existing-name seeding read from this file.
+	configContent := `[profile test-sso-profile]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 222222222222
+sso_role_name = AdministratorAccess
+region = us-east-1
+`
+	configPath := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	t.Setenv("AWS_CONFIG_FILE", configPath)
+
+	// Naming pattern {account_name} collides for two roles in the same account.
+	pg, err := NewProfileGenerator("test-sso-profile", "{account_name}", false, "", ConflictPrompt, aws.Config{})
+	if err != nil {
+		t.Fatalf("NewProfileGenerator returned error: %v", err)
+	}
+
+	roles := []DiscoveredRole{
+		{
+			AccountID:         "111111111111",
+			AccountName:       "shared-account",
+			PermissionSetName: "AdministratorAccess",
+			RoleName:          "AWSReservedSSO_AdministratorAccess_a",
+		},
+		{
+			AccountID:         "111111111111",
+			AccountName:       "shared-account",
+			PermissionSetName: "ReadOnlyAccess",
+			RoleName:          "AWSReservedSSO_ReadOnlyAccess_b",
+		},
+	}
+
+	profiles, err := pg.GenerateProfilesForNonConflictedRoles(roles)
+	if err != nil {
+		t.Fatalf("GenerateProfilesForNonConflictedRoles returned error: %v", err)
+	}
+
+	if len(profiles) != len(roles) {
+		t.Fatalf("expected %d generated profiles, got %d", len(roles), len(profiles))
+	}
+
+	// Every generated name must be unique, otherwise a role would be silently
+	// dropped when appended to the AWS config file via AppendProfiles.
+	seen := make(map[string]int)
+	for _, p := range profiles {
+		seen[p.Name]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate generated profile name %q appeared %d times; roles would be overwritten", name, count)
+		}
+	}
+
+	// Confirm both permission sets are represented (no role lost).
+	roleNames := make(map[string]bool)
+	for _, p := range profiles {
+		roleNames[p.RoleName] = true
+	}
+	for _, r := range roles {
+		if !roleNames[r.PermissionSetName] {
+			t.Errorf("role with permission set %q was dropped from generated profiles", r.PermissionSetName)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`GenerateProfilesForNonConflictedRoles` generated profile names directly from the naming pattern with no deduplication. Unlike `GenerateProfiles`, it never used `ProfileNameConflictResolver`, so a pattern like `{account_name}` produced identical names for multiple roles in one account. `AWSConfigFile.AppendProfiles` then saw `HasProfile` for the duplicate and replaced the first profile with the second, silently dropping discovered roles.

## Root cause

Two parallel profile-generation paths existed; conflict resolution was added to `GenerateProfiles` but not to `GenerateProfilesForNonConflictedRoles`, which the workflow actually uses for non-conflicted roles.

## Fix

- Seed a `ProfileNameConflictResolver` from existing profile names (matching `GenerateProfiles`).
- Extract the per-role generation loop into `buildProfilesForRoles`, which applies `resolver.ResolveConflict` to every name. The resolver tracks names produced earlier in the batch, so both existing-profile and intra-batch collisions get unique names.

## Testing

- New regression test `TestGenerateProfilesForNonConflictedRoles_DuplicateNames` (two non-conflicted roles producing the same name; asserts distinct names / no overwrite).
- Red/green verified: FAILS without the fix ("duplicate generated profile name ... appeared 2 times"), PASSES with it.
- `go test ./...` passes; `go vet ./helpers/` clean.

Closes T-1167.