### PR TITLE
Fix T-1278: Profile Generator Replace Leaves Renamed Old Profile

### DIFF
--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -337,7 +337,7 @@ func displayComprehensiveResults(result *helpers.ProfileGenerationResult, genera
 		}
 
 		fmt.Println("💾 Applying profiles to AWS configuration...")
-		if err := generator.AppendToConfig(result.GeneratedProfiles); err != nil {
+		if err := generator.AppendToConfig(result.GeneratedProfiles, result.ResolutionActions); err != nil {
 			displayErrorWithRecovery("Error appending profiles to config", err)
 			os.Exit(1)
 		}

--- a/helpers/aws_config_file_test.go
+++ b/helpers/aws_config_file_test.go
@@ -2954,7 +2954,7 @@ output = json
 		},
 	}
 
-	err = pg.AppendToConfig(profiles)
+	err = pg.AppendToConfig(profiles, nil)
 	require.NoError(t, err)
 
 	// Read file and verify no duplicates
@@ -2969,5 +2969,129 @@ output = json
 
 	// Unrelated profile must survive
 	assert.Contains(t, string(content), "[profile unrelated-profile]",
+		"unrelated profile should not be removed")
+}
+
+// TestAppendToConfig_ReplaceRemovesRenamedOldProfile verifies the end-to-end
+// replace workflow when the existing same-role profile has a DIFFERENT name
+// from the generated replacement. Existing profile "old-admin" points at the
+// same SSO account/role as the generated "prod-AdministratorAccess"; replace
+// mode must remove "old-admin" and write only "prod-AdministratorAccess", so
+// the file does not end up with two profiles for the same account/role.
+// Regression test for T-1278.
+func TestAppendToConfig_ReplaceRemovesRenamedOldProfile(t *testing.T) {
+	tempDir := t.TempDir()
+	awsDir := filepath.Join(tempDir, ".aws")
+	err := os.MkdirAll(awsDir, 0700)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(awsDir, "config")
+	// Existing profile uses a custom name "old-admin" but points at the same
+	// SSO account/role that the generator will produce as "prod-AdministratorAccess".
+	existingContent := `[profile old-admin]
+region = us-east-1
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = AdministratorAccess
+sso_session = test-session
+
+[profile unrelated-profile]
+region = eu-west-1
+output = json
+`
+	err = os.WriteFile(configPath, []byte(existingContent), 0600)
+	require.NoError(t, err)
+
+	// Override HOME so AppendToConfig finds our temp config
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer func() {
+		if oldHome != "" {
+			os.Setenv("HOME", oldHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	}()
+
+	pg, err := NewProfileGenerator(
+		"test-profile",
+		"{account_name}-{role_name}",
+		true, // autoApprove
+		"",   // use default path
+		ConflictReplace,
+		aws.Config{},
+	)
+	require.NoError(t, err)
+
+	// The generated replacement profile for the same account/role.
+	generated := GeneratedProfile{
+		Name:         "prod-AdministratorAccess",
+		AccountID:    "123456789012",
+		AccountName:  "prod",
+		RoleName:     "AdministratorAccess",
+		Region:       "us-east-1",
+		SSOStartURL:  "https://example.awsapps.com/start",
+		SSORegion:    "us-east-1",
+		SSOSession:   "test-session",
+		SSOAccountID: "123456789012",
+		SSORoleName:  "AdministratorAccess",
+	}
+
+	// The resolution action carries the old (renamed) profile name and the new name,
+	// mirroring what ResolveConflicts records for a ConflictReplace same-role conflict.
+	actions := []ConflictAction{
+		{
+			Conflict: ProfileConflict{
+				DiscoveredRole: DiscoveredRole{
+					AccountID:         "123456789012",
+					AccountName:       "prod",
+					PermissionSetName: "AdministratorAccess",
+				},
+				ExistingProfiles: []Profile{
+					{
+						Name:         "old-admin",
+						Region:       "us-east-1",
+						SSOStartURL:  "https://example.awsapps.com/start",
+						SSORegion:    "us-east-1",
+						SSOSession:   "test-session",
+						SSOAccountID: "123456789012",
+						SSORoleName:  "AdministratorAccess",
+					},
+				},
+				ProposedName: "prod-AdministratorAccess",
+			},
+			Action:  ActionReplace,
+			OldName: "old-admin",
+			NewName: "prod-AdministratorAccess",
+		},
+	}
+
+	err = pg.AppendToConfig([]GeneratedProfile{generated}, actions)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	got := string(content)
+
+	// The renamed old profile must be gone.
+	assert.NotContains(t, got, "[profile old-admin]",
+		"old renamed profile should be removed during replace.\nFile content:\n%s", got)
+
+	// The new profile must be present exactly once.
+	newHeader := "[profile prod-AdministratorAccess]"
+	count := strings.Count(got, newHeader)
+	assert.Equal(t, 1, count,
+		"generated profile %q should appear exactly once, found %d.\nFile content:\n%s",
+		newHeader, count, got)
+
+	// Only one profile should point at this account/role.
+	roleLineCount := strings.Count(got, "sso_role_name = AdministratorAccess")
+	assert.Equal(t, 1, roleLineCount,
+		"only one profile should reference the AdministratorAccess role, found %d.\nFile content:\n%s",
+		roleLineCount, got)
+
+	// Unrelated profile must survive.
+	assert.Contains(t, got, "[profile unrelated-profile]",
 		"unrelated profile should not be removed")
 }

--- a/helpers/profile_generator.go
+++ b/helpers/profile_generator.go
@@ -373,8 +373,17 @@ func (pg *ProfileGenerator) PreviewProfiles(profiles []GeneratedProfile) error {
 	return nil
 }
 
-// AppendToConfig appends profiles to the AWS config file
-func (pg *ProfileGenerator) AppendToConfig(profiles []GeneratedProfile) error {
+// AppendToConfig appends profiles to the AWS config file.
+//
+// The actions parameter carries the conflict resolution actions produced by
+// ResolveConflicts. For replace actions where the existing same-role profile
+// has a different name than the generated profile (e.g. an existing "old-admin"
+// being replaced by "prod-AdministratorAccess"), the old profile is removed
+// before the new profile is written. Without this, AppendProfiles would only
+// replace by the new name and leave the differently-named old profile behind,
+// resulting in two profiles pointing at the same account/role. Callers without
+// resolution actions (e.g. tests, no-conflict paths) may pass nil.
+func (pg *ProfileGenerator) AppendToConfig(profiles []GeneratedProfile, actions []ConflictAction) error {
 	if len(profiles) == 0 {
 		return NewValidationError("no profiles to append", nil)
 	}
@@ -406,6 +415,27 @@ func (pg *ProfileGenerator) AppendToConfig(profiles []GeneratedProfile) error {
 			WithContext("suggestion", "Use --yes flag to auto-approve or rename conflicting profiles")
 	}
 
+	// Remove renamed old profiles for replace actions. When a same-role conflict
+	// is resolved by replacing an existing profile whose name differs from the
+	// generated name, the old profile must be removed so it is not left dangling
+	// alongside the new one.
+	removedOldProfiles := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if action.Action != ActionReplace {
+			continue
+		}
+		if action.OldName == "" || action.OldName == action.NewName {
+			continue
+		}
+		if !configFile.HasProfile(action.OldName) {
+			continue
+		}
+		if err := configFile.RemoveProfile(action.OldName); err != nil {
+			return err
+		}
+		removedOldProfiles = append(removedOldProfiles, action.OldName)
+	}
+
 	// Append profiles
 	if err := configFile.AppendProfiles(profiles); err != nil {
 		return err
@@ -413,6 +443,10 @@ func (pg *ProfileGenerator) AppendToConfig(profiles []GeneratedProfile) error {
 
 	if len(conflicts) > 0 {
 		pg.logger.Printf("Warning: %d existing profiles were overwritten: %v", len(conflicts), conflicts)
+	}
+
+	if len(removedOldProfiles) > 0 {
+		pg.logger.Printf("Removed %d renamed existing profiles during replace: %v", len(removedOldProfiles), removedOldProfiles)
 	}
 
 	return nil
@@ -591,7 +625,7 @@ func (pg *ProfileGenerator) GenerateProfilesWorkflow() (*ProfileGenerationResult
 
 	// Append to config (if approved)
 	if pg.autoApprove {
-		if err := pg.AppendToConfig(result.GeneratedProfiles); err != nil {
+		if err := pg.AppendToConfig(result.GeneratedProfiles, result.ResolutionActions); err != nil {
 			if pgErr, ok := err.(ProfileGeneratorError); ok {
 				result.AddError(pgErr)
 			} else {

--- a/helpers/profile_generator_test.go
+++ b/helpers/profile_generator_test.go
@@ -849,7 +849,7 @@ func TestAppendToConfig(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Test append operation
-			err = pg.AppendToConfig(tt.profiles)
+			err = pg.AppendToConfig(tt.profiles, nil)
 
 			if tt.expectedError {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary

The profile generator's `ConflictReplace` path did not remove an existing same-role profile when the proposed replacement had a different name. `--replace-existing` for a same-role conflict could leave two profiles pointing at the same account/role.

## Root Cause

`ResolveConflicts` records `ConflictAction.OldName` (existing same-role profile name) and `NewName` (generated name), but `GenerateProfilesWorkflow` / `cmd/sso.go` only passed `result.GeneratedProfiles` to `AppendToConfig`. `AppendProfiles` keys replacement on the new name via `HasProfile(genProfile.Name)`, so a differently-named old profile (e.g. `old-admin`) was never matched and survived alongside the new `prod-AdministratorAccess`.

## Fix

- `AppendToConfig` now takes `actions []ConflictAction`. Before appending, for each `ActionReplace` where `OldName != ""` and `OldName != NewName` and the old profile exists, it calls `RemoveProfile(OldName)`. Removal is in-memory; `AppendProfiles` writes the file once at the end.
- `GenerateProfilesWorkflow` and `cmd/sso.go` pass `result.ResolutionActions`. Direct-call tests pass `nil` (unchanged behaviour).

Distinct from T-444 (name-equal duplicate sections) and T-1167 (duplicate generated names among non-conflicted roles).

## Regression Test

`helpers/aws_config_file_test.go::TestAppendToConfig_ReplaceRemovesRenamedOldProfile` — existing `old-admin` (same SSO account/role as generated `prod-AdministratorAccess`); replace removes `old-admin`, writes only `prod-AdministratorAccess`, leaves exactly one profile for the role, unrelated profiles survive. Verified red (fix disabled) then green (fix applied).

## Verification

- `go build ./...` passes
- `go test ./...` / `make test` pass
- `go vet ./...` passes; gofmt clean; golangci-lint introduces no new issues (pre-existing goconst findings in unrelated files only)