### PR TITLE
Fix T-1411: VPC Overview Marks Blackhole IGW Routes as Public

### DIFF
--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -1255,6 +1255,12 @@ func isPublicSubnet(subnetID string, vpcID string, routeTables []types.RouteTabl
 // hasInternetGatewayRoute checks if a route table has a route to an internet gateway
 func hasInternetGatewayRoute(routeTable types.RouteTable) bool {
 	for _, route := range routeTable.Routes {
+		// Skip blackhole routes: when an internet gateway target is deleted,
+		// AWS leaves the route in the table with State=blackhole. Such a route
+		// is unusable, so it must not make a subnet public (T-1411).
+		if route.State == types.RouteStateBlackhole {
+			continue
+		}
 		// Check for internet gateway route
 		if route.GatewayId != nil && strings.HasPrefix(*route.GatewayId, "igw-") {
 			// Check for IPv4 default route (0.0.0.0/0)

--- a/helpers/ec2_test.go
+++ b/helpers/ec2_test.go
@@ -1903,6 +1903,85 @@ func TestIsPublicSubnet_IPv6OnlyPublic(t *testing.T) {
 	}
 }
 
+// Regression tests for T-1411: blackhole IGW default routes were classified
+// as public. When an internet gateway target is deleted, AWS leaves the route
+// in the table with State=blackhole. Such a route is unusable and must not
+// make a subnet public.
+
+func TestHasInternetGatewayRoute_IPv4BlackholeNotPublic(t *testing.T) {
+	routeTable := types.RouteTable{
+		RouteTableId: aws.String("rtb-blackhole-v4"),
+		Routes: []types.Route{
+			{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				GatewayId:            aws.String("igw-deleted"),
+				State:                types.RouteStateBlackhole,
+			},
+		},
+	}
+	if hasInternetGatewayRoute(routeTable) {
+		t.Error("route table with blackhole IPv4 igw default route should NOT be detected as having internet gateway route")
+	}
+}
+
+func TestHasInternetGatewayRoute_IPv6BlackholeNotPublic(t *testing.T) {
+	routeTable := types.RouteTable{
+		RouteTableId: aws.String("rtb-blackhole-v6"),
+		Routes: []types.Route{
+			{
+				DestinationIpv6CidrBlock: aws.String("::/0"),
+				GatewayId:                aws.String("igw-deleted"),
+				State:                    types.RouteStateBlackhole,
+			},
+		},
+	}
+	if hasInternetGatewayRoute(routeTable) {
+		t.Error("route table with blackhole IPv6 igw default route should NOT be detected as having internet gateway route")
+	}
+}
+
+func TestHasInternetGatewayRoute_ActiveStateStillPublic(t *testing.T) {
+	// An explicitly active route must still be treated as public.
+	routeTable := types.RouteTable{
+		RouteTableId: aws.String("rtb-active"),
+		Routes: []types.Route{
+			{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				GatewayId:            aws.String("igw-active"),
+				State:                types.RouteStateActive,
+			},
+		},
+	}
+	if !hasInternetGatewayRoute(routeTable) {
+		t.Error("route table with active igw default route should be detected as having internet gateway route")
+	}
+}
+
+func TestIsPublicSubnet_BlackholeIGWNotPublic(t *testing.T) {
+	routeTables := []types.RouteTable{
+		{
+			RouteTableId: aws.String("rtb-blackhole-subnet"),
+			VpcId:        aws.String("vpc-bh"),
+			Associations: []types.RouteTableAssociation{
+				{
+					SubnetId: aws.String("subnet-bh"),
+				},
+			},
+			Routes: []types.Route{
+				{
+					DestinationCidrBlock: aws.String("0.0.0.0/0"),
+					GatewayId:            aws.String("igw-deleted"),
+					State:                types.RouteStateBlackhole,
+				},
+			},
+		},
+	}
+
+	if isPublicSubnet("subnet-bh", "vpc-bh", routeTables) {
+		t.Error("subnet whose only igw default route is blackhole should NOT be classified as public")
+	}
+}
+
 // Regression tests for T-568: prefix list routes were silently dropped
 // because FormatRouteTableInfo only checked DestinationCidrBlock and
 // DestinationIpv6CidrBlock, ignoring DestinationPrefixListId entirely.


### PR DESCRIPTION
## Summary

`vpc overview` classified a subnet as public whenever its route table had an `igw-*` default route (`0.0.0.0/0` or `::/0`), regardless of route state. When an internet gateway is deleted, AWS leaves the route in the table with `State=blackhole`. Such routes are unusable, so affected subnets were wrongly reported as public.

## Root cause

`helpers/ec2.go:hasInternetGatewayRoute` matched on `GatewayId` prefix and destination CIDR only, never inspecting `route.State`.

## Fix

Skip routes with `State == types.RouteStateBlackhole` before evaluating them as IGW default routes. Active routes (empty or `active` state) remain classified as public.

## Tests

Added regression tests in `helpers/ec2_test.go`:
- `TestHasInternetGatewayRoute_IPv4BlackholeNotPublic`
- `TestHasInternetGatewayRoute_IPv6BlackholeNotPublic`
- `TestHasInternetGatewayRoute_ActiveStateStillPublic` (control)
- `TestIsPublicSubnet_BlackholeIGWNotPublic`

These fail before the fix and pass after. Full suite (`go test ./...`) passes.

Closes T-1411.