### PR TITLE
Fix T-1255: Validate TGW Routetables --list Resource ID

### DIFF
--- a/cmd/tgwroutes.go
+++ b/cmd/tgwroutes.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"slices"
 	"strings"
 
@@ -41,7 +42,7 @@ type attachedResourceInfo struct {
 func init() {
 	tgwCmd.AddCommand(tgwroutetablesCmd)
 	tgwroutetablesCmd.Flags().StringVarP(&tgwresourceid, "resource-id", "r", "", "The id(s) of the resource you want to limit to (comma-separated for multiple)")
-	tgwroutetablesCmd.Flags().BoolVarP(&simplelist, "list", "l", false, "Only show a simple list of routes")
+	tgwroutetablesCmd.Flags().BoolVarP(&simplelist, "list", "l", false, "Only show a simple list of routes for a single route table; requires --resource-id with a tgw-rtb-* ID")
 }
 
 func tgwroutes(_ *cobra.Command, _ []string) {
@@ -129,14 +130,39 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 	output.Write()
 }
 
+// validateSimpleListResourceID checks that the resource ID supplied for the
+// --list output is a single Transit Gateway route table ID (tgw-rtb-*).
+//
+// The simple list queries SearchTransitGatewayRoutes for one route table, so
+// an empty value, a non-route-table resource (VPC, TGW, attachment, ...), or a
+// comma-separated list must be rejected with a clear usage error rather than
+// silently calling the AWS API with an empty or wrong ID.
+func validateSimpleListResourceID(resourceID string) error {
+	trimmed := strings.TrimSpace(resourceID)
+	if trimmed == "" {
+		return fmt.Errorf("the --list output requires a Transit Gateway route table ID; pass one with --resource-id (e.g. -r tgw-rtb-0123456789abcdef0)")
+	}
+	if strings.Contains(trimmed, ",") {
+		return fmt.Errorf("the --list output supports a single Transit Gateway route table ID, not a list: %q", resourceID)
+	}
+	if helpers.TypeByResourceID(trimmed) != "tgw-rtb" {
+		return fmt.Errorf("the --list output requires a Transit Gateway route table ID (tgw-rtb-*), got %q", trimmed)
+	}
+	return nil
+}
+
 func simplelistOnly(awsConfig config.AWSConfig) {
+	if err := validateSimpleListResourceID(tgwresourceid); err != nil {
+		log.Fatal(err)
+	}
+	routetableID := strings.TrimSpace(tgwresourceid)
 	keys := []string{cidrColumn, "Target", "Route Type", "State"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
-	output.Settings.Title = fmt.Sprintf("Simple route list for %s", tgwresourceid)
+	output.Settings.Title = fmt.Sprintf("Simple route list for %s", routetableID)
 	output.Settings.SortKey = cidrColumn
 
-	activeroutes := helpers.GetActiveRoutesForTransitGatewayRouteTable(tgwresourceid, awsConfig.Ec2Client())
-	blackholeroutes := helpers.GetBlackholeRoutesForTransitGatewayRouteTable(tgwresourceid, awsConfig.Ec2Client())
+	activeroutes := helpers.GetActiveRoutesForTransitGatewayRouteTable(routetableID, awsConfig.Ec2Client())
+	blackholeroutes := helpers.GetBlackholeRoutesForTransitGatewayRouteTable(routetableID, awsConfig.Ec2Client())
 
 	for _, route := range activeroutes {
 		content := make(map[string]any)

--- a/cmd/tgwroutes_test.go
+++ b/cmd/tgwroutes_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ArjenSchwarz/awstools/helpers"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestFilterGatewaySkipsBlackholeRoutes is the regression test for T-1124.
@@ -81,5 +82,45 @@ func TestFilterGatewaySkipsBlackholeRoutes(t *testing.T) {
 	}
 	if _, exists := attachedresources[activeVPCID]; !exists {
 		t.Errorf("attached resources should contain the active VPC %q; got %#v", activeVPCID, attachedresources)
+	}
+}
+
+// TestValidateSimpleListResourceID is the regression test for T-1255.
+//
+// Bug: simplelistOnly used the global tgwresourceid value directly as a
+// Transit Gateway route table ID and passed it to
+// GetActiveRoutesForTransitGatewayRouteTable /
+// GetBlackholeRoutesForTransitGatewayRouteTable without validating it. Running
+// `awstools tgw routetables --list` without --resource-id, or with a VPC/TGW
+// ID, would call SearchTransitGatewayRoutes with an empty or wrong route table
+// ID instead of rejecting the input with a clear usage error.
+//
+// Expected: validation requires a non-empty tgw-rtb-* route table ID and
+// rejects everything else with an error.
+func TestValidateSimpleListResourceID(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		wantErr    bool
+	}{
+		{name: "empty rejected", resourceID: "", wantErr: true},
+		{name: "whitespace rejected", resourceID: "   ", wantErr: true},
+		{name: "vpc id rejected", resourceID: "vpc-00000001", wantErr: true},
+		{name: "tgw id rejected", resourceID: "tgw-00000001", wantErr: true},
+		{name: "tgw attachment rejected", resourceID: "tgw-attach-00000001", wantErr: true},
+		{name: "multiple ids rejected", resourceID: "tgw-rtb-1,tgw-rtb-2", wantErr: true},
+		{name: "valid route table accepted", resourceID: "tgw-rtb-00000001", wantErr: false},
+		{name: "valid route table with surrounding whitespace accepted", resourceID: "  tgw-rtb-00000001  ", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSimpleListResourceID(tt.resourceID)
+			if tt.wantErr {
+				assert.Error(t, err, "expected validation error for %q", tt.resourceID)
+			} else {
+				assert.NoError(t, err, "expected no validation error for %q", tt.resourceID)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`cmd/tgwroutes.go:simplelistOnly` treated the global `tgwresourceid` value as a Transit Gateway route table ID and passed it directly to `GetActiveRoutesForTransitGatewayRouteTable` / `GetBlackholeRoutesForTransitGatewayRouteTable` without validation. Running `awstools tgw routetables --list` without `--resource-id`, or with a VPC/TGW/attachment ID, called `SearchTransitGatewayRoutes` with an empty or wrong route table ID instead of rejecting the input.

## Root cause

Missing input validation. The simple-list path requires exactly one `tgw-rtb-*` route table ID, but the shared `--resource-id` flag (which also accepts other types and comma-separated lists for the main path) was never validated for this narrower contract.

## Fix

- Added `validateSimpleListResourceID`, a pure function that rejects empty/whitespace values, comma-separated lists, and any non-`tgw-rtb-*` resource type.
- `simplelistOnly` now validates first and exits with a clear usage message (via `log.Fatal`, matching existing cmd conventions), then uses the trimmed route table ID.
- Updated `--list` help text to state it requires a `tgw-rtb-*` `--resource-id`.

Change is scoped to `simplelistOnly` so it does not conflict with the `filterGateway` changes from T-1124.

## Testing

- New regression test `TestValidateSimpleListResourceID` in `cmd/tgwroutes_test.go` (fails before fix: undefined symbol; passes after).
- `go test ./...` passes.
- No new lint findings in `cmd/tgwroutes.go`.