### PR TITLE
Fix T-1176: S3 Encryption Nil Default Rule

### DIFF
--- a/cmd/s3list.go
+++ b/cmd/s3list.go
@@ -136,12 +136,24 @@ func negatedTriState(v *bool) any {
 	return !*v
 }
 
+// s3EncryptionToString renders the default encryption algorithm of the first
+// encryption rule. A malformed or partial GetBucketEncryption response can
+// return a rule without the default encryption block, so guard against a nil
+// ApplyServerSideEncryptionByDefault (and an empty algorithm) rather than
+// dereferencing it directly, which would panic (see T-1176). When no algorithm
+// can be read the rule's state is reported as s3StateUnknown.
 func s3EncryptionToString(rules []types.ServerSideEncryptionRule) string {
-	result := ""
-	for _, rule := range rules {
-		return string(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
+	if len(rules) == 0 {
+		return ""
 	}
-	return result
+	rule := rules[0]
+	if rule.ApplyServerSideEncryptionByDefault == nil {
+		return s3StateUnknown
+	}
+	if algorithm := string(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm); algorithm != "" {
+		return algorithm
+	}
+	return s3StateUnknown
 }
 
 // parsePublicAccessBlock renders a PublicAccessBlockConfiguration as a human

--- a/cmd/s3list_test.go
+++ b/cmd/s3list_test.go
@@ -62,3 +62,60 @@ func TestParsePublicAccessBlock(t *testing.T) {
 		})
 	}
 }
+
+// TestS3EncryptionToString verifies that s3EncryptionToString tolerates rules
+// with a nil ApplyServerSideEncryptionByDefault block. A malformed or partial
+// GetBucketEncryption response can return a rule without the default
+// encryption block; before the fix this dereferenced a nil pointer and
+// panicked while rendering `awstools s3 list`. Regression test for T-1176.
+func TestS3EncryptionToString(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []types.ServerSideEncryptionRule
+		want  string
+	}{
+		{
+			name:  "no rules",
+			rules: nil,
+			want:  "",
+		},
+		{
+			name: "nil default rule does not panic",
+			rules: []types.ServerSideEncryptionRule{
+				{ApplyServerSideEncryptionByDefault: nil},
+			},
+			want: s3StateUnknown,
+		},
+		{
+			name: "aes256 algorithm",
+			rules: []types.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+						SSEAlgorithm: types.ServerSideEncryptionAes256,
+					},
+				},
+			},
+			want: string(types.ServerSideEncryptionAes256),
+		},
+		{
+			name: "kms algorithm",
+			rules: []types.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+						SSEAlgorithm: types.ServerSideEncryptionAwsKms,
+					},
+				},
+			},
+			want: string(types.ServerSideEncryptionAwsKms),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s3EncryptionToString(tt.rules)
+			if got != tt.want {
+				t.Errorf("s3EncryptionToString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

`awstools s3 list` could panic with a nil pointer dereference while rendering a bucket's encryption state.

## Root Cause

`s3EncryptionToString` (cmd/s3list.go) returned `string(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)` directly. The AWS SDK declares `ApplyServerSideEncryptionByDefault` as `*types.ServerSideEncryptionByDefault` (a pointer). A malformed or partial `GetBucketEncryption` response with a rule missing the default encryption block yields a nil pointer, and the unguarded dereference panicked.

## Fix

Guard the extraction in `s3EncryptionToString`:
- Return `""` when there are no rules.
- Return `Unknown` when the first rule's `ApplyServerSideEncryptionByDefault` is nil or the algorithm is empty.
- Otherwise return the algorithm string as before.

The original code only ever read the first rule, so the fix reads `rules[0]` directly (this also resolves a staticcheck SA4004 warning). Scope kept to `s3EncryptionToString`; distinct from T-1093 and T-1391.

## Tests

Added `TestS3EncryptionToString` covering: no rules, nil default rule (panicked before the fix), AES256, and aws:kms. Verified the nil case panicked before the fix and passes after. `go build ./...` and `go test ./...` pass.