### PR TITLE
Fix T-1382: Validate Required Stack And Mesh Flags Before AWS Calls

### DIFF
--- a/cmd/appmesh.go
+++ b/cmd/appmesh.go
@@ -16,4 +16,10 @@ var meshname *string
 func init() {
 	rootCmd.AddCommand(appmeshCmd)
 	meshname = appmeshCmd.PersistentFlags().StringP("meshname", "m", "", "The name of the mesh")
+	// Every appmesh subcommand operates on a specific mesh, so require the flag.
+	// Cobra rejects the command with a usage error before the Run function (and
+	// thus any AWS config loading or API call) executes. See T-1382.
+	if err := appmeshCmd.MarkPersistentFlagRequired("meshname"); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/cfn.go
+++ b/cmd/cfn.go
@@ -14,4 +14,10 @@ var stackname *string
 func init() {
 	rootCmd.AddCommand(cfnCmd)
 	stackname = cfnCmd.PersistentFlags().StringP("stack", "s", "", "The name of the stack")
+	// Every cfn subcommand operates on a specific stack, so require the flag.
+	// Cobra rejects the command with a usage error before the Run function (and
+	// thus any AWS config loading or API call) executes. See T-1382.
+	if err := cfnCmd.MarkPersistentFlagRequired("stack"); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/flag_validation_test.go
+++ b/cmd/flag_validation_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequiredFlagsRejectedBeforeAWSCalls verifies that the cfn and appmesh
+// subcommands reject a missing/empty required flag (--stack / --meshname) with
+// a Cobra usage error, before any AWS config is loaded or AWS API is called.
+//
+// Bug T-1382: --stack and --meshname were registered with an empty-string
+// default and not marked required, so the subcommands ran their Run function
+// with an empty pointer, eventually sending an empty StackName/meshName to AWS
+// and panicking/printing an AWS validation error instead of Cobra usage.
+//
+// Expected: each command returns an error containing "required flag(s)" and the
+// flag name, with no AWS interaction. If this test reaches an AWS call it would
+// fail (panic or hang) rather than returning a clean required-flag error.
+func TestRequiredFlagsRejectedBeforeAWSCalls(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flagName string
+	}{
+		{
+			name:     "cfn resources without --stack",
+			args:     []string{"cfn", "resources"},
+			flagName: "stack",
+		},
+		{
+			name:     "appmesh routelist without --meshname",
+			args:     []string{"appmesh", "routelist"},
+			flagName: "meshname",
+		},
+		{
+			name:     "appmesh showmesh without --meshname",
+			args:     []string{"appmesh", "showmesh"},
+			flagName: "meshname",
+		},
+		{
+			name:     "appmesh danglingnodes without --meshname",
+			args:     []string{"appmesh", "danglingnodes"},
+			flagName: "meshname",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs(tt.args)
+
+			err := rootCmd.Execute()
+
+			require.Error(t, err, "expected a required-flag error, command should not reach AWS")
+			assert.Contains(t, err.Error(), "required flag(s)")
+			assert.Contains(t, err.Error(), tt.flagName)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`cmd/cfn.go` registered `--stack`/`-s` and `cmd/appmesh.go` registered `--meshname`/`-m` with empty-string defaults, neither marked required. Subcommands ran their `Run` function with an empty flag pointer, loaded AWS config, and called an AWS API with an empty stack/mesh value — producing a panic / AWS validation error instead of a Cobra usage error.

## Root cause

The persistent flags were optional with empty defaults and the subcommands (`Run`, not `RunE`) performed no validation, so Cobra never blocked execution for a missing flag.

## Fix

- `cmd/cfn.go`: mark `--stack` persistent flag required on `cfnCmd`.
- `cmd/appmesh.go`: mark `--meshname` persistent flag required on `appmeshCmd`.

`MarkPersistentFlagRequired` makes Cobra reject the command with a `required flag(s) ... not set` usage error during argument validation, before the `Run` function executes and therefore before any AWS config loading or API call. Every cfn/appmesh subcommand requires the value, so marking the inherited flag required on the parent is the minimal, uniform fix. Change is scoped to the `cmd` package (helpers error propagation is handled separately in T-1366).

## Regression test

`cmd/flag_validation_test.go` (`TestRequiredFlagsRejectedBeforeAWSCalls`) exercises the real command tree for `cfn resources`, `appmesh routelist`, `appmesh showmesh`, and `appmesh danglingnodes` without their required flag, asserting a `required flag(s)` error with the flag name and no AWS interaction. Before the fix it panicked in `config.DefaultAwsConfig`; after the fix it passes.

## Verification

- Regression test passes
- `go test ./...` passes (exit 0)
- Linter clean on changed files (pre-existing goconst warnings exist only in unrelated vpc* files)