### PR TITLE
Fix T-1393: Tgw Dangling Blackhole Blank

### DIFF
--- a/cmd/tgwdangling.go
+++ b/cmd/tgwdangling.go
@@ -30,18 +30,7 @@ func tgwdangling(_ *cobra.Command, _ []string) {
 	keys := []string{vpcColumn, "VPCName", "DestinationVPC", "DestinationName"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
-	vpcs := make(map[string][]string)
-	for _, gateway := range gateways {
-		for _, routetable := range gateway.RouteTables {
-			for _, assoc := range routetable.SourceAttachments {
-				vpcs[assoc.ResourceID] = []string{}
-				for _, route := range routetable.Routes {
-					vpcs[assoc.ResourceID] = append(vpcs[assoc.ResourceID], route.Attachment.ResourceID)
-				}
-			}
-
-		}
-	}
+	vpcs := danglingRouteTargets(gateways)
 
 	for vpcid, targets := range vpcs {
 		for _, target := range targets {
@@ -59,4 +48,27 @@ func tgwdangling(_ *cobra.Command, _ []string) {
 	}
 	// fmt.Printf("%v", vpcs)
 	output.Write()
+}
+
+// danglingRouteTargets builds, for each source attachment, the list of resource
+// IDs it routes to. Blackhole routes are parsed with an empty attachment
+// ResourceID (see helpers.parseBlackholeRoute); they have no destination, so
+// they are skipped to avoid emitting dangling rows with an empty destination.
+func danglingRouteTargets(gateways []helpers.TransitGateway) map[string][]string {
+	vpcs := make(map[string][]string)
+	for _, gateway := range gateways {
+		for _, routetable := range gateway.RouteTables {
+			for _, assoc := range routetable.SourceAttachments {
+				vpcs[assoc.ResourceID] = []string{}
+				for _, route := range routetable.Routes {
+					if route.Attachment.ResourceID == "" {
+						continue
+					}
+					vpcs[assoc.ResourceID] = append(vpcs[assoc.ResourceID], route.Attachment.ResourceID)
+				}
+			}
+
+		}
+	}
+	return vpcs
 }

--- a/cmd/tgwdangling_test.go
+++ b/cmd/tgwdangling_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/ArjenSchwarz/awstools/helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDanglingRoutes_SkipsBlackholeRoutes is the regression test for T-1393.
+// A blackhole route is parsed with an empty Attachment.ResourceID. Before the
+// fix, that empty string was appended as a target, producing a dangling row
+// with an empty DestinationVPC/DestinationName. This test asserts no such empty
+// destination is produced.
+func TestDanglingRoutes_SkipsBlackholeRoutes(t *testing.T) {
+	gateways := []helpers.TransitGateway{
+		{
+			ID:        "tgw-00000001",
+			AccountID: "123456789012",
+			RouteTables: map[string]helpers.TransitGatewayRouteTable{
+				"tgw-rtb-00000001": {
+					ID: "tgw-rtb-00000001",
+					Routes: []helpers.TransitGatewayRoute{
+						{
+							State: "active",
+							CIDR:  "10.0.0.0/16",
+							Attachment: helpers.TransitGatewayAttachment{
+								ID:         "tgw-attach-vpc2",
+								ResourceID: "vpc-00000002",
+							},
+						},
+						{
+							// Blackhole route: parseBlackholeRoute leaves the
+							// attachment empty.
+							State:     "blackhole",
+							CIDR:      "172.16.0.0/12",
+							RouteType: "static",
+						},
+					},
+					SourceAttachments: []helpers.TransitGatewayAttachment{
+						{
+							ID:           "tgw-attach-vpc1",
+							ResourceID:   "vpc-00000001",
+							ResourceType: "vpc",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vpcs := danglingRouteTargets(gateways)
+
+	// The source VPC's target list must not contain an empty resource ID.
+	assert.NotContains(t, vpcs["vpc-00000001"], "", "blackhole route should not be appended as an empty target")
+	assert.Contains(t, vpcs["vpc-00000001"], "vpc-00000002", "active route target should be present")
+
+	// No empty-key entry should be created either.
+	_, hasEmpty := vpcs[""]
+	assert.False(t, hasEmpty, "no empty source key should exist")
+}


### PR DESCRIPTION
## Bug

`awstools tgw dangling` emitted dangling-route rows with an empty `DestinationVPC`/`DestinationName` whenever a TGW route table contained a blackhole route.

## Root Cause

`cmd/tgwdangling.go` built each source attachment's target list from `routetable.Routes`, appending `route.Attachment.ResourceID` for every route. `helpers.parseBlackholeRoute` intentionally leaves `Attachment.ResourceID` empty, so `""` was appended as a target. The uni-directional reduction then found no reverse route from `""` and emitted a row with empty destination columns.

## Fix

- Extracted the target-list construction into a pure, testable `danglingRouteTargets` function.
- Skip routes with an empty attachment `ResourceID` (blackhole routes).

## Tests

Added `TestDanglingRoutes_SkipsBlackholeRoutes` in `cmd/tgwdangling_test.go` with one source attachment, one active route, and one blackhole route, asserting no empty-destination target is produced. Verified failing before the fix and passing after. Full suite (`make test`) passes.

Note: `cmd/tgwroutes.go` was intentionally not modified (related to but distinct from T-1124).

Fixes T-1393.