### PR TITLE
Fix T-1354: Profile Conflict Detection Ignores SSO Start URL

### DIFF
--- a/helpers/profile_conflict_detector.go
+++ b/helpers/profile_conflict_detector.go
@@ -319,15 +319,18 @@ func (pcd *ProfileConflictDetector) AnalyzeRole(role DiscoveredRole) (*ProfileCo
 // - Same Role: Existing "prod-admin" profile points to same role as discovered "production-AdministratorAccess"
 // - Same Name: Existing "prod-admin" profile points to different role than discovered "prod-admin"
 func (pcd *ProfileConflictDetector) ClassifyConflict(existingProfiles []Profile, proposedName string, role DiscoveredRole) ConflictType {
-	// Check if any existing profile matches the same role (SSO configuration)
+	// Check if any existing profile matches the same role (SSO configuration).
+	// The comparison includes the SSO start URL (and region) when the discovered
+	// role carries them, so a profile belonging to a different SSO start URL with
+	// the same account ID and role name is not misclassified as a same-role conflict.
 	for _, profile := range existingProfiles {
-		matches, err := pcd.configFile.MatchesRole(profile, role.AccountID, role.RoleName, "")
+		resolvedConfig, err := pcd.configFile.ResolveProfileSSOConfig(profile)
 		if err != nil {
 			pcd.logger.Printf("Warning: failed to match profile %s against role: %v", profile.Name, err)
 			continue
 		}
 
-		if matches {
+		if resolvedConfigMatchesRole(resolvedConfig, role) {
 			return ConflictSameRole
 		}
 	}
@@ -379,6 +382,26 @@ func (pcd *ProfileConflictDetector) GenerateConflictSummary(conflicts []ProfileC
 	return summary.String()
 }
 
+// resolvedConfigMatchesRole reports whether a resolved SSO config refers to the
+// same role as the discovered role. It always compares account ID and role name,
+// and additionally compares the SSO start URL (and SSO region) when the discovered
+// role carries them. This prevents profiles belonging to a different SSO start URL
+// from being treated as the same role when they happen to share an account ID and
+// role name. When the role has no SSO start URL (legacy/unspecified), only account
+// ID and role name are compared, preserving the previous behaviour.
+func resolvedConfigMatchesRole(resolvedConfig *ResolvedSSOConfig, role DiscoveredRole) bool {
+	if resolvedConfig.AccountID != role.AccountID || resolvedConfig.RoleName != role.RoleName {
+		return false
+	}
+	if role.SSOStartURL != "" && resolvedConfig.StartURL != role.SSOStartURL {
+		return false
+	}
+	if role.SSORegion != "" && resolvedConfig.Region != role.SSORegion {
+		return false
+	}
+	return true
+}
+
 // findMatchingProfiles finds existing profiles that match the discovered role's SSO configuration
 func (pcd *ProfileConflictDetector) findMatchingProfiles(role DiscoveredRole) ([]Profile, error) {
 	// Use profile index for efficient lookup if available
@@ -390,7 +413,7 @@ func (pcd *ProfileConflictDetector) findMatchingProfiles(role DiscoveredRole) ([
 		for _, profile := range accountProfiles {
 			// Use cached resolved SSO config
 			if resolvedConfig, exists := pcd.resolvedSSOConfigs[profile.Name]; exists {
-				if resolvedConfig.AccountID == role.AccountID && resolvedConfig.RoleName == role.RoleName {
+				if resolvedConfigMatchesRole(resolvedConfig, role) {
 					matchingProfiles = append(matchingProfiles, profile)
 				}
 			}
@@ -409,7 +432,7 @@ func (pcd *ProfileConflictDetector) findMatchingProfiles(role DiscoveredRole) ([
 
 		// Use cached resolved SSO config
 		if resolvedConfig, exists := pcd.resolvedSSOConfigs[profileName]; exists {
-			if resolvedConfig.AccountID == role.AccountID && resolvedConfig.RoleName == role.RoleName {
+			if resolvedConfigMatchesRole(resolvedConfig, role) {
 				matchingProfiles = append(matchingProfiles, profile)
 			}
 		}

--- a/helpers/profile_conflict_detector_test.go
+++ b/helpers/profile_conflict_detector_test.go
@@ -398,3 +398,90 @@ func TestProfileConflictDetector_DetectConflicts_MultipleConflicts(t *testing.T)
 	assert.Equal(t, ConflictSameName, conflicts[1].ConflictType)
 	assert.Equal(t, "production-ReadOnlyAccess", conflicts[1].ProposedName)
 }
+
+// TestProfileConflictDetector_DifferentStartURL_NoSameRoleConflict is the
+// regression test for T-1354. An AWS config may contain profiles for multiple
+// SSO start URLs that expose the same account ID and role name. When generating
+// profiles from a template tied to one SSO start URL, a profile belonging to a
+// DIFFERENT SSO start URL must NOT be treated as a same-role conflict.
+//
+// Expected: no conflict (the discovered role and the existing profile point at
+// different SSO instances even though account/role match).
+// Buggy behaviour: detected as a ConflictSameRole because only account ID and
+// role name were compared.
+func TestProfileConflictDetector_DifferentStartURL_NoSameRoleConflict(t *testing.T) {
+	configFile := &AWSConfigFile{
+		Profiles: map[string]Profile{
+			// Profile belongs to a different SSO start URL than the discovered role.
+			"other-sso-profile": {
+				Name:         "other-sso-profile",
+				SSOAccountID: "123456789012",
+				SSORoleName:  "PowerUserAccess",
+				SSOStartURL:  "https://other.awsapps.com/start",
+				SSORegion:    "us-east-1",
+			},
+		},
+		Sessions: make(map[string]SSOSession),
+	}
+
+	namingPattern, err := NewNamingPattern("{account_name}-{role_name}")
+	require.NoError(t, err)
+
+	detector := NewProfileConflictDetector(configFile, namingPattern)
+
+	roles := []DiscoveredRole{
+		{
+			AccountID:         "123456789012",
+			AccountName:       "production",
+			RoleName:          "PowerUserAccess",
+			PermissionSetName: "PowerUserAccess",
+			// Discovered via a template tied to a different SSO start URL.
+			SSOStartURL: "https://example.awsapps.com/start",
+			SSORegion:   "us-east-1",
+		},
+	}
+
+	conflicts, err := detector.DetectConflicts(roles)
+	assert.NoError(t, err)
+	assert.Empty(t, conflicts, "profile from a different SSO start URL must not be a same-role conflict")
+}
+
+// TestProfileConflictDetector_SameStartURL_SameRoleConflict confirms that when
+// the discovered role's SSO start URL matches the existing profile, the same-role
+// conflict is still detected (the fix must not break the positive case).
+func TestProfileConflictDetector_SameStartURL_SameRoleConflict(t *testing.T) {
+	configFile := &AWSConfigFile{
+		Profiles: map[string]Profile{
+			"existing-profile": {
+				Name:         "existing-profile",
+				SSOAccountID: "123456789012",
+				SSORoleName:  "PowerUserAccess",
+				SSOStartURL:  "https://example.awsapps.com/start",
+				SSORegion:    "us-east-1",
+			},
+		},
+		Sessions: make(map[string]SSOSession),
+	}
+
+	namingPattern, err := NewNamingPattern("{account_name}-{role_name}")
+	require.NoError(t, err)
+
+	detector := NewProfileConflictDetector(configFile, namingPattern)
+
+	roles := []DiscoveredRole{
+		{
+			AccountID:         "123456789012",
+			AccountName:       "production",
+			RoleName:          "PowerUserAccess",
+			PermissionSetName: "PowerUserAccess",
+			SSOStartURL:       "https://example.awsapps.com/start",
+			SSORegion:         "us-east-1",
+		},
+	}
+
+	conflicts, err := detector.DetectConflicts(roles)
+	assert.NoError(t, err)
+	require.Len(t, conflicts, 1)
+	assert.Equal(t, ConflictSameRole, conflicts[0].ConflictType)
+	assert.Equal(t, "existing-profile", conflicts[0].ExistingProfiles[0].Name)
+}

--- a/helpers/profile_generator_types.go
+++ b/helpers/profile_generator_types.go
@@ -240,6 +240,13 @@ type DiscoveredRole struct {
 	PermissionSetName string `json:"permission_set_name" yaml:"permission_set_name"`
 	PermissionSetArn  string `json:"permission_set_arn,omitempty" yaml:"permission_set_arn,omitempty"`
 	RoleName          string `json:"role_name" yaml:"role_name"`
+	// SSOStartURL and SSORegion identify the SSO instance the role was discovered
+	// through (carried from the template profile's resolved SSO config). They allow
+	// conflict detection to distinguish profiles that share an account ID and role
+	// name but belong to different SSO start URLs. They may be empty for roles built
+	// without SSO context, in which case start-URL comparison is skipped.
+	SSOStartURL string `json:"sso_start_url,omitempty" yaml:"sso_start_url,omitempty"`
+	SSORegion   string `json:"sso_region,omitempty" yaml:"sso_region,omitempty"`
 }
 
 // Validate checks if the discovered role is valid and contains all required information.

--- a/helpers/role_discovery.go
+++ b/helpers/role_discovery.go
@@ -216,6 +216,10 @@ func (rd *RoleDiscovery) getRolesForAccount(ctx context.Context, token *CachedTo
 				AccountAlias:      accountAlias,
 				PermissionSetName: roleName,
 				RoleName:          roleName,
+				// Carry the SSO instance the role was discovered through so conflict
+				// detection can distinguish profiles for different SSO start URLs.
+				SSOStartURL: token.StartURL,
+				SSORegion:   token.Region,
 			}
 
 			if err := role.Validate(); err != nil {


### PR DESCRIPTION
## Summary

Profile conflict detection matched discovered SSO roles against existing AWS CLI profiles using only account ID and role name. When an AWS config contains profiles for multiple SSO start URLs that expose the same account ID and role name, generating profiles from one template could misclassify the other SSO instance's profile as a same-role conflict — skipping generation or replacing/renaming the wrong profile.

## Root Cause

The detector had no knowledge of which SSO instance the discovered roles came from. Both `findMatchingProfiles` paths filtered only on `AccountID`/`RoleName`, and `ClassifyConflict` called `MatchesRole(..., "")` with an empty start URL, bypassing the existing start-URL guard.

## Fix

- Added `SSOStartURL` and `SSORegion` to `DiscoveredRole`, populated from the cached SSO token in `role_discovery.go`.
- Added `resolvedConfigMatchesRole` helper comparing account ID + role name, plus SSO start URL/region when the role carries them. Used in both `findMatchingProfiles` paths and `ClassifyConflict`.
- Comparison is conditional on the role having a start URL, so legacy callers/tests keep account+role behaviour (backward compatible).

## Tests

- `TestProfileConflictDetector_DifferentStartURL_NoSameRoleConflict` — different start URL must not be a same-role conflict (fails before fix).
- `TestProfileConflictDetector_SameStartURL_SameRoleConflict` — matching start URL still reports the conflict.

`go test ./...` passes (exit 0).