### PR TITLE
Fix T-1270: VPC routes main route table default marker

### DIFF
--- a/cmd/vpcroutes.go
+++ b/cmd/vpcroutes.go
@@ -25,7 +25,7 @@ func routes(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "VPC Routes for account " + getName(helpers.GetAccountID(awsConfig.StsClient()))
 	routes := helpers.GetAllVPCRouteTables(awsConfig.Ec2Client())
-	keys := []string{accountIDColumn, "Account Name", "ID", nameColumn, vpcColumn, "VPC Name", "Subnets", routesColumn}
+	keys := []string{accountIDColumn, "Account Name", "ID", nameColumn, vpcColumn, "VPC Name", "Default", "Subnets", routesColumn}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
 	for _, routetable := range routes {
@@ -34,9 +34,16 @@ func routes(_ *cobra.Command, _ []string) {
 		content[nameColumn] = getName(routetable.ID)
 		content[vpcColumn] = routetable.Vpc.ID
 		content["VPC Name"] = getName(routetable.Vpc.ID)
+		content["Default"] = routetable.Default
 		var subnets []string
 		for _, subnet := range routetable.Subnets {
 			subnets = append(subnets, fmt.Sprintf("%v (%v)", getName(subnet), subnet))
+		}
+		// The main/default route table applies to every subnet that has no
+		// explicit association. EC2 reports no SubnetId for it, so make that
+		// state visible instead of leaving the column blank (T-1270).
+		if routetable.Default && len(subnets) == 0 {
+			subnets = append(subnets, "main (all unassociated subnets)")
 		}
 		content["Subnets"] = subnets
 		content[accountIDColumn] = routetable.Vpc.AccountID

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -380,9 +380,17 @@ func getAllVPCRouteTables(svc ec2.DescribeRouteTablesAPIClient) []VPCRouteTable 
 		}
 		for _, routetable := range page.RouteTables {
 			var subnets []string
+			var isDefault bool
 			for _, assocs := range routetable.Associations {
 				if assocs.SubnetId != nil {
 					subnets = append(subnets, *assocs.SubnetId)
+				}
+				// EC2 represents a VPC's main route table as an implicit
+				// association with Main == true and no SubnetId. Flag it so
+				// callers can show that it applies to all subnets without an
+				// explicit association (T-1270).
+				if aws.ToBool(assocs.Main) {
+					isDefault = true
 				}
 			}
 			table := VPCRouteTable{
@@ -391,6 +399,7 @@ func getAllVPCRouteTables(svc ec2.DescribeRouteTablesAPIClient) []VPCRouteTable 
 				ID:      aws.ToString(routetable.RouteTableId),
 				Routes:  parseVPCRoutes(routetable.Routes),
 				Subnets: subnets,
+				Default: isDefault,
 			}
 			result = append(result, table)
 		}

--- a/helpers/vpc_routetable_pagination_test.go
+++ b/helpers/vpc_routetable_pagination_test.go
@@ -87,3 +87,54 @@ func TestGetAllVPCRouteTables_Pagination(t *testing.T) {
 		}
 	}
 }
+
+// TestGetAllVPCRouteTables_MainAssociationSetsDefault verifies that a route
+// table whose only association is the implicit/main association (Main == true,
+// no SubnetId) is mapped with Default == true and no Subnets. EC2 represents a
+// VPC's main route table this way; before the fix the mapper only looked at
+// Association.SubnetId, so the main route table came back with Default == false
+// and an empty Subnets slice, hiding that it applies to all unassociated
+// subnets (T-1270).
+func TestGetAllVPCRouteTables_MainAssociationSetsDefault(t *testing.T) {
+	mock := &mockDescribeRouteTablesClient{
+		routeTables: []types.RouteTable{
+			{
+				RouteTableId: aws.String("rtb-main0001"),
+				VpcId:        aws.String("vpc-00000001"),
+				OwnerId:      aws.String("123456789012"),
+				Associations: []types.RouteTableAssociation{
+					{Main: aws.Bool(true)},
+				},
+			},
+			{
+				RouteTableId: aws.String("rtb-explicit1"),
+				VpcId:        aws.String("vpc-00000001"),
+				OwnerId:      aws.String("123456789012"),
+				Associations: []types.RouteTableAssociation{
+					{Main: aws.Bool(false), SubnetId: aws.String("subnet-11111111")},
+				},
+			},
+		},
+	}
+
+	result := getAllVPCRouteTables(mock)
+	if len(result) != 2 {
+		t.Fatalf("getAllVPCRouteTables() returned %d route tables, want 2", len(result))
+	}
+
+	main := result[0]
+	if !main.Default {
+		t.Errorf("main route table %q: Default = false, want true (main association not detected)", main.ID)
+	}
+	if len(main.Subnets) != 0 {
+		t.Errorf("main route table %q: Subnets = %v, want empty (main association has no SubnetId)", main.ID, main.Subnets)
+	}
+
+	explicit := result[1]
+	if explicit.Default {
+		t.Errorf("explicit route table %q: Default = true, want false (no main association)", explicit.ID)
+	}
+	if len(explicit.Subnets) != 1 || explicit.Subnets[0] != "subnet-11111111" {
+		t.Errorf("explicit route table %q: Subnets = %v, want [subnet-11111111]", explicit.ID, explicit.Subnets)
+	}
+}


### PR DESCRIPTION
## Summary

`awstools vpc routes` showed a VPC's main (default) route table with an empty Subnets column, hiding that it applies to all subnets without an explicit association.

## Root Cause

`helpers/ec2.go:getAllVPCRouteTables` built `VPCRouteTable` values by appending only `Association.SubnetId` values. A VPC's main route table is represented by EC2 as an implicit association with `Main == true` and no `SubnetId`, so the existing `VPCRouteTable.Default` field was never set, and `cmd/vpcroutes.go` never rendered it.

## Fix

- `helpers/ec2.go`: set `Default` when any association has `Main == true`.
- `cmd/vpcroutes.go`: add a `Default` column and render `main (all unassociated subnets)` in the Subnets column for the default route table when it has no explicit associations.

## Testing

- Added `TestGetAllVPCRouteTables_MainAssociationSetsDefault` (helpers/vpc_routetable_pagination_test.go) — fails before the fix, passes after.
- `go test ./...` passes.
- `go vet ./...` clean; `golangci-lint` shows only pre-existing goconst findings (unchanged by this fix).