### PR TITLE
Fix T-1204: SSO Token Session-Name Cache Lookup

### DIFF
--- a/helpers/role_discovery.go
+++ b/helpers/role_discovery.go
@@ -74,7 +74,7 @@ func (rd *RoleDiscovery) DiscoverAccessibleRoles(templateProfile *TemplateProfil
 	ctx := context.TODO()
 
 	// Load cached token for the template profile
-	cachedToken, err := rd.tokenCache.LoadTokenForProfile(templateProfile.SSOStartURL, templateProfile.SSORegion)
+	cachedToken, err := rd.tokenCache.LoadTokenForTemplateProfile(templateProfile)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func (rd *RoleDiscovery) TestConnection(templateProfile *TemplateProfile) error 
 	ctx := context.TODO()
 
 	// Load cached token
-	cachedToken, err := rd.tokenCache.LoadTokenForProfile(templateProfile.SSOStartURL, templateProfile.SSORegion)
+	cachedToken, err := rd.tokenCache.LoadTokenForTemplateProfile(templateProfile)
 	if err != nil {
 		return err
 	}

--- a/helpers/sso_token_cache.go
+++ b/helpers/sso_token_cache.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 )
+
+// tokenCacheNotFoundMessage is the error message used when an SSO token cache
+// file does not exist. It is shared so callers can detect the not-found case.
+const tokenCacheNotFoundMessage = "SSO token cache not found"
 
 // SSOTokenCache handles access to AWS SSO token cache
 type SSOTokenCache struct {
@@ -57,13 +62,46 @@ func (stc *SSOTokenCache) SetLogger(logger Logger) {
 	stc.logger = logger
 }
 
-// LoadTokenForProfile loads cached token for a specific SSO profile
+// LoadTokenForTemplateProfile loads the cached SSO token for a template profile.
+//
+// Modern profiles (sso_session) and legacy profiles (sso_start_url only) store
+// their tokens under different cache filenames. For modern profiles the AWS CLI
+// hashes the session name; for legacy profiles it hashes the start URL. This
+// method tries the session-name cache first when a session is present and falls
+// back to the start-url cache so that caches written by older tooling still
+// resolve.
+func (stc *SSOTokenCache) LoadTokenForTemplateProfile(profile *TemplateProfile) (*CachedToken, error) {
+	// Modern profiles cache the token under the SHA1 of the session name.
+	if profile.SSOSession != "" {
+		token, err := stc.LoadTokenForKey(profile.SSOSession, profile.SSORegion)
+		if err == nil {
+			return token, nil
+		}
+		// Fall back to the legacy start-url cache (e.g. caches written by an
+		// older AWS CLI) only when the session-name cache is absent.
+		if !isTokenCacheNotFound(err) {
+			return nil, err
+		}
+	}
+
+	return stc.LoadTokenForKey(profile.SSOStartURL, profile.SSORegion)
+}
+
+// LoadTokenForProfile loads cached token for a specific SSO profile keyed by its
+// start URL. Retained for legacy callers; prefer LoadTokenForTemplateProfile so
+// modern sso_session profiles resolve correctly.
 func (stc *SSOTokenCache) LoadTokenForProfile(startURL, region string) (*CachedToken, error) {
-	tokenFile := stc.getTokenFilePath(startURL)
+	return stc.LoadTokenForKey(startURL, region)
+}
+
+// LoadTokenForKey loads and validates the cached token whose filename is derived
+// from the SHA1 hash of cacheKey (either an SSO session name or an SSO start URL).
+func (stc *SSOTokenCache) LoadTokenForKey(cacheKey, region string) (*CachedToken, error) {
+	tokenFile := stc.getTokenFilePath(cacheKey)
 
 	if _, err := os.Stat(tokenFile); os.IsNotExist(err) {
-		return nil, NewAuthError("SSO token cache not found", err).
-			WithContext("start_url", startURL).
+		return nil, NewAuthError(tokenCacheNotFoundMessage, err).
+			WithContext("cache_key", cacheKey).
 			WithContext("region", region).
 			WithContext("suggestion", "Run 'aws sso login' to authenticate")
 	}
@@ -95,13 +133,25 @@ func (stc *SSOTokenCache) LoadTokenForProfile(startURL, region string) (*CachedT
 	return &token, nil
 }
 
-// getTokenFilePath generates the cache file path for a given start URL
-func (stc *SSOTokenCache) getTokenFilePath(startURL string) string {
+// isTokenCacheNotFound reports whether err indicates the token cache file was
+// absent (as opposed to being present but expired or unreadable).
+func isTokenCacheNotFound(err error) bool {
+	var pgErr ProfileGeneratorError
+	if errors.As(err, &pgErr) {
+		return pgErr.Type == ErrorTypeAuth && pgErr.Message == tokenCacheNotFoundMessage
+	}
+	return false
+}
+
+// getTokenFilePath generates the cache file path for a given cache key (an SSO
+// session name for modern profiles or an SSO start URL for legacy profiles).
+func (stc *SSOTokenCache) getTokenFilePath(cacheKey string) string {
 	// NOTE: SHA1 is used here for compatibility with AWS CLI cache file naming conventions.
 	// This is NOT for security purposes. SHA1 is cryptographically weak and should not be used
-	// for integrity or authentication. AWS CLI uses SHA1 hash of the start URL to generate
-	// cache file names, and we follow the same convention to maintain compatibility.
-	hash := sha1.Sum([]byte(startURL))
+	// for integrity or authentication. AWS CLI uses a SHA1 hash of the session name (modern
+	// sso_session profiles) or the start URL (legacy profiles) to generate cache file names,
+	// and we follow the same convention to maintain compatibility.
+	hash := sha1.Sum([]byte(cacheKey))
 	hashStr := hex.EncodeToString(hash[:])
 
 	return filepath.Join(stc.cacheDir, hashStr+".json")
@@ -159,7 +209,7 @@ func (stc *SSOTokenCache) ValidateProfileToken(profile *TemplateProfile) error {
 		return NewValidationError("profile is not an SSO profile", nil)
 	}
 
-	token, err := stc.LoadTokenForProfile(profile.SSOStartURL, profile.SSORegion)
+	token, err := stc.LoadTokenForTemplateProfile(profile)
 	if err != nil {
 		return err
 	}

--- a/helpers/sso_token_cache_test.go
+++ b/helpers/sso_token_cache_test.go
@@ -1,0 +1,143 @@
+package helpers
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newTestTokenCache creates an SSOTokenCache backed by a temporary directory so
+// tests do not touch the real ~/.aws/sso/cache.
+func newTestTokenCache(t *testing.T) *SSOTokenCache {
+	t.Helper()
+	dir := t.TempDir()
+	return &SSOTokenCache{
+		cacheDir: dir,
+		logger:   &defaultLogger{},
+	}
+}
+
+// writeCacheFile writes a CachedToken to a cache file keyed by the SHA1 hash of key.
+func writeCacheFile(t *testing.T, cache *SSOTokenCache, key string, token CachedToken) {
+	t.Helper()
+	hash := sha1.Sum([]byte(key))
+	name := hex.EncodeToString(hash[:]) + ".json"
+	data, err := json.Marshal(token)
+	if err != nil {
+		t.Fatalf("failed to marshal token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cache.cacheDir, name), data, 0600); err != nil {
+		t.Fatalf("failed to write cache file: %v", err)
+	}
+}
+
+func validToken(startURL, region string) CachedToken {
+	return CachedToken{
+		AccessToken: "test-access-token",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		Region:      region,
+		StartURL:    startURL,
+	}
+}
+
+// TestLoadTokenForProfile_LegacyStartURLCache verifies legacy profiles (no
+// sso_session) still resolve via the start-url hash.
+func TestLoadTokenForProfile_LegacyStartURLCache(t *testing.T) {
+	cache := newTestTokenCache(t)
+	startURL := "https://legacy-org.awsapps.com/start"
+	region := "us-east-1"
+	writeCacheFile(t, cache, startURL, validToken(startURL, region))
+
+	profile := &TemplateProfile{
+		Name:        "legacy",
+		SSOStartURL: startURL,
+		SSORegion:   region,
+		IsSSO:       true,
+	}
+
+	token, err := cache.LoadTokenForTemplateProfile(profile)
+	if err != nil {
+		t.Fatalf("expected to load legacy token, got error: %v", err)
+	}
+	if token.AccessToken != "test-access-token" {
+		t.Fatalf("unexpected access token: %q", token.AccessToken)
+	}
+}
+
+// TestLoadTokenForProfile_ModernSessionCache reproduces T-1204: modern
+// sso_session profiles store the token under the SHA1 of the session name, not
+// the start URL. Before the fix this fails with "SSO token cache not found".
+func TestLoadTokenForProfile_ModernSessionCache(t *testing.T) {
+	cache := newTestTokenCache(t)
+	startURL := "https://modern-org.awsapps.com/start"
+	region := "us-east-1"
+	sessionName := "my-sso-session"
+
+	// AWS CLI writes the modern token keyed by the session name only.
+	writeCacheFile(t, cache, sessionName, validToken(startURL, region))
+
+	profile := &TemplateProfile{
+		Name:        "modern",
+		SSOStartURL: startURL,
+		SSORegion:   region,
+		SSOSession:  sessionName,
+		IsSSO:       true,
+	}
+
+	token, err := cache.LoadTokenForTemplateProfile(profile)
+	if err != nil {
+		t.Fatalf("expected to load modern session token, got error: %v", err)
+	}
+	if token.AccessToken != "test-access-token" {
+		t.Fatalf("unexpected access token: %q", token.AccessToken)
+	}
+}
+
+// TestLoadTokenForProfile_ModernFallsBackToStartURL verifies that when a modern
+// profile's session-name cache file is absent but a start-url cache file exists
+// (e.g. cache written by an older CLI), lookup still succeeds via fallback.
+func TestLoadTokenForProfile_ModernFallsBackToStartURL(t *testing.T) {
+	cache := newTestTokenCache(t)
+	startURL := "https://fallback-org.awsapps.com/start"
+	region := "us-east-1"
+	sessionName := "fallback-session"
+
+	// Only the legacy start-url file exists.
+	writeCacheFile(t, cache, startURL, validToken(startURL, region))
+
+	profile := &TemplateProfile{
+		Name:        "modern-fallback",
+		SSOStartURL: startURL,
+		SSORegion:   region,
+		SSOSession:  sessionName,
+		IsSSO:       true,
+	}
+
+	token, err := cache.LoadTokenForTemplateProfile(profile)
+	if err != nil {
+		t.Fatalf("expected fallback to start-url token, got error: %v", err)
+	}
+	if token.AccessToken != "test-access-token" {
+		t.Fatalf("unexpected access token: %q", token.AccessToken)
+	}
+}
+
+// TestLoadTokenForProfile_NotFound verifies a missing token returns an error.
+func TestLoadTokenForProfile_NotFound(t *testing.T) {
+	cache := newTestTokenCache(t)
+	profile := &TemplateProfile{
+		Name:        "missing",
+		SSOStartURL: "https://missing-org.awsapps.com/start",
+		SSORegion:   "us-east-1",
+		SSOSession:  "missing-session",
+		IsSSO:       true,
+	}
+
+	if _, err := cache.LoadTokenForTemplateProfile(profile); err == nil {
+		t.Fatal("expected error for missing token cache, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Modern AWS config profiles that use `sso_session` could fail with "SSO token cache not found" in `awstools sso generate-profiles` and role discovery, even after a successful `aws sso login --profile <profile>`.

## Root cause

`helpers/sso_token_cache.go:LoadTokenForProfile` always derived the cache filename from `SHA1(sso_start_url)`. The AWS CLI stores modern `sso_session` tokens under `SHA1(session name)`, so the lookup targeted a non-existent file. Both `helpers/role_discovery.go` call sites passed only `SSOStartURL`, dropping the `SSOSession` carried on the `TemplateProfile`.

## Fix

- Add `LoadTokenForTemplateProfile(*TemplateProfile)`: tries the session-name cache first for modern profiles, falls back to the start-url cache only when the session cache file is genuinely absent, and resolves legacy profiles via the start URL.
- Extract the shared lookup into `LoadTokenForKey`; keep `LoadTokenForProfile` as a backward-compatible wrapper.
- Both `role_discovery.go` call sites now pass the full template profile.

## Tests

New `helpers/sso_token_cache_test.go` covers legacy start-url, modern session-name, modern→start-url fallback, and not-found cases.

Red/green verified: with the session branch disabled, the modern test fails with the reported "SSO token cache not found" error; with the fix, all four pass. `go test ./...` passes.