### PR TITLE
Fix T-1090: S3 Unencrypted-Only Hides Unknown Encryption State

### DIFF
--- a/cmd/s3list.go
+++ b/cmd/s3list.go
@@ -53,18 +53,10 @@ func s3List(_ *cobra.Command, _ []string) {
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
 	for _, bucket := range buckets {
-		// --public-only excludes buckets that are confirmed private.
-		// Buckets with an unknown public state are kept so the user
-		// still sees them (and the rendered "Unknown" makes the state
-		// visible); exclude only those we know to be private.
-		if publicBucketsOnly && bucket.IsPublic != nil && !*bucket.IsPublic {
+		if publicBucketsOnly && skipForPublicOnly(bucket.IsPublic) {
 			continue
 		}
-		// --unencrypted-only excludes buckets that are confirmed
-		// encrypted. Buckets whose encryption state could not be
-		// determined are also excluded so we do not falsely flag them
-		// as unencrypted.
-		if unencryptedBucketsOnly && (bucket.HasEncryption == nil || *bucket.HasEncryption) {
+		if unencryptedBucketsOnly && skipForUnencryptedOnly(bucket.HasEncryption) {
 			continue
 		}
 		content := make(map[string]any)
@@ -114,6 +106,24 @@ func s3List(_ *cobra.Command, _ []string) {
 		output.AddHolder(holder)
 	}
 	output.Write()
+}
+
+// skipForPublicOnly reports whether a bucket should be skipped under the
+// --public-only filter. It excludes only buckets confirmed private; buckets
+// with an unknown public state (nil) are kept so the user still sees them and
+// the rendered "Unknown" makes the state visible.
+func skipForPublicOnly(isPublic *bool) bool {
+	return isPublic != nil && !*isPublic
+}
+
+// skipForUnencryptedOnly reports whether a bucket should be skipped under the
+// --unencrypted-only filter. It excludes only buckets confirmed encrypted
+// (HasEncryption is non-nil and true). Buckets whose encryption state could
+// not be determined (nil) are kept so the unknown state stays visible for
+// investigation (see T-714); previously these were hidden from the security
+// view (T-1090).
+func skipForUnencryptedOnly(hasEncryption *bool) bool {
+	return hasEncryption != nil && *hasEncryption
 }
 
 // triState renders an optional boolean for the bucket listing output.

--- a/cmd/s3list_test.go
+++ b/cmd/s3list_test.go
@@ -7,6 +7,80 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
+// TestUnencryptedOnlyFilter verifies that the --unencrypted-only filter
+// excludes only buckets that are confirmed encrypted, while keeping both
+// confirmed-unencrypted and unknown-encryption buckets visible. Unknown
+// states must stay visible so users can investigate them (see T-714).
+// Regression test for T-1090.
+func TestUnencryptedOnlyFilter(t *testing.T) {
+	tests := []struct {
+		name          string
+		hasEncryption *bool
+		wantSkip      bool
+	}{
+		{
+			name:          "confirmed encrypted is excluded",
+			hasEncryption: aws.Bool(true),
+			wantSkip:      true,
+		},
+		{
+			name:          "confirmed unencrypted is kept",
+			hasEncryption: aws.Bool(false),
+			wantSkip:      false,
+		},
+		{
+			name:          "unknown encryption state is kept",
+			hasEncryption: nil,
+			wantSkip:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := skipForUnencryptedOnly(tt.hasEncryption)
+			if got != tt.wantSkip {
+				t.Errorf("skipForUnencryptedOnly(%v) = %v, want %v", tt.hasEncryption, got, tt.wantSkip)
+			}
+		})
+	}
+}
+
+// TestPublicOnlyFilter verifies that the --public-only filter excludes only
+// buckets confirmed private, while keeping confirmed-public and
+// unknown-public buckets visible. Companion coverage for T-1090.
+func TestPublicOnlyFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		isPublic *bool
+		wantSkip bool
+	}{
+		{
+			name:     "confirmed private is excluded",
+			isPublic: aws.Bool(false),
+			wantSkip: true,
+		},
+		{
+			name:     "confirmed public is kept",
+			isPublic: aws.Bool(true),
+			wantSkip: false,
+		},
+		{
+			name:     "unknown public state is kept",
+			isPublic: nil,
+			wantSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := skipForPublicOnly(tt.isPublic)
+			if got != tt.wantSkip {
+				t.Errorf("skipForPublicOnly(%v) = %v, want %v", tt.isPublic, got, tt.wantSkip)
+			}
+		})
+	}
+}
+
 // TestParsePublicAccessBlock verifies that parsePublicAccessBlock distinguishes
 // between "unknown" (no PAB configured or GetPublicAccessBlock failed) and the
 // legitimate "all four flags false" state. Regression test for T-693.


### PR DESCRIPTION
## Summary

`awstools s3 list --unencrypted-only` skipped buckets whose encryption state could not be read (`bucket.HasEncryption == nil`), hiding them from the filtered security view. Those unknown-encryption buckets are exactly the ones a user needs to investigate.

## Root cause

The filter predicate was `bucket.HasEncryption == nil || *bucket.HasEncryption`, which excluded unknown-encryption buckets alongside confirmed-encrypted ones. This conflicts with the T-714 convention that tri-state security booleans must keep unknown states visible (the renderer already shows an `Unknown` label).

## Fix

- Extracted the filter logic into named predicates `skipForPublicOnly` and `skipForUnencryptedOnly` in `cmd/s3list.go`.
- `skipForUnencryptedOnly` now returns `hasEncryption != nil && *hasEncryption`, excluding only confirmed-encrypted buckets and keeping confirmed-unencrypted and unknown-encryption buckets visible.
- `skipForPublicOnly` preserves existing correct public-only behaviour.

## Tests

Added `TestUnencryptedOnlyFilter` and `TestPublicOnlyFilter` in `cmd/s3list_test.go` covering all three tri-state cases (confirmed-on, confirmed-off, unknown) for both filters.

Verified red/green: with the original buggy logic the `unknown_encryption_state_is_kept` subtest fails (`skipForUnencryptedOnly(<nil>) = true, want false`); with the fix the full suite passes (`go test ./...`).