### PR TITLE
Fix T-1314: Profile Generator Concatenation On Append

### DIFF
--- a/docs/agent-notes/aws-config.md
+++ b/docs/agent-notes/aws-config.md
@@ -29,3 +29,7 @@ AWS profile names are case-sensitive — they are matched verbatim against `[pro
 ## AWS Config File Parser
 
 `helpers/aws_config_file.go:parseConfigFileWithRecovery` reads `~/.aws/config` with `bufio.Scanner`. The default token size (64 KiB) is too small for configs with long `credential_process` commands or other oversized custom properties, so the parser calls `scanner.Buffer` with a 1 MiB cap (`maxConfigLineSize`). Without this, a single long line causes `bufio.ErrTooLong` and aborts the whole parse, bypassing the partial-recovery logic. This was the fix for T-867.
+
+## Appending Profiles (AppendToFile)
+
+`AppendToFile` opens the config with `os.O_APPEND|os.O_CREATE|os.O_RDWR` and writes each generated profile's `ToConfigString()`. Each `ToConfigString()` block already ends in `\n\n`, so successive appended profiles separate correctly — but the boundary between pre-existing content and the first appended profile is not guaranteed. Before the append loop it now `Stat`s the file and, if non-empty with a final byte that is not `\n`, writes one separator newline. Without this, a user config ending on a property line with no trailing newline would have the next `[profile ...]` header concatenated onto it, corrupting both entries (T-1314). The fd is `O_RDWR` (not `O_WRONLY`) specifically so the trailing byte can be read via `ReadAt`; `O_APPEND` still forces all writes to the end.

--- a/helpers/aws_config_file.go
+++ b/helpers/aws_config_file.go
@@ -620,8 +620,11 @@ func (cf *AWSConfigFile) AppendToFile(profiles []GeneratedProfile) error {
 
 	// Append with file locking for concurrent access protection
 	appendErr := func() error {
-		// Open file for appending with locking
-		file, err := os.OpenFile(cf.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		// Open file for appending with locking. O_RDWR (rather than
+		// O_WRONLY) is required so the existing trailing byte can be
+		// inspected before appending; O_APPEND still forces writes to
+		// the end of the file.
+		file, err := os.OpenFile(cf.FilePath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			return NewFileSystemError("failed to open config file for appending", err).
 				WithContext("file_path", cf.FilePath)
@@ -638,6 +641,27 @@ func (cf *AWSConfigFile) AppendToFile(profiles []GeneratedProfile) error {
 		if err := file.Chmod(0600); err != nil {
 			return NewFileSystemError("failed to set file permissions", err).
 				WithContext("file_path", cf.FilePath)
+		}
+
+		// Ensure the existing content ends with a newline before appending.
+		// If the file is non-empty and its final byte is not a newline,
+		// appending a profile header would concatenate it onto the previous
+		// property line, corrupting both entries (T-1314).
+		if info, statErr := file.Stat(); statErr != nil {
+			return NewFileSystemError("failed to stat config file", statErr).
+				WithContext("file_path", cf.FilePath)
+		} else if info.Size() > 0 {
+			lastByte := make([]byte, 1)
+			if _, readErr := file.ReadAt(lastByte, info.Size()-1); readErr != nil {
+				return NewFileSystemError("failed to read end of config file", readErr).
+					WithContext("file_path", cf.FilePath)
+			}
+			if lastByte[0] != '\n' {
+				if _, writeErr := file.WriteString("\n"); writeErr != nil {
+					return NewFileSystemError("failed to write separator newline", writeErr).
+						WithContext("file_path", cf.FilePath)
+				}
+			}
 		}
 
 		// Append new profiles

--- a/helpers/aws_config_file_test.go
+++ b/helpers/aws_config_file_test.go
@@ -2282,6 +2282,49 @@ func TestAWSConfigFile_AppendToFileWithLocking(t *testing.T) {
 		os.Remove(backupFiles[0])
 	})
 
+	t.Run("append when file has no trailing newline (T-1314)", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "aws-config-test-*.conf")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		// Initial content ends on a property line with NO trailing newline.
+		initialContent := "[profile initial]\nregion = us-east-1"
+		_, err = tmpFile.WriteString(initialContent)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		configFile := &AWSConfigFile{
+			FilePath: tmpFile.Name(),
+			Profiles: make(map[string]Profile),
+			Sessions: make(map[string]SSOSession),
+		}
+
+		profiles := []GeneratedProfile{
+			{
+				Name:   "test-profile",
+				Region: "us-west-2",
+			},
+		}
+
+		err = configFile.AppendToFile(profiles)
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+
+		// The appended profile header must not be concatenated onto the
+		// previous property line.
+		assert.NotContains(t, string(content), "region = us-east-1[profile test-profile]")
+		assert.Contains(t, string(content), "region = us-east-1\n[profile test-profile]")
+
+		// Cleanup backup
+		backupFiles, err := filepath.Glob(tmpFile.Name() + ".backup.*")
+		require.NoError(t, err)
+		for _, bf := range backupFiles {
+			os.Remove(bf)
+		}
+	})
+
 	t.Run("append failure with permission error", func(t *testing.T) {
 		tmpFile, err := os.CreateTemp("", "aws-config-test-*.conf")
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

`AWSConfigFile.AppendToFile` opened `~/.aws/config` with `os.O_APPEND` and wrote each generated profile's `ToConfigString()` without ensuring the existing file ended in a newline. If a user's config ended on a property line with no trailing newline, the next profile header was concatenated onto that line, corrupting both entries (T-1314).

## Root cause

The append path never inspected the file's final byte before writing the first new profile header. The only existing test seeded content ending in `\n\n`, masking the case.

## Fix

- Open the append fd as `O_RDWR` instead of `O_WRONLY` so the trailing byte can be read (`O_APPEND` still forces writes to the end).
- Before the append loop, `Stat` the file; if it is non-empty and its final byte is not `\n`, write a single separator newline first.

## Tests

Added regression subtest `TestAWSConfigFile_AppendToFileWithLocking/append_when_file_has_no_trailing_newline_(T-1314)` using initial content `[profile initial]\nregion = us-east-1` (no trailing newline). It asserts the output contains `region = us-east-1\n[profile test-profile]` and not the concatenated form. Verified failing before the fix and passing after. Full suite (`go test ./...`) passes.