### PR TITLE
Fix T-1155: SSO Permission-Set Details Panic On Nil Metadata

### DIFF
--- a/helpers/sso.go
+++ b/helpers/sso.go
@@ -148,6 +148,9 @@ func (instance *SSOInstance) getPermissionSetDetails(permissionsetarn string, sv
 		return SSOPermissionSet{}, fmt.Errorf("failed to describe permission set %s: %w", permissionsetarn, err)
 	}
 	ps := permissionsetdescription.PermissionSet
+	if ps == nil {
+		return SSOPermissionSet{}, fmt.Errorf("DescribePermissionSet returned no metadata for permission set %s", permissionsetarn)
+	}
 	permissionset := SSOPermissionSet{
 		Arn:             permissionsetarn,
 		Name:            aws.ToString(ps.Name),

--- a/helpers/sso_test.go
+++ b/helpers/sso_test.go
@@ -475,6 +475,21 @@ func TestGetSSOAccountInstance_DescribePermissionSetError_ReturnsError(t *testin
 	assert.Contains(t, err.Error(), "failed to describe permission set")
 }
 
+// Regression test for T-1155: a partial DescribePermissionSet response with
+// PermissionSet == nil must return a contextual error rather than panicking
+// when getPermissionSetDetails dereferences the nil pointer for Name,
+// SessionDuration, CreatedDate, and Description.
+func TestGetSSOAccountInstance_NilPermissionSet_ReturnsError(t *testing.T) {
+	mock := newBasicMock()
+	mock.DescribePermissionSetFunc = func(ctx context.Context, params *ssoadmin.DescribePermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.DescribePermissionSetOutput, error) {
+		return &ssoadmin.DescribePermissionSetOutput{PermissionSet: nil}, nil
+	}
+	_, err := GetSSOAccountInstance(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "arn:aws:sso:::permissionSet/ps-001",
+		"error should reference the permission set ARN")
+}
+
 func TestGetSSOAccountInstance_ListAccountsError_ReturnsError(t *testing.T) {
 	mock := newBasicMock()
 	mock.ListAccountsForProvisionedPermissionSetFunc = func(ctx context.Context, params *ssoadmin.ListAccountsForProvisionedPermissionSetInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountsForProvisionedPermissionSetOutput, error) {


### PR DESCRIPTION
## Summary

`helpers/sso.go:getPermissionSetDetails` dereferenced the SDK pointer field `permissionsetdescription.PermissionSet` (reading `ps.Name`, `ps.SessionDuration`, `ps.CreatedDate`, `ps.Description`) without a nil check. A partial `DescribePermissionSet` response with `PermissionSet == nil` panicked instead of returning an error, affecting all commands using `helpers.GetSSOAccountInstance` (`sso listpermissionsets`, `sso overview account`, `sso overview permissionset`, `sso dangling`).

## Root Cause

The code treated `err == nil` as a guarantee that `PermissionSet` was populated. AWS SDK pointer fields are not guaranteed non-nil on a successful call.

## Fix

Added a nil guard immediately after assigning `ps`. When `ps == nil`, the function returns a contextual error referencing the permission-set ARN before any field is dereferenced. The error propagates through `getPermissionSets` and `GetSSOAccountInstance`.

## Regression Test

`TestGetSSOAccountInstance_NilPermissionSet_ReturnsError` in `helpers/sso_test.go` uses `mockSSOAdminClient.DescribePermissionSetFunc` returning `&ssoadmin.DescribePermissionSetOutput{PermissionSet: nil}`. It panicked (SIGSEGV at sso.go:153) before the fix and passes after.

`go test ./...` passes.