### PR TITLE
Fix T-1413: vpc ip-finder drops duplicate private IP matches

### DIFF
--- a/cmd/vpcipfinder.go
+++ b/cmd/vpcipfinder.go
@@ -49,16 +49,24 @@ func findIPAddress(_ *cobra.Command, args []string) {
 	// Load AWS configuration
 	awsConfig := config.DefaultAwsConfig(*settings)
 
-	// Call helper function
-	result := helpers.FindIPAddressDetails(awsConfig.Ec2Client(), ipAddress)
+	// Call helper function. A single private IP can match more than one ENI
+	// (e.g. duplicate RFC1918 ranges across unrelated VPCs), so every match is
+	// returned and rendered.
+	results := helpers.FindIPAddressDetails(awsConfig.Ec2Client(), ipAddress)
 
 	// Format and output results
-	formatIPFinderOutput(result)
+	formatIPFinderOutput(results)
 }
 
-func formatIPFinderOutput(result helpers.IPFinderResult) {
-	if !result.Found {
-		fmt.Fprintf(os.Stderr, "IP address %s not found in any ENI in the current region\n", result.IPAddress)
+func formatIPFinderOutput(results []helpers.IPFinderResult) {
+	// The helper always returns at least one result. When nothing matched it is
+	// a single result with Found=false.
+	if len(results) == 0 || !results[0].Found {
+		ipAddress := ""
+		if len(results) > 0 {
+			ipAddress = results[0].IPAddress
+		}
+		fmt.Fprintf(os.Stderr, "IP address %s not found in any ENI in the current region\n", ipAddress)
 		fmt.Fprintf(os.Stderr, "\nTroubleshooting suggestions:\n")
 		fmt.Fprintf(os.Stderr, "  - Verify the IP address is correct\n")
 		fmt.Fprintf(os.Stderr, "  - Check if the IP is in a different AWS region using --region flag\n")
@@ -66,6 +74,18 @@ func formatIPFinderOutput(result helpers.IPFinderResult) {
 		fmt.Fprintf(os.Stderr, "  - Consider that the IP might be associated with a different AWS account\n")
 		return
 	}
+
+	if len(results) > 1 {
+		fmt.Fprintf(os.Stderr, "Note: IP address %s matched %d ENIs (duplicate private IPs across VPCs). Showing all matches.\n",
+			results[0].IPAddress, len(results))
+	}
+
+	for _, result := range results {
+		formatSingleIPFinderResult(result)
+	}
+}
+
+func formatSingleIPFinderResult(result helpers.IPFinderResult) {
 
 	keys := []string{fieldColumn, valueColumn}
 	output := format.OutputArray{

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"math"
 	"net"
-	"os"
 	"regexp"
 	"slices"
 	"sort"
@@ -2061,9 +2060,15 @@ func IsValidCIDR(cidr string) bool {
 	return err == nil
 }
 
-// FindIPAddressDetails searches for an IP address across ENIs and returns detailed information
-// Searches both primary and secondary IP addresses on all ENIs
-func FindIPAddressDetails(svc *ec2.Client, ipAddress string) IPFinderResult {
+// FindIPAddressDetails searches for an IP address across ENIs and returns
+// detailed information for every matching ENI. A single private IP can
+// legitimately appear on more than one ENI — duplicate RFC1918 ranges are
+// common across unrelated VPCs in the same account/region — so all matches are
+// returned rather than silently collapsing to the first one (T-1413).
+//
+// When no ENI matches, a single result with Found=false is returned so callers
+// can report the IP as not found. Searches both primary and secondary IPs.
+func FindIPAddressDetails(svc *ec2.Client, ipAddress string) []IPFinderResult {
 	// Create filter for IP address search
 	// Note: addresses.private-ip-address filter includes both primary and secondary IPs
 	filters := []types.Filter{
@@ -2077,43 +2082,47 @@ func FindIPAddressDetails(svc *ec2.Client, ipAddress string) IPFinderResult {
 	enis := searchENIsByIP(svc, filters)
 
 	if len(enis) == 0 {
-		return IPFinderResult{
+		return []IPFinderResult{{
 			IPAddress: ipAddress,
 			Found:     false,
-		}
+		}}
 	}
 
-	// Handle multiple ENIs with the same IP (rare but possible)
-	if len(enis) > 1 {
-		// Log warning about multiple matches - following awstools pattern of using panic for warnings
-		// This is a rare scenario but can happen in some edge cases
-		fmt.Fprintf(os.Stderr, "Warning: Multiple ENIs found with IP %s. Returning details for first ENI (%s)\n",
-			ipAddress, aws.ToString(enis[0].NetworkInterfaceId))
+	// Build a base result per matching ENI, then enrich each with resource
+	// details. A shared cache covering every matching ENI keeps the lookups
+	// efficient even when the IP is reused across multiple VPCs.
+	results := buildBaseIPFinderResults(ipAddress, enis)
+	cache := NewENILookupCache(svc, enis)
+
+	for i := range results {
+		eni := *results[i].ENI
+		results[i].ResourceType = getENIUsageTypeOptimized(eni, cache)
+		results[i].ResourceName, results[i].ResourceID = getResourceNameAndID(eni, cache)
+		results[i].VPC = getVPCInfo(svc, aws.ToString(eni.VpcId))
+		results[i].Subnet = getSubnetInfo(svc, aws.ToString(eni.SubnetId))
+		results[i].SecurityGroups = getSecurityGroupInfo(svc, eni.Groups)
+		results[i].RouteTable = getRouteTableInfo(svc, aws.ToString(eni.SubnetId), aws.ToString(eni.VpcId))
 	}
 
-	// Process the first matching ENI
-	eni := enis[0]
+	return results
+}
 
-	// Create ENI cache for efficient resource lookup
-	cache := NewENILookupCache(svc, []types.NetworkInterface{eni})
-
-	// Build detailed result
-	result := IPFinderResult{
-		IPAddress:     ipAddress,
-		ENI:           &eni,
-		Found:         true,
-		IsSecondaryIP: isSecondaryIP(eni, ipAddress),
+// buildBaseIPFinderResults creates one IPFinderResult per matching ENI,
+// populating only the fields that can be derived from the ENI itself (IP, ENI
+// pointer, Found, IsSecondaryIP). Client-dependent fields are filled in by the
+// caller. Extracted so the multi-match collection can be tested without AWS.
+func buildBaseIPFinderResults(ipAddress string, enis []types.NetworkInterface) []IPFinderResult {
+	results := make([]IPFinderResult, 0, len(enis))
+	for i := range enis {
+		eni := enis[i]
+		results = append(results, IPFinderResult{
+			IPAddress:     ipAddress,
+			ENI:           &eni,
+			Found:         true,
+			IsSecondaryIP: isSecondaryIP(eni, ipAddress),
+		})
 	}
-
-	// Populate resource information
-	result.ResourceType = getENIUsageTypeOptimized(eni, cache)
-	result.ResourceName, result.ResourceID = getResourceNameAndID(eni, cache)
-	result.VPC = getVPCInfo(svc, aws.ToString(eni.VpcId))
-	result.Subnet = getSubnetInfo(svc, aws.ToString(eni.SubnetId))
-	result.SecurityGroups = getSecurityGroupInfo(svc, eni.Groups)
-	result.RouteTable = getRouteTableInfo(svc, aws.ToString(eni.SubnetId), aws.ToString(eni.VpcId))
-
-	return result
+	return results
 }
 
 // handleAWSAPIError provides better error messages for common AWS API errors

--- a/helpers/ec2_ipfinder_pagination_test.go
+++ b/helpers/ec2_ipfinder_pagination_test.go
@@ -158,3 +158,78 @@ func TestSearchENIsByIP_NoMatches(t *testing.T) {
 		t.Errorf("DescribeNetworkInterfaces called %d times, want 1", mock.callCount)
 	}
 }
+
+// TestBuildBaseIPFinderResults_DuplicateIPAcrossVPCs is the regression test for
+// T-1413. Two ENIs in different VPCs share the same private IP — a common
+// scenario because RFC1918 ranges are reused across unrelated VPCs. Before the
+// fix FindIPAddressDetails logged a warning and returned only enis[0], hiding
+// the second match. The fix returns one result per matching ENI.
+func TestBuildBaseIPFinderResults_DuplicateIPAcrossVPCs(t *testing.T) {
+	ip := "10.0.1.100"
+	enis := []types.NetworkInterface{
+		{
+			NetworkInterfaceId: aws.String("eni-aaaa"),
+			VpcId:              aws.String("vpc-aaaa"),
+			SubnetId:           aws.String("subnet-aaaa"),
+			PrivateIpAddress:   aws.String(ip),
+			PrivateIpAddresses: []types.NetworkInterfacePrivateIpAddress{
+				{PrivateIpAddress: aws.String(ip), Primary: aws.Bool(true)},
+			},
+		},
+		{
+			NetworkInterfaceId: aws.String("eni-bbbb"),
+			VpcId:              aws.String("vpc-bbbb"),
+			SubnetId:           aws.String("subnet-bbbb"),
+			PrivateIpAddress:   aws.String("10.0.2.50"),
+			PrivateIpAddresses: []types.NetworkInterfacePrivateIpAddress{
+				{PrivateIpAddress: aws.String("10.0.2.50"), Primary: aws.Bool(true)},
+				{PrivateIpAddress: aws.String(ip), Primary: aws.Bool(false)},
+			},
+		},
+	}
+
+	results := buildBaseIPFinderResults(ip, enis)
+
+	if len(results) != 2 {
+		t.Fatalf("buildBaseIPFinderResults() returned %d results, want 2 (duplicate IP across VPCs must not be dropped)", len(results))
+	}
+
+	// Every result must be marked Found and carry its own ENI/IP.
+	for i, r := range results {
+		if !r.Found {
+			t.Errorf("results[%d].Found = false, want true", i)
+		}
+		if r.IPAddress != ip {
+			t.Errorf("results[%d].IPAddress = %s, want %s", i, r.IPAddress, ip)
+		}
+		if r.ENI == nil {
+			t.Fatalf("results[%d].ENI is nil", i)
+		}
+	}
+
+	// The two results must reference distinct ENIs in distinct VPCs, proving the
+	// second match was preserved rather than overwritten by the first.
+	if aws.ToString(results[0].ENI.NetworkInterfaceId) == aws.ToString(results[1].ENI.NetworkInterfaceId) {
+		t.Errorf("both results reference the same ENI %s", aws.ToString(results[0].ENI.NetworkInterfaceId))
+	}
+	if aws.ToString(results[0].ENI.VpcId) == aws.ToString(results[1].ENI.VpcId) {
+		t.Errorf("both results reference the same VPC %s", aws.ToString(results[0].ENI.VpcId))
+	}
+
+	// Primary on first ENI, secondary on second ENI.
+	if results[0].IsSecondaryIP {
+		t.Errorf("results[0].IsSecondaryIP = true, want false (primary IP)")
+	}
+	if !results[1].IsSecondaryIP {
+		t.Errorf("results[1].IsSecondaryIP = false, want true (secondary IP)")
+	}
+}
+
+// TestBuildBaseIPFinderResults_NoMatches verifies an empty ENI list yields no
+// results (the not-found case is handled separately by FindIPAddressDetails).
+func TestBuildBaseIPFinderResults_NoMatches(t *testing.T) {
+	results := buildBaseIPFinderResults("10.0.1.100", nil)
+	if len(results) != 0 {
+		t.Errorf("buildBaseIPFinderResults() returned %d results, want 0", len(results))
+	}
+}


### PR DESCRIPTION
## Summary

`helpers/ec2.go:FindIPAddressDetails` searched all ENIs for a private IP but, when multiple ENIs matched, logged a warning and returned details for only `enis[0]`. Duplicate RFC1918 addresses are common across unrelated VPCs in the same account/region, so `awstools vpc ip-finder <ip>` could hide valid matches and report a misleading single resource.

## Root cause

The function detected `len(enis) > 1`, printed a warning to stderr, then processed only the first ENI. The single-value return type (`IPFinderResult`) could not express more than one match.

## Fix

- `FindIPAddressDetails` now returns `[]IPFinderResult` — one per matching ENI. Not-found returns a single `Found:false` result.
- Extracted `buildBaseIPFinderResults` (no AWS client) so the multi-match collection is unit-testable; each result is then enriched using a single shared `ENILookupCache` over all matching ENIs.
- `cmd/vpcipfinder.go` iterates over all results and prints a stderr note when more than one ENI matches. Removed the warning-and-drop behaviour and the now-unused `os` import in `ec2.go`.

## Tests

Added `TestBuildBaseIPFinderResults_DuplicateIPAcrossVPCs` (two ENIs, same private IP, different VPCs — both returned) and `TestBuildBaseIPFinderResults_NoMatches`. The regression test failed to compile before the fix and passes after.

- `go test ./...` passes
- `go build ./...` passes
- No new lint issues (goconst count unchanged before/after)