### PR TITLE
Fix T-901: Organizations Child Formatting Nil Metadata Panic

### DIFF
--- a/helpers/organizations.go
+++ b/helpers/organizations.go
@@ -121,10 +121,10 @@ func formatChild(raw types.Child, svc OrganizationsAPI) (OrganizationEntry, erro
 		}
 		details, err := svc.DescribeOrganizationalUnit(context.TODO(), input)
 		if err != nil {
-			return OrganizationEntry{}, fmt.Errorf("failed to describe OU %s: %w", *raw.Id, err)
+			return OrganizationEntry{}, fmt.Errorf("failed to describe OU %s: %w", aws.ToString(raw.Id), err)
 		}
 		if details.OrganizationalUnit == nil {
-			return OrganizationEntry{}, fmt.Errorf("OU metadata is nil for %s", *raw.Id)
+			return OrganizationEntry{}, fmt.Errorf("OU metadata is nil for %s", aws.ToString(raw.Id))
 		}
 		return OrganizationEntry{
 			Name:     aws.ToString(details.OrganizationalUnit.Name),
@@ -139,10 +139,10 @@ func formatChild(raw types.Child, svc OrganizationsAPI) (OrganizationEntry, erro
 	}
 	details, err := svc.DescribeAccount(context.TODO(), input)
 	if err != nil {
-		return OrganizationEntry{}, fmt.Errorf("failed to describe account %s: %w", *raw.Id, err)
+		return OrganizationEntry{}, fmt.Errorf("failed to describe account %s: %w", aws.ToString(raw.Id), err)
 	}
 	if details.Account == nil {
-		return OrganizationEntry{}, fmt.Errorf("account metadata is nil for %s", *raw.Id)
+		return OrganizationEntry{}, fmt.Errorf("account metadata is nil for %s", aws.ToString(raw.Id))
 	}
 	return OrganizationEntry{
 		Name:     aws.ToString(details.Account.Name),

--- a/helpers/organizations_test.go
+++ b/helpers/organizations_test.go
@@ -422,3 +422,43 @@ func TestFormatChild_NilAccountMetadata_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "account metadata is nil")
 }
+
+// TestFormatChild_NilOUID_DescribeError_ReturnsError verifies that when AWS
+// returns an OU child with a nil Id and the subsequent DescribeOrganizationalUnit
+// call fails, formatChild returns an error rather than panicking while formatting
+// the error message (it must not dereference *raw.Id).
+func TestFormatChild_NilOUID_DescribeError_ReturnsError(t *testing.T) {
+	mock := &mockOrganizationsClient{
+		DescribeOrganizationalUnitFunc: func(_ context.Context, _ *organizations.DescribeOrganizationalUnitInput, _ ...func(*organizations.Options)) (*organizations.DescribeOrganizationalUnitOutput, error) {
+			return nil, errors.New("access denied to OU")
+		},
+	}
+	child := orgtypes.Child{
+		Id:   nil,
+		Type: orgtypes.ChildType(orgtypes.TargetTypeOrganizationalUnit),
+	}
+
+	_, err := formatChild(child, mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied to OU")
+}
+
+// TestFormatChild_NilAccountID_DescribeError_ReturnsError verifies that when AWS
+// returns an account child with a nil Id and the subsequent DescribeAccount call
+// fails, formatChild returns an error rather than panicking while formatting the
+// error message (it must not dereference *raw.Id).
+func TestFormatChild_NilAccountID_DescribeError_ReturnsError(t *testing.T) {
+	mock := &mockOrganizationsClient{
+		DescribeAccountFunc: func(_ context.Context, _ *organizations.DescribeAccountInput, _ ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error) {
+			return nil, errors.New("account not found")
+		},
+	}
+	child := orgtypes.Child{
+		Id:   nil,
+		Type: orgtypes.ChildType(orgtypes.TargetTypeAccount),
+	}
+
+	_, err := formatChild(child, mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account not found")
+}


### PR DESCRIPTION
## Summary

`helpers/organizations.go:formatChild` could panic with a nil pointer dereference when AWS returned an Organizations child whose `Id` was nil and the subsequent `DescribeOrganizationalUnit` / `DescribeAccount` call failed (or returned nil metadata). The error-formatting paths dereferenced `*raw.Id` directly, so `GetFullOrganization` crashed instead of returning an error — contradicting the T-418 direction that org error handling must not panic.

## Root Cause

The success paths and nil-metadata guards already used `aws.ToString(...)`, but the four error-format statements still dereferenced the raw pointer:

- `failed to describe OU %s` / `OU metadata is nil for %s` with `*raw.Id`
- `failed to describe account %s` / `account metadata is nil for %s` with `*raw.Id`

`raw.Id` is an `*string` from `ListChildren`; AWS does not guarantee it is non-nil. When nil and the Describe call also failed, building the error message panicked (observed at `organizations.go:124`).

## Fix

Replaced all four `*raw.Id` dereferences with `aws.ToString(raw.Id)`, which yields the empty string for a nil pointer. The failure mode stays an error return; no signatures changed.

## Tests

Added regression tests:
- `TestFormatChild_NilOUID_DescribeError_ReturnsError`
- `TestFormatChild_NilAccountID_DescribeError_ReturnsError`

Both panicked against the unfixed code and pass after the fix. `go build ./...` and `go test ./...` pass.