### PR TITLE
Fix T-1145: Disable Unsupported dot/drawio Output For vpc enis

### DIFF
--- a/cmd/vpcenis.go
+++ b/cmd/vpcenis.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ArjenSchwarz/awstools/config"
 	"github.com/ArjenSchwarz/awstools/helpers"
@@ -12,16 +13,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// peeringsCmd represents the peerings command
+// enisCmd represents the enis command
 var enisCmd = &cobra.Command{
 	Use:   "enis",
 	Short: "Get ENIs overview",
-	Long: `Get an overview of ENIs in a VPC. For a graphical option consider using
-	the dot or drawio output formats.
+	Long: `Get an overview of ENIs in a VPC.
 
-	awstools vpc peerings -o dot | dot -Tpng  -o peerings.png
-	awstools vpc peerings -o drawio | pbcopy`,
-	Run: enis,
+	Supported output formats are json, csv, table, and html. The graph formats
+	(dot and drawio) are not supported for this command because ENIs are leaf
+	resources without a meaningful from/to relationship to diagram.`,
+	RunE: enis,
 }
 
 var vpceenisSplit bool
@@ -31,7 +32,24 @@ func init() {
 	enisCmd.Flags().BoolVar(&vpceenisSplit, "split", false, "Split the result by subnet")
 }
 
-func enis(_ *cobra.Command, _ []string) {
+// enisGraphFormatError reports whether the requested output format is a graph
+// format the enis command cannot produce. ENIs have no from/to relationship to
+// diagram, so dot and drawio are rejected with a clear error instead of letting
+// go-output log.Fatal (non-split) or silently emit nothing (split). The
+// comparison is case-insensitive to match the format normalisation in config.
+func enisGraphFormatError(format string) error {
+	switch strings.ToLower(format) {
+	case "dot", "drawio":
+		return fmt.Errorf("the %s output format is not supported by 'vpc enis'; supported formats are json, csv, table, and html", strings.ToLower(format))
+	default:
+		return nil
+	}
+}
+
+func enis(_ *cobra.Command, _ []string) error {
+	if err := enisGraphFormatError(settings.GetOutputFormat()); err != nil {
+		return err
+	}
 	awsConfig := config.DefaultAwsConfig(*settings)
 	ec2Client := awsConfig.Ec2Client()
 	names := helpers.GetAllEC2ResourceNames(ec2Client, awsConfig.DirectConnectClient())
@@ -48,6 +66,7 @@ func enis(_ *cobra.Command, _ []string) {
 		printENIs(interfaces, names, resultTitle, false, ec2Client)
 	}
 	output.Write()
+	return nil
 }
 
 func printENIs(interfaces []types.NetworkInterface, names map[string]string, resultTitle string, split bool, svc *ec2.Client) {

--- a/cmd/vpcenis_test.go
+++ b/cmd/vpcenis_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
+// TestEnisGraphFormatError_T1145 verifies that the vpc enis command rejects the
+// graph output formats it cannot produce. ENIs are leaf resources with no
+// from/to relationship, so dot/drawio cannot generate a meaningful diagram.
+//
+// Before the T-1145 fix the command advertised dot/drawio in its help but never
+// configured DrawIOHeader or FromToColumns. go-output v1.4.0 then either called
+// log.Fatal (non-split path) or silently produced nothing (split path). This
+// test pins the expectation that those formats now yield a clear, returnable
+// error rather than a fatal exit or empty output.
+func TestEnisGraphFormatError_T1145(t *testing.T) {
+	rejected := []string{"dot", "drawio", "DOT", "DrawIO"}
+	for _, format := range rejected {
+		if err := enisGraphFormatError(format); err == nil {
+			t.Errorf("format %q: expected an error for unsupported graph format, got nil", format)
+		}
+	}
+
+	allowed := []string{"json", "csv", "table", "html", "mermaid", ""}
+	for _, format := range allowed {
+		if err := enisGraphFormatError(format); err != nil {
+			t.Errorf("format %q: expected no error for supported format, got %v", format, err)
+		}
+	}
+}
+
 // eniAttachmentLookupClient is the minimum EC2 API surface used by
 // getAttachment (below) to resolve ENI attachment metadata via the paginated
 // helpers. Kept in the test file after T-727 moved production code to use


### PR DESCRIPTION
## Bug

`awstools vpc enis` advertised the `dot` and `drawio` output formats in its help, but the command never configured `OutputArray.Settings.DrawIOHeader` or `FromToColumns`. In go-output v1.4.0 this means:

- `vpc enis -o dot` / `-o drawio` → `OutputArray.Write()` calls `log.Fatal` (output.go:110-116).
- `vpc enis --split -o drawio` → the split path uses `AddToBuffer()`, whose drawio branch is commented out, so it silently produces nothing.

Ticket: T-1145.

## Root cause

The help text was copied from `vpc peerings` (a graphable command — the example lines even referenced `awstools vpc peerings`), but `vpc enis` never had the corresponding graph configuration. ENIs are leaf resources with no from/to relationship, so a meaningful diagram cannot be produced.

## Fix

Chose to remove/disable graph support rather than implement a graph (no meaningful from/to relationship for ENIs):

- Rewrote the command `Long` help to list the actually supported formats (json, csv, table, html) and explain why graph formats are not supported.
- Added `enisGraphFormatError(format string) error`, a pure, testable guard that returns a clear error for `dot`/`drawio` (case-insensitive).
- Switched the command from `Run` to `RunE` and call the guard first, so an unsupported format returns a clean error instead of a library `log.Fatal` or silent empty output.

Scoped to the graph-advertising/guarding concern only — does not touch the buffer/`--file` plumbing owned by T-1294 in the same file.

## Testing

- New regression test `TestEnisGraphFormatError_T1145` in `cmd/vpcenis_test.go` (fails to compile before the fix, passes after).
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass (exit 0).
- Pre-existing `goconst` lint warnings across the repo are unrelated to this change.