### PR TITLE
fix: guard App Mesh helpers against partial Describe payloads (T-1207)

### DIFF
--- a/helpers/appmesh.go
+++ b/helpers/appmesh.go
@@ -71,6 +71,11 @@ func getAppMeshRouteDescriptions(meshName *string, svc AppMeshAPI) []*types.Rout
 			fmt.Print(err)
 			continue
 		}
+		if output.Route == nil {
+			// A successful response can still omit the route payload; skip it
+			// so downstream processing does not dereference a nil pointer.
+			continue
+		}
 		routedetails = append(routedetails, output.Route)
 	}
 	return routedetails
@@ -98,6 +103,11 @@ func getAllAppMeshNodes(meshName *string, svc AppMeshAPI) []*types.VirtualNodeDa
 			nodetails, err := svc.DescribeVirtualNode(context.TODO(), input)
 			if err != nil {
 				fmt.Print(err)
+				continue
+			}
+			if nodetails.VirtualNode == nil {
+				// Skip incomplete payloads so callers that dereference the
+				// virtual node (e.g. VirtualNodeName) do not panic.
 				continue
 			}
 			nodelist = append(nodelist, nodetails.VirtualNode)
@@ -130,6 +140,11 @@ func getAllAppMeshVirtualServices(meshName *string, svc AppMeshAPI) []*types.Vir
 				fmt.Print(err)
 				continue
 			}
+			if servicedetails.VirtualService == nil {
+				// Skip incomplete payloads so callers that dereference the
+				// service spec (e.g. Spec.Provider) do not panic.
+				continue
+			}
 			servicelist = append(servicelist, servicedetails.VirtualService)
 		}
 	}
@@ -141,6 +156,11 @@ func getAllAppMeshVirtualServices(meshName *string, svc AppMeshAPI) []*types.Vir
 func buildRoutesHolder(routes []*types.RouteData) map[string][]AppMeshVirtualServiceRoute {
 	routesholder := make(map[string][]AppMeshVirtualServiceRoute)
 	for _, route := range routes {
+		if route == nil || route.Spec == nil {
+			// A partial Describe payload may omit the route or its spec.
+			continue
+		}
+
 		var targets []types.WeightedTarget
 		var path string
 
@@ -197,6 +217,11 @@ func GetAllAppMeshPaths(meshName *string, svc AppMeshAPI) []AppMeshVirtualServic
 	routes := getAppMeshRouteDescriptions(meshName, svc)
 	routesholder := buildRoutesHolder(routes)
 	for _, service := range services {
+		if service.Spec == nil {
+			// A partial Describe payload may omit the spec; skip rather than
+			// dereferencing service.Spec.Provider.
+			continue
+		}
 		switch v := service.Spec.Provider.(type) {
 		case *types.VirtualServiceProviderMemberVirtualRouter:
 			serviceroutes := AppMeshVirtualService{
@@ -301,6 +326,10 @@ func getAppMeshVirtualNodeBackendServices2(meshname *string, nodename *string, s
 	if err != nil {
 		fmt.Print(err)
 		return nil
+	}
+	if nodetails.VirtualNode == nil || nodetails.VirtualNode.Spec == nil {
+		// A partial Describe payload may omit the virtual node or its spec.
+		return backendlists
 	}
 	for _, backend := range nodetails.VirtualNode.Spec.Backends {
 		switch v := backend.(type) {

--- a/helpers/appmesh_test.go
+++ b/helpers/appmesh_test.go
@@ -615,3 +615,193 @@ func TestGetAllAppMeshPaths_VirtualNodeProvider(t *testing.T) {
 		t.Errorf("Expected DestinationNode 'my-node', got '%s'", directNodeSvc.VirtualServiceRoutes[0].DestinationNode)
 	}
 }
+
+// --- Regression tests for partial Describe payloads (T-1207) ---
+//
+// AWS Describe APIs can return a successful (non-error) response whose nested
+// payload is incomplete: a nil Route/VirtualNode/VirtualService pointer, or a
+// nil nested Spec. The helpers previously appended these payloads unguarded and
+// later dereferenced them, panicking instead of skipping the incomplete item.
+
+// TestGetAppMeshRouteDescriptions_NilRoutePayload_Skipped covers a DescribeRoute
+// response with Route == nil. Such an entry must be skipped, otherwise the nil
+// is appended and buildRoutesHolder panics on route.Spec.
+func TestGetAppMeshRouteDescriptions_NilRoutePayload_Skipped(t *testing.T) {
+	mock := &mockAppMeshClient{
+		listVirtualRoutersFunc: func(_ context.Context, _ *appmesh.ListVirtualRoutersInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualRoutersOutput, error) {
+			return &appmesh.ListVirtualRoutersOutput{
+				VirtualRouters: []types.VirtualRouterRef{
+					{MeshName: aws.String("test-mesh"), VirtualRouterName: aws.String("router-1")},
+				},
+			}, nil
+		},
+		listRoutesFunc: func(_ context.Context, _ *appmesh.ListRoutesInput, _ ...func(*appmesh.Options)) (*appmesh.ListRoutesOutput, error) {
+			return &appmesh.ListRoutesOutput{
+				Routes: []types.RouteRef{
+					{MeshName: aws.String("test-mesh"), RouteName: aws.String("route-1"), VirtualRouterName: aws.String("router-1")},
+				},
+			}, nil
+		},
+		describeRouteFunc: func(_ context.Context, _ *appmesh.DescribeRouteInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeRouteOutput, error) {
+			// Successful response, but the Route payload is missing.
+			return &appmesh.DescribeRouteOutput{Route: nil}, nil
+		},
+	}
+
+	meshName := aws.String("test-mesh")
+	result := getAppMeshRouteDescriptions(meshName, mock)
+	if len(result) != 0 {
+		t.Errorf("Expected 0 route descriptions when Route payload is nil, got %d", len(result))
+	}
+	// buildRoutesHolder must not panic on whatever getAppMeshRouteDescriptions returns.
+	_ = buildRoutesHolder(result)
+}
+
+// TestBuildRoutesHolder_NilRoute_NoPanic ensures buildRoutesHolder tolerates a
+// nil RouteData pointer in its input slice.
+func TestBuildRoutesHolder_NilRoute_NoPanic(t *testing.T) {
+	routes := []*types.RouteData{nil}
+	result := buildRoutesHolder(routes)
+	if len(result) != 0 {
+		t.Errorf("Expected empty result for nil route, got %d", len(result))
+	}
+}
+
+// TestBuildRoutesHolder_NilSpec_NoPanic ensures buildRoutesHolder tolerates a
+// RouteData with a nil Spec (a partial Describe payload).
+func TestBuildRoutesHolder_NilSpec_NoPanic(t *testing.T) {
+	routes := []*types.RouteData{
+		{VirtualRouterName: aws.String("router-1"), Spec: nil},
+	}
+	result := buildRoutesHolder(routes)
+	if len(result["router-1"]) != 0 {
+		t.Errorf("Expected 0 routes for nil-spec route, got %d", len(result["router-1"]))
+	}
+}
+
+// TestGetAllAppMeshNodes_NilNodePayload_Skipped covers a DescribeVirtualNode
+// response with VirtualNode == nil. The nil must be skipped so downstream
+// consumers (GetAllAppMeshNodeConnections) do not panic on node.VirtualNodeName.
+func TestGetAllAppMeshNodes_NilNodePayload_Skipped(t *testing.T) {
+	mock := &mockAppMeshClient{
+		listVirtualNodesFunc: func(_ context.Context, _ *appmesh.ListVirtualNodesInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualNodesOutput, error) {
+			return &appmesh.ListVirtualNodesOutput{
+				VirtualNodes: []types.VirtualNodeRef{
+					{MeshName: aws.String("test-mesh"), VirtualNodeName: aws.String("node-1")},
+				},
+			}, nil
+		},
+		describeVirtualNodeFunc: func(_ context.Context, _ *appmesh.DescribeVirtualNodeInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualNodeOutput, error) {
+			return &appmesh.DescribeVirtualNodeOutput{VirtualNode: nil}, nil
+		},
+	}
+
+	meshName := aws.String("test-mesh")
+	result := getAllAppMeshNodes(meshName, mock)
+	if len(result) != 0 {
+		t.Errorf("Expected 0 nodes when VirtualNode payload is nil, got %d", len(result))
+	}
+	// Dereferencing the returned nodes must be safe.
+	for _, node := range result {
+		_ = aws.ToString(node.VirtualNodeName)
+	}
+}
+
+// TestGetAllAppMeshVirtualServices_NilServicePayload_Skipped covers a
+// DescribeVirtualService response with VirtualService == nil. The nil must be
+// skipped so GetAllAppMeshPaths does not panic on service.Spec.Provider.
+func TestGetAllAppMeshVirtualServices_NilServicePayload_Skipped(t *testing.T) {
+	mock := &mockAppMeshClient{
+		listVirtualServicesFunc: func(_ context.Context, _ *appmesh.ListVirtualServicesInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualServicesOutput, error) {
+			return &appmesh.ListVirtualServicesOutput{
+				VirtualServices: []types.VirtualServiceRef{
+					{MeshName: aws.String("test-mesh"), VirtualServiceName: aws.String("svc-1")},
+				},
+			}, nil
+		},
+		describeVirtualServiceFunc: func(_ context.Context, _ *appmesh.DescribeVirtualServiceInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualServiceOutput, error) {
+			return &appmesh.DescribeVirtualServiceOutput{VirtualService: nil}, nil
+		},
+	}
+
+	meshName := aws.String("test-mesh")
+	result := getAllAppMeshVirtualServices(meshName, mock)
+	if len(result) != 0 {
+		t.Errorf("Expected 0 services when VirtualService payload is nil, got %d", len(result))
+	}
+}
+
+// TestGetAllAppMeshPaths_NilServiceSpec_NoPanic covers a DescribeVirtualService
+// response whose VirtualService is present but Spec is nil. GetAllAppMeshPaths
+// switches on service.Spec.Provider and must not panic.
+func TestGetAllAppMeshPaths_NilServiceSpec_NoPanic(t *testing.T) {
+	mock := &mockAppMeshClient{
+		listVirtualServicesFunc: func(_ context.Context, _ *appmesh.ListVirtualServicesInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualServicesOutput, error) {
+			return &appmesh.ListVirtualServicesOutput{
+				VirtualServices: []types.VirtualServiceRef{
+					{MeshName: aws.String("test-mesh"), VirtualServiceName: aws.String("svc-1")},
+				},
+			}, nil
+		},
+		describeVirtualServiceFunc: func(_ context.Context, params *appmesh.DescribeVirtualServiceInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualServiceOutput, error) {
+			return &appmesh.DescribeVirtualServiceOutput{
+				VirtualService: &types.VirtualServiceData{
+					MeshName:           params.MeshName,
+					VirtualServiceName: params.VirtualServiceName,
+					Spec:               nil,
+				},
+			}, nil
+		},
+		listVirtualRoutersFunc: func(_ context.Context, _ *appmesh.ListVirtualRoutersInput, _ ...func(*appmesh.Options)) (*appmesh.ListVirtualRoutersOutput, error) {
+			return &appmesh.ListVirtualRoutersOutput{}, nil
+		},
+	}
+
+	meshName := aws.String("test-mesh")
+	// Must not panic; service with nil spec is simply skipped.
+	result := GetAllAppMeshPaths(meshName, mock)
+	if len(result) != 0 {
+		t.Errorf("Expected 0 paths for service with nil spec, got %d", len(result))
+	}
+}
+
+// TestGetAppMeshVirtualNodeBackendServices2_NilNodePayload_NoPanic covers a
+// DescribeVirtualNode success response with VirtualNode == nil (or nil Spec).
+// The helper dereferences nodetails.VirtualNode.Spec.Backends and must not panic.
+func TestGetAppMeshVirtualNodeBackendServices2_NilNodePayload_NoPanic(t *testing.T) {
+	mock := &mockAppMeshClient{
+		describeVirtualNodeFunc: func(_ context.Context, _ *appmesh.DescribeVirtualNodeInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualNodeOutput, error) {
+			return &appmesh.DescribeVirtualNodeOutput{VirtualNode: nil}, nil
+		},
+	}
+
+	meshName := aws.String("test-mesh")
+	nodeName := aws.String("node-1")
+	result := getAppMeshVirtualNodeBackendServices2(meshName, nodeName, mock)
+	if len(result) != 0 {
+		t.Errorf("Expected empty result when VirtualNode payload is nil, got %v", result)
+	}
+}
+
+// TestGetAppMeshVirtualNodeBackendServices2_NilSpec_NoPanic covers a present
+// VirtualNode with a nil Spec.
+func TestGetAppMeshVirtualNodeBackendServices2_NilSpec_NoPanic(t *testing.T) {
+	mock := &mockAppMeshClient{
+		describeVirtualNodeFunc: func(_ context.Context, params *appmesh.DescribeVirtualNodeInput, _ ...func(*appmesh.Options)) (*appmesh.DescribeVirtualNodeOutput, error) {
+			return &appmesh.DescribeVirtualNodeOutput{
+				VirtualNode: &types.VirtualNodeData{
+					MeshName:        params.MeshName,
+					VirtualNodeName: params.VirtualNodeName,
+					Spec:            nil,
+				},
+			}, nil
+		},
+	}
+
+	meshName := aws.String("test-mesh")
+	nodeName := aws.String("node-1")
+	result := getAppMeshVirtualNodeBackendServices2(meshName, nodeName, mock)
+	if len(result) != 0 {
+		t.Errorf("Expected empty result when VirtualNode.Spec is nil, got %v", result)
+	}
+}


### PR DESCRIPTION
Fixes T-1207.

App Mesh helper paths trusted successful Describe responses to contain every nested payload, appending `output.Route`, `nodetails.VirtualNode`, and `servicedetails.VirtualService` without nil checks and later dereferencing nested fields. A partial SDK response could panic `awstools appmesh` commands.

This adds nil guards that skip incomplete items / return contextual errors across the affected paths in `helpers/appmesh.go`, with regression tests in `helpers/appmesh_test.go` driving partial Describe payloads.

`go test ./...` passes.