### PR TITLE
Fix T-1302: Preserve AWS SSO Session Extra Properties

### DIFF
--- a/helpers/aws_config_file.go
+++ b/helpers/aws_config_file.go
@@ -25,9 +25,10 @@ type AWSConfigFile struct {
 
 // SSOSession represents an SSO session configuration
 type SSOSession struct {
-	Name        string `json:"name" yaml:"name"`
-	SSOStartURL string `json:"sso_start_url" yaml:"sso_start_url"`
-	SSORegion   string `json:"sso_region" yaml:"sso_region"`
+	Name            string            `json:"name" yaml:"name"`
+	SSOStartURL     string            `json:"sso_start_url" yaml:"sso_start_url"`
+	SSORegion       string            `json:"sso_region" yaml:"sso_region"`
+	OtherProperties map[string]string `json:"other_properties" yaml:"other_properties"`
 }
 
 // Validate checks if the SSO session is valid
@@ -339,7 +340,8 @@ func (cf *AWSConfigFile) parseConfigFileWithRecovery(file *os.File) error {
 
 			// Start new SSO session
 			currentSession = &SSOSession{
-				Name: sessionName,
+				Name:            sessionName,
+				OtherProperties: make(map[string]string),
 			}
 		} else if currentSession != nil { //nolint:gocritic // Sequential parsing logic requires if-else chain
 			// Parse SSO session property line
@@ -365,12 +367,13 @@ func (cf *AWSConfigFile) parseConfigFileWithRecovery(file *os.File) error {
 					case ssoRegionKey:
 						currentSession.SSORegion = value
 					default:
-						// Log unknown property but continue
-						parseErrors = append(parseErrors, NewValidationError(
-							fmt.Sprintf("unknown SSO session property '%s' at line %d", key, lineNumber), nil).
-							WithContext("line_number", lineNumber).
-							WithContext("property_key", key).
-							WithContext("session_name", currentSession.Name))
+						// Preserve other AWS CLI session properties (e.g.
+						// sso_registration_scopes) so write paths don't drop
+						// them. See T-1302.
+						if currentSession.OtherProperties == nil {
+							currentSession.OtherProperties = make(map[string]string)
+						}
+						currentSession.OtherProperties[key] = value
 					}
 				} else {
 					parseErrors = append(parseErrors, NewValidationError(
@@ -561,6 +564,11 @@ func (cf *AWSConfigFile) WriteToFile() error {
 			}
 			if session.SSORegion != "" {
 				sessionConfig += fmt.Sprintf("sso_region = %s\n", session.SSORegion)
+			}
+			// Preserve other AWS CLI session properties (e.g.
+			// sso_registration_scopes). See T-1302.
+			for key, value := range session.OtherProperties {
+				sessionConfig += fmt.Sprintf("%s = %s\n", key, value)
 			}
 			sessionConfig += "\n"
 

--- a/helpers/aws_config_file_test.go
+++ b/helpers/aws_config_file_test.go
@@ -573,6 +573,59 @@ func TestAWSConfigFile_ParseLongLine(t *testing.T) {
 	assert.Equal(t, "us-west-2", trailing.Region)
 }
 
+// TestAWSConfigFile_PreserveSSOSessionExtraProperties is a regression test for
+// T-1302: the parser only stored sso_start_url and sso_region on SSOSession and
+// treated other AWS CLI session keys (such as sso_registration_scopes) as parse
+// warnings, dropping them. Any write path that rewrites the config from the
+// parsed model (WriteToFile) therefore silently corrupted modern AWS CLI SSO
+// session configuration. Extra SSO session properties must now be preserved
+// across a parse-then-write round trip.
+func TestAWSConfigFile_PreserveSSOSessionExtraProperties(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+
+	configContent := `[sso-session test-session]
+sso_start_url = https://test.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[profile test-profile]
+region = us-east-1
+sso_session = test-session
+sso_account_id = 123456789012
+sso_role_name = AdministratorAccess
+`
+
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0600))
+
+	// Parse loads cleanly with no warning for the known-good extra key.
+	configFile, err := LoadAWSConfigFile(configPath)
+	require.NoError(t, err)
+
+	session, exists := configFile.Sessions["test-session"]
+	require.True(t, exists)
+	assert.Equal(t, "https://test.awsapps.com/start", session.SSOStartURL)
+	assert.Equal(t, "us-east-1", session.SSORegion)
+	assert.Equal(t, "sso:account:access", session.OtherProperties["sso_registration_scopes"],
+		"extra SSO session properties must be retained on parse")
+
+	// Rewriting the whole config from the parsed model must not drop the
+	// extra property.
+	require.NoError(t, configFile.WriteToFile())
+
+	written, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "sso_registration_scopes = sso:account:access",
+		"extra SSO session properties must be written back")
+
+	// Reloading the rewritten file must still expose the extra property.
+	reloaded, err := LoadAWSConfigFile(configPath)
+	require.NoError(t, err)
+	reloadedSession, exists := reloaded.Sessions["test-session"]
+	require.True(t, exists)
+	assert.Equal(t, "sso:account:access", reloadedSession.OtherProperties["sso_registration_scopes"])
+}
+
 func TestAWSConfigFile_FindProfilesByName(t *testing.T) {
 	configFile := &AWSConfigFile{
 		Profiles: map[string]Profile{
@@ -1936,11 +1989,13 @@ sso_account_id = 123456789012`,
 			errorType:      ErrorTypeValidation,
 		},
 		{
-			name: "unknown SSO session property",
+			// T-1302: additional SSO session properties are now preserved
+			// rather than reported as parse errors.
+			name: "extra SSO session property is preserved",
 			configContent: `[sso-session dev]
 sso_start_url = https://example.awsapps.com/start
 sso_region = us-east-1
-unknown_property = value
+sso_registration_scopes = sso:account:access
 
 [profile dev-admin]
 sso_session = dev
@@ -1948,8 +2003,7 @@ sso_account_id = 123456789012
 sso_role_name = AdministratorAccess`,
 			expectProfiles: 1,
 			expectSessions: 1,
-			expectError:    true,
-			errorType:      ErrorTypeValidation,
+			expectError:    false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

`helpers/aws_config_file.go` parsed `[sso-session ...]` sections but only stored `sso_start_url` and `sso_region` on `SSOSession`. Other AWS CLI session keys (e.g. `sso_registration_scopes = sso:account:access`) were treated as parse warnings and discarded. Because `WriteToFile()` rewrites the whole config from the parsed model, those keys were silently dropped when profile-generator appended/replaced profiles, corrupting modern AWS CLI SSO session configuration.

## Root cause

`SSOSession` lacked an equivalent of `Profile.OtherProperties`, so unknown session keys had nowhere to be stored and were lost at parse time.

## Fix

- Add `OtherProperties map[string]string` to `SSOSession` (mirrors `Profile.OtherProperties`).
- Initialise it when a session starts; store unknown session keys instead of emitting a parse warning.
- Write each `OtherProperties` entry back into the `[sso-session]` block in `WriteToFile()`.

## Tests

- New `TestAWSConfigFile_PreserveSSOSessionExtraProperties`: parse → write → reload round trip asserting `sso_registration_scopes` survives. Verified failing (compile error, field missing) before the fix and passing after.
- Updated the `TestAWSConfigFile_ParseConfigFileWithRecovery` case that previously asserted unknown session keys produce a validation error to assert the new preserve-and-no-error behaviour.

`go test ./...` passes (exit 0). `go vet` clean; no new lint issues in the changed file.