### PR TITLE
Fix T-1366: CloudFormation resources panic on list errors

### DIFF
--- a/cmd/cfnresources.go
+++ b/cmd/cfnresources.go
@@ -18,7 +18,7 @@ var resourcesCmd = &cobra.Command{
 Return values are the ResourceID, Type, and Stack of the resource. You can use the --namefile flag to show names instead of resource ids.
 
 --verbose will add the status and logicalname (the nme within the stack) to the output`,
-	Run: listResources,
+	RunE: listResources,
 }
 
 type cfnResource struct {
@@ -59,10 +59,13 @@ func buildCfnResource(resource types.StackResource, nameResolver func(string) st
 	}
 }
 
-func listResources(_ *cobra.Command, _ []string) {
+func listResources(_ *cobra.Command, _ []string) error {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "CloudFormation resources for stack " + *stackname
-	unparsedResources := helpers.GetNestedCloudFormationResources(stackname, awsConfig.CloudformationClient())
+	unparsedResources, err := helpers.GetNestedCloudFormationResources(stackname, awsConfig.CloudformationClient())
+	if err != nil {
+		return err
+	}
 	resources := make([]cfnResource, len(unparsedResources))
 
 	c := make(chan cfnResource)
@@ -95,4 +98,5 @@ func listResources(_ *cobra.Command, _ []string) {
 		output.AddHolder(holder)
 	}
 	output.Write()
+	return nil
 }

--- a/helpers/cfn.go
+++ b/helpers/cfn.go
@@ -11,15 +11,18 @@ import (
 // GetResourcesByStackName returns every resource in the provided stack. It
 // walks the ListStackResources paginator so stacks with more than 100
 // resources are handled correctly; DescribeStackResources silently caps its
-// response at 100 and offers no continuation token (T-784).
-func GetResourcesByStackName(stackname *string, svc *cloudformation.Client) []types.StackResource {
+// response at 100 and offers no continuation token (T-784). Any CloudFormation
+// API error (missing/invalid stack, access denied, throttling) is returned to
+// the caller rather than panicking (T-1366).
+func GetResourcesByStackName(stackname *string, svc *cloudformation.Client) ([]types.StackResource, error) {
 	return getResourcesByStackName(stackname, svc)
 }
 
 // GetNestedCloudFormationResources retrieves every resource in the provided
 // stack plus those of any nested stacks it contains. Each level is paginated
-// independently.
-func GetNestedCloudFormationResources(stackname *string, svc *cloudformation.Client) []types.StackResource {
+// independently. Errors from any level (including nested stacks) are returned
+// to the caller rather than panicking (T-1366).
+func GetNestedCloudFormationResources(stackname *string, svc *cloudformation.Client) ([]types.StackResource, error) {
 	return getNestedCloudFormationResources(stackname, svc)
 }
 
@@ -31,7 +34,7 @@ func GetNestedCloudFormationResources(stackname *string, svc *cloudformation.Cli
 // StackName field; the helper backfills it from the input so downstream
 // consumers (notably cmd/cfnresources.go's buildCfnResource) keep the
 // originating stack name for each resource.
-func getResourcesByStackName(stackname *string, svc cloudformation.ListStackResourcesAPIClient) []types.StackResource {
+func getResourcesByStackName(stackname *string, svc cloudformation.ListStackResourcesAPIClient) ([]types.StackResource, error) {
 	paginator := cloudformation.NewListStackResourcesPaginator(svc, &cloudformation.ListStackResourcesInput{
 		StackName: stackname,
 	})
@@ -39,13 +42,13 @@ func getResourcesByStackName(stackname *string, svc cloudformation.ListStackReso
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.TODO())
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		for _, summary := range page.StackResourceSummaries {
 			result = append(result, stackResourceFromSummary(summary, stackname))
 		}
 	}
-	return result
+	return result, nil
 }
 
 // getNestedCloudFormationResources is the testable implementation behind
@@ -53,8 +56,11 @@ func getResourcesByStackName(stackname *string, svc cloudformation.ListStackReso
 // PhysicalResourceId is skipped rather than recursed into — passing a nil
 // StackName to ListStackResources would otherwise re-describe the parent
 // stack, leading to duplicates or infinite recursion.
-func getNestedCloudFormationResources(stackname *string, svc cloudformation.ListStackResourcesAPIClient) []types.StackResource {
-	resources := getResourcesByStackName(stackname, svc)
+func getNestedCloudFormationResources(stackname *string, svc cloudformation.ListStackResourcesAPIClient) ([]types.StackResource, error) {
+	resources, err := getResourcesByStackName(stackname, svc)
+	if err != nil {
+		return nil, err
+	}
 	result := make([]types.StackResource, 0, len(resources))
 	for _, resource := range resources {
 		result = append(result, resource)
@@ -64,9 +70,13 @@ func getNestedCloudFormationResources(stackname *string, svc cloudformation.List
 		if resource.PhysicalResourceId == nil || aws.ToString(resource.PhysicalResourceId) == "" {
 			continue
 		}
-		result = append(result, getNestedCloudFormationResources(resource.PhysicalResourceId, svc)...)
+		nested, err := getNestedCloudFormationResources(resource.PhysicalResourceId, svc)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, nested...)
 	}
-	return result
+	return result, nil
 }
 
 // stackResourceFromSummary converts a ListStackResources summary into the

--- a/helpers/cfn_error_test.go
+++ b/helpers/cfn_error_test.go
@@ -1,0 +1,130 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+// Regression tests for T-1366: getResourcesByStackName previously called
+// panic(err) when the ListStackResources paginator's NextPage returned an
+// error. Normal API failures (missing/invalid --stack, access denied,
+// throttling, deleted nested stack) therefore aborted the CLI with a panic
+// instead of a controlled error. The fix propagates the error so the command
+// can render it normally. getNestedCloudFormationResources is covered too
+// because it recurses through the same helper.
+
+// errListStackResourcesAPIClient implements
+// cloudformation.ListStackResourcesAPIClient and always fails, mirroring an
+// AWS API error such as ValidationError, AccessDenied, or Throttling.
+type errListStackResourcesAPIClient struct {
+	err   error
+	calls int
+}
+
+func (m *errListStackResourcesAPIClient) ListStackResources(_ context.Context, _ *cloudformation.ListStackResourcesInput, _ ...func(*cloudformation.Options)) (*cloudformation.ListStackResourcesOutput, error) {
+	m.calls++
+	return nil, m.err
+}
+
+// TestGetResourcesByStackName_PropagatesError proves the helper returns the
+// underlying API error instead of panicking. Before the fix this test would
+// panic in NextPage and never reach the assertions.
+func TestGetResourcesByStackName_PropagatesError(t *testing.T) {
+	apiErr := errors.New("ValidationError: Stack [missing] does not exist")
+	mock := &errListStackResourcesAPIClient{err: apiErr}
+
+	name := "missing"
+	result, err := getResourcesByStackName(&name, mock)
+
+	if err == nil {
+		t.Fatalf("getResourcesByStackName() returned nil error, want the API error to be propagated")
+	}
+	if !errors.Is(err, apiErr) {
+		t.Errorf("getResourcesByStackName() error = %v, want it to wrap %v", err, apiErr)
+	}
+	if result != nil {
+		t.Errorf("getResourcesByStackName() returned %d resources on error, want nil", len(result))
+	}
+}
+
+// TestGetNestedCloudFormationResources_PropagatesError proves the recursive
+// helper also propagates the API error from the first failing page rather
+// than panicking.
+func TestGetNestedCloudFormationResources_PropagatesError(t *testing.T) {
+	apiErr := errors.New("AccessDenied: not authorized to perform cloudformation:ListStackResources")
+	mock := &errListStackResourcesAPIClient{err: apiErr}
+
+	name := "parent"
+	result, err := getNestedCloudFormationResources(&name, mock)
+
+	if err == nil {
+		t.Fatalf("getNestedCloudFormationResources() returned nil error, want the API error to be propagated")
+	}
+	if !errors.Is(err, apiErr) {
+		t.Errorf("getNestedCloudFormationResources() error = %v, want it to wrap %v", err, apiErr)
+	}
+	if result != nil {
+		t.Errorf("getNestedCloudFormationResources() returned %d resources on error, want nil", len(result))
+	}
+}
+
+// TestGetNestedCloudFormationResources_PropagatesNestedError proves an error
+// raised while listing a nested stack (after the parent listed successfully)
+// is propagated rather than panicking mid-recursion.
+func TestGetNestedCloudFormationResources_PropagatesNestedError(t *testing.T) {
+	const parent = "parent-stack"
+	const nested = "nested-stack"
+	nestedErr := errors.New("ValidationError: Stack [nested-stack] does not exist")
+
+	mock := &failingNestedAPIClient{
+		parent:    parent,
+		nested:    nested,
+		nestedErr: nestedErr,
+	}
+
+	name := parent
+	result, err := getNestedCloudFormationResources(&name, mock)
+
+	if err == nil {
+		t.Fatalf("getNestedCloudFormationResources() returned nil error, want the nested API error to be propagated")
+	}
+	if !errors.Is(err, nestedErr) {
+		t.Errorf("getNestedCloudFormationResources() error = %v, want it to wrap %v", err, nestedErr)
+	}
+	if result != nil {
+		t.Errorf("getNestedCloudFormationResources() returned %d resources on nested error, want nil", len(result))
+	}
+}
+
+// failingNestedAPIClient serves the parent stack successfully (with a single
+// nested-stack marker) but fails when the nested stack is listed.
+type failingNestedAPIClient struct {
+	parent    string
+	nested    string
+	nestedErr error
+}
+
+func (m *failingNestedAPIClient) ListStackResources(_ context.Context, input *cloudformation.ListStackResourcesInput, _ ...func(*cloudformation.Options)) (*cloudformation.ListStackResourcesOutput, error) {
+	switch aws.ToString(input.StackName) {
+	case m.parent:
+		return &cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []types.StackResourceSummary{
+				{
+					LogicalResourceId:  aws.String("NestedChild"),
+					PhysicalResourceId: aws.String(m.nested),
+					ResourceType:       aws.String("AWS::CloudFormation::Stack"),
+					ResourceStatus:     types.ResourceStatusCreateComplete,
+				},
+			},
+		}, nil
+	case m.nested:
+		return nil, m.nestedErr
+	default:
+		return &cloudformation.ListStackResourcesOutput{}, nil
+	}
+}

--- a/helpers/cfn_pagination_test.go
+++ b/helpers/cfn_pagination_test.go
@@ -102,7 +102,10 @@ func TestGetResourcesByStackName_Pagination(t *testing.T) {
 	mock.pages[stack] = makeStackResourceSummaries(total)
 
 	name := stack
-	result := getResourcesByStackName(&name, mock)
+	result, err := getResourcesByStackName(&name, mock)
+	if err != nil {
+		t.Fatalf("getResourcesByStackName() returned unexpected error: %v", err)
+	}
 
 	if len(result) != total {
 		t.Fatalf("getResourcesByStackName() returned %d resources, want %d (pagination bug: only first page returned)", len(result), total)
@@ -153,7 +156,10 @@ func TestGetNestedCloudFormationResources_PaginatesNested(t *testing.T) {
 	mock.pages[nested] = makeStackResourceSummaries(150)
 
 	name := parent
-	result := getNestedCloudFormationResources(&name, mock)
+	result, err := getNestedCloudFormationResources(&name, mock)
+	if err != nil {
+		t.Fatalf("getNestedCloudFormationResources() returned unexpected error: %v", err)
+	}
 
 	// Expect every resource from both levels: 150 + 1 (nested marker) + 150.
 	wantTotal := 150 + 1 + 150
@@ -200,7 +206,10 @@ func TestGetNestedCloudFormationResources_SkipsNestedWithoutPhysicalID(t *testin
 	}
 
 	name := parent
-	result := getNestedCloudFormationResources(&name, mock)
+	result, err := getNestedCloudFormationResources(&name, mock)
+	if err != nil {
+		t.Fatalf("getNestedCloudFormationResources() returned unexpected error: %v", err)
+	}
 
 	if len(result) != 1 {
 		t.Fatalf("expected only the orphan nested entry, got %d resources", len(result))


### PR DESCRIPTION
## Bug

`awstools cfn resources` aborted with an unrecovered panic and a Go stack trace whenever the CloudFormation `ListStackResources` API call failed — e.g. a missing/invalid `--stack`, access denial, throttling, or a deleted nested stack. Nested stacks were affected too because the recursion reused the same helper.

## Root cause

`helpers/cfn.go:getResourcesByStackName` called `panic(err)` when the paginator's `NextPage` returned an error. The exported wrappers returned only `[]types.StackResource` (no error), and `cmd/cfnresources.go:listResources` used a non-error `Run` handler, so there was no channel to propagate the failure to Cobra.

## Fix

- `helpers/cfn.go`: `getResourcesByStackName` and `getNestedCloudFormationResources` (and their exported wrappers) now return `([]types.StackResource, error)` and propagate the API error — at the top level and through nested-stack recursion.
- `cmd/cfnresources.go`: `listResources` changed from `Run` to `RunE`, returning the helper error. `rootCmd.Execute()` already prints a returned error and exits non-zero, so failures now render as a normal command error with no panic.

Scope kept to error propagation; required-flag validation is left for T-1382 as noted on the ticket.

## Tests

Added `helpers/cfn_error_test.go` with a failing `cloudformation.ListStackResourcesAPIClient` mock, covering top-level failures and a failure that occurs only when listing a nested stack. Verified red/green: against the pre-fix code the helper panicked with the injected error; after the fix the helpers return the error (checked with `errors.Is`) and a nil result, no panic.

`go test ./...` passes; `go vet` clean; `golangci-lint` reports no issues in the changed files.