### PR TITLE
Fix T-1104: RDS Name Collection Nil Field Handling

### DIFF
--- a/helpers/rds.go
+++ b/helpers/rds.go
@@ -45,13 +45,19 @@ func addAllInstanceNames(svc rds.DescribeDBInstancesAPIClient, result map[string
 			panic(err)
 		}
 		for _, dbinstance := range resp.DBInstances {
-			result[*dbinstance.DbiResourceId] = *dbinstance.DBInstanceIdentifier
-			if dbinstance.TagList != nil {
-				for _, tag := range dbinstance.TagList {
-					if *tag.Key == "Name" {
-						result[*dbinstance.DbiResourceId] = *tag.Value
-						break
-					}
+			// DbiResourceId is the map key; without it there is nothing to
+			// store, so skip instances that lack one rather than panic.
+			resourceID := aws.ToString(dbinstance.DbiResourceId)
+			if resourceID == "" {
+				continue
+			}
+			// Fall back to the instance identifier (which may itself be
+			// empty) and prefer a Name tag when one is present.
+			result[resourceID] = aws.ToString(dbinstance.DBInstanceIdentifier)
+			for _, tag := range dbinstance.TagList {
+				if aws.ToString(tag.Key) == "Name" && tag.Value != nil {
+					result[resourceID] = aws.ToString(tag.Value)
+					break
 				}
 			}
 		}

--- a/helpers/rds_pagination_test.go
+++ b/helpers/rds_pagination_test.go
@@ -103,3 +103,61 @@ func TestAddAllInstanceNames_Pagination(t *testing.T) {
 		}
 	}
 }
+
+// TestAddAllInstanceNames_NilFields verifies that addAllInstanceNames safely
+// handles DB instances and tags with nil pointer fields. The AWS SDK returns
+// pointer fields that may be nil; before the fix the helper dereferenced
+// DbiResourceId, DBInstanceIdentifier, tag.Key, and tag.Value directly, which
+// panicked instead of skipping or falling back. T-1104.
+func TestAddAllInstanceNames_NilFields(t *testing.T) {
+	instances := []types.DBInstance{
+		// nil DbiResourceId: no map key available, must be skipped entirely.
+		{
+			DBInstanceIdentifier: aws.String("db-no-resource-id"),
+		},
+		// nil DBInstanceIdentifier: should fall back to empty rather than panic.
+		{
+			DbiResourceId: aws.String("db-resource-nil-identifier"),
+		},
+		// nil tag key and nil Name tag value: must not panic; identifier is used.
+		{
+			DbiResourceId:        aws.String("db-resource-nil-tags"),
+			DBInstanceIdentifier: aws.String("db-identifier-nil-tags"),
+			TagList: []types.Tag{
+				{Key: nil, Value: aws.String("ignored")},
+				{Key: aws.String("Name"), Value: nil},
+			},
+		},
+		// well-formed instance with a Name tag to confirm normal behaviour.
+		{
+			DbiResourceId:        aws.String("db-resource-good"),
+			DBInstanceIdentifier: aws.String("db-identifier-good"),
+			TagList: []types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("good-name")},
+			},
+		},
+	}
+	mock := &mockDescribeDBInstancesClient{instances: instances}
+
+	result := addAllInstanceNames(mock, map[string]string{})
+
+	// Instance with nil DbiResourceId must be skipped (no key to store under).
+	if _, ok := result["db-no-resource-id"]; ok {
+		t.Errorf("instance with nil DbiResourceId should be skipped, got entry %q", result["db-no-resource-id"])
+	}
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries (nil-resource-id skipped), got %d: %v", len(result), result)
+	}
+	// nil DBInstanceIdentifier falls back to empty string.
+	if got := result["db-resource-nil-identifier"]; got != "" {
+		t.Errorf("nil DBInstanceIdentifier should fall back to %q, got %q", "", got)
+	}
+	// nil tag key / nil Name value: falls back to the instance identifier.
+	if got := result["db-resource-nil-tags"]; got != "db-identifier-nil-tags" {
+		t.Errorf("nil tag fields should fall back to identifier %q, got %q", "db-identifier-nil-tags", got)
+	}
+	// well-formed instance uses its Name tag.
+	if got := result["db-resource-good"]; got != "good-name" {
+		t.Errorf("expected Name tag %q, got %q", "good-name", got)
+	}
+}


### PR DESCRIPTION
## Summary

`awstools names` calls `helpers.GetAllRdsResourceNames`, which walked RDS DB instances in `addAllInstanceNames` (`helpers/rds.go`). The helper directly dereferenced the AWS SDK pointer fields `DbiResourceId`, `DBInstanceIdentifier`, `tag.Key`, and `tag.Value`. These optional fields can be nil in an API response, so a single missing value panicked the whole command.

## Root cause

Optional SDK `*string` fields were dereferenced without nil guards.

## Fix

- Use `aws.ToString` for all optional string fields (consistent with `GetRDSName` in the same file).
- Skip instances with no `DbiResourceId` (it is the map key).
- Fall back to the instance identifier, applying a `Name` tag only when its value pointer is non-nil.

## Tests

Added `TestAddAllInstanceNames_NilFields` covering nil `DbiResourceId`, nil `DBInstanceIdentifier`, nil tag key, and nil Name tag value. The test panicked at `helpers/rds.go:48` before the fix and passes after. Full suite (`go test ./...`) passes.