### PR TITLE
chore: extract repeated strings into constants to satisfy goconst lint

### DIFF
--- a/cmd/appmeshshowmesh.go
+++ b/cmd/appmeshshowmesh.go
@@ -33,9 +33,9 @@ func showmesh(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	svc := awsConfig.AppmeshClient()
 	nodes := helpers.GetAllAppMeshNodeConnections(meshname, svc)
-	keys := []string{"Name", "Endpoints"}
+	keys := []string{nameColumn, "Endpoints"}
 	if settings.IsDrawIO() {
-		keys = append(keys, "Image")
+		keys = append(keys, imageColumn)
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
@@ -44,14 +44,14 @@ func showmesh(_ *cobra.Command, _ []string) {
 		output.Settings.DrawIOHeader = createAppmeshShowmeshDrawIOHeader()
 	}
 	if output.Settings.NeedsFromToColumns() {
-		output.Settings.AddFromToColumns("Name", "Endpoints")
+		output.Settings.AddFromToColumns(nameColumn, "Endpoints")
 	}
 
 	for _, node := range nodes {
 		content := make(map[string]any)
-		content["Name"] = node.VirtualNodeName
+		content[nameColumn] = node.VirtualNodeName
 		if settings.IsDrawIO() {
-			content["Image"] = drawio.AWSShape("Containers", "Container")
+			content[imageColumn] = drawio.AWSShape("Containers", "Container")
 		}
 		endpoints := append([]string{}, node.BackendNodes...)
 		content["Endpoints"] = endpoints
@@ -62,11 +62,11 @@ func showmesh(_ *cobra.Command, _ []string) {
 }
 
 func createAppmeshShowmeshDrawIOHeader() drawio.Header {
-	drawioheader := drawio.NewHeader("%Name%", "%Image%", "Image")
+	drawioheader := drawio.NewHeader("%Name%", "%Image%", imageColumn)
 	drawioheader.SetHeightAndWidth("78", "78")
 	connection := drawio.NewConnection()
 	connection.From = "Endpoints"
-	connection.To = "Name"
+	connection.To = nameColumn
 	connection.Invert = false
 	connection.Label = "Calls"
 	drawioheader.AddConnection(connection)

--- a/cmd/cfnresources.go
+++ b/cmd/cfnresources.go
@@ -74,7 +74,7 @@ func listResources(_ *cobra.Command, _ []string) {
 	for i := range unparsedResources {
 		resources[i] = <-c
 	}
-	keys := []string{"ResourceID", "Type", "Stack", "Name"}
+	keys := []string{"ResourceID", typeColumn, stackColumn, nameColumn}
 	if settings.IsVerbose() {
 		keys = append(keys, "Status")
 		keys = append(keys, "LogicalName")
@@ -84,9 +84,9 @@ func listResources(_ *cobra.Command, _ []string) {
 	for _, resource := range resources {
 		content := make(map[string]any)
 		content["ResourceID"] = resource.ResourceID
-		content["Type"] = resource.Type
-		content["Stack"] = resource.Stack
-		content["Name"] = resource.ResourceName
+		content[typeColumn] = resource.Type
+		content[stackColumn] = resource.Stack
+		content[nameColumn] = resource.ResourceName
 		if settings.IsVerbose() {
 			content["Status"] = resource.Status
 			content["LogicalName"] = resource.LogicalName

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -5,6 +5,30 @@ const (
 	nameColumn          = "Name"
 	childrenColumn      = "Children"
 	permissionSetColumn = "PermissionSet"
+	accountColumn       = "Account"
+	accountIDColumn     = "AccountID"
+	attachmentColumn    = "Attachment"
+	cidrColumn          = "CIDR"
+	descriptionColumn   = "Description"
+	destinationsColumn  = "Destinations"
+	drawIOIDColumn      = "DrawIOID"
+	fieldColumn         = "Field"
+	imageColumn         = "Image"
+	routeTableColumn    = "Route Table"
+	routesColumn        = "Routes"
+	subnetColumn        = "Subnet"
+	typeColumn          = "Type"
+	vpcColumn           = "VPC"
+	stackColumn         = "Stack"
+	exportColumn        = "Export"
+	valueColumn         = "Value"
+	targetGatewayColumn = "TargetGateway"
+	importedColumn      = "Imported"
+)
+
+// Common literal values used across commands
+const (
+	s3BucketARNDescription = "ARN of the S3 bucket"
 )
 
 // Resource type constants

--- a/cmd/demotables.go
+++ b/cmd/demotables.go
@@ -43,46 +43,46 @@ func init() {
 }
 
 func demoTables(_ *cobra.Command, _ []string) {
-	keys := []string{"Export", "Description", "Stack", "Value", "Imported"}
+	keys := []string{exportColumn, descriptionColumn, stackColumn, valueColumn, importedColumn}
 	title := "CloudFormation Export values demo"
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = title
-	output.Settings.SortKey = "Export"
+	output.Settings.SortKey = exportColumn
 
 	value1 := format.OutputHolder{
 		Contents: map[string]any{
-			"Export":      "awesome-stack-dev-s3-arn",
-			"Value":       "arn:aws:s3:::fog-awesome-stack-dev",
-			"Description": "ARN of the S3 bucket",
-			"Stack":       "awesome-stack-dev",
-			"Imported":    true,
+			exportColumn:      "awesome-stack-dev-s3-arn",
+			valueColumn:       "arn:aws:s3:::fog-awesome-stack-dev",
+			descriptionColumn: s3BucketARNDescription,
+			stackColumn:       "awesome-stack-dev",
+			importedColumn:    true,
 		},
 	}
 	value2 := format.OutputHolder{
 		Contents: map[string]any{
-			"Export":      "awesome-stack-test-s3-arn",
-			"Value":       "arn:aws:s3:::fog-awesome-stack-test",
-			"Description": "ARN of the S3 bucket",
-			"Stack":       "awesome-stack-test",
-			"Imported":    true,
+			exportColumn:      "awesome-stack-test-s3-arn",
+			valueColumn:       "arn:aws:s3:::fog-awesome-stack-test",
+			descriptionColumn: s3BucketARNDescription,
+			stackColumn:       "awesome-stack-test",
+			importedColumn:    true,
 		},
 	}
 	value3 := format.OutputHolder{
 		Contents: map[string]any{
-			"Export":      "awesome-stack-prod-s3-arn",
-			"Value":       "arn:aws:s3:::fog-awesome-stack-prod",
-			"Description": "ARN of the S3 bucket",
-			"Stack":       "awesome-stack-prod",
-			"Imported":    true,
+			exportColumn:      "awesome-stack-prod-s3-arn",
+			valueColumn:       "arn:aws:s3:::fog-awesome-stack-prod",
+			descriptionColumn: s3BucketARNDescription,
+			stackColumn:       "awesome-stack-prod",
+			importedColumn:    true,
 		},
 	}
 	value4 := format.OutputHolder{
 		Contents: map[string]any{
-			"Export":      "demo-s3-bucket",
-			"Value":       "fog-demo-bucket",
-			"Description": "The S3 bucket used for demos but has an exceptionally long description so it can show a multi-line example",
-			"Stack":       "demo-resources",
-			"Imported":    true,
+			exportColumn:      "demo-s3-bucket",
+			valueColumn:       "fog-demo-bucket",
+			descriptionColumn: "The S3 bucket used for demos but has an exceptionally long description so it can show a multi-line example",
+			stackColumn:       "demo-resources",
+			importedColumn:    true,
 		},
 	}
 	output.AddHolder(value1)

--- a/cmd/iamrolelist.go
+++ b/cmd/iamrolelist.go
@@ -38,9 +38,9 @@ func iamrolelist(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "IAM Role overview for account " + getName(helpers.GetAccountID(awsConfig.StsClient()))
 	roles, policies := helpers.GetRolesAndPolicies(settings.IsVerbose(), awsConfig.IamClient())
-	keys := []string{nameColumn, "Type", "AssumedFrom", "Policies", "Roles"}
+	keys := []string{nameColumn, typeColumn, "AssumedFrom", "Policies", "Roles"}
 	if settings.IsDrawIO() {
-		keys = append(keys, "Image")
+		keys = append(keys, imageColumn)
 		keys = append(keys, "DrawioID")
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
@@ -55,11 +55,11 @@ func iamrolelist(_ *cobra.Command, _ []string) {
 		content := make(map[string]any)
 		content[nameColumn] = role.Name
 		content["AssumedFrom"] = role.CanBeAssumedFrom()
-		content["Type"] = role.Type
+		content[typeColumn] = role.Type
 		content["Policies"] = role.GetPolicyNames()
 		if settings.IsDrawIO() {
 			content["DrawioID"] = role.ID
-			content["Image"] = drawio.AWSShape("Security Identity Compliance", "Role")
+			content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Role")
 		}
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
@@ -69,9 +69,9 @@ func iamrolelist(_ *cobra.Command, _ []string) {
 		content[nameColumn] = policyname
 		if settings.IsDrawIO() {
 			content["DrawioID"] = policyname
-			content["Image"] = drawio.AWSShape("Security Identity Compliance", "Permissions")
+			content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Permissions")
 		}
-		content["Type"] = policy.Type
+		content[typeColumn] = policy.Type
 		content["Roles"] = policy.GetRoleNames()
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)

--- a/cmd/iamuserlist.go
+++ b/cmd/iamuserlist.go
@@ -36,9 +36,9 @@ func detailUsers(_ *cobra.Command, _ []string) {
 	for _, group := range grouplist {
 		objectlist = append(objectlist, group)
 	}
-	keys := []string{nameColumn, "Type", "Groups", "Users", "PolicyNames", "InheritedPolicyNames", "Console", "API"}
+	keys := []string{nameColumn, typeColumn, "Groups", "Users", "PolicyNames", "InheritedPolicyNames", "Console", "API"}
 	if settings.IsDrawIO() {
-		keys = append(keys, "Image")
+		keys = append(keys, imageColumn)
 		keys = append(keys, "DrawioID")
 		if settings.IsVerbose() {
 			keys = append(keys, "AttachedToGroups")
@@ -57,7 +57,7 @@ func detailUsers(_ *cobra.Command, _ []string) {
 	for _, object := range objectlist {
 		content := make(map[string]any)
 		content[nameColumn] = object.GetName()
-		content["Type"] = object.GetObjectType()
+		content[typeColumn] = object.GetObjectType()
 		if user, ok := object.(helpers.IAMUser); ok {
 			if user.HasUsedPassword() {
 				content["Console"] = user.GetLastPasswordDate().String()
@@ -90,9 +90,9 @@ func detailUsers(_ *cobra.Command, _ []string) {
 
 		if settings.IsDrawIO() {
 			if object.GetObjectType() == "User" {
-				content["Image"] = drawio.AWSShape("General Resources", "User")
+				content[imageColumn] = drawio.AWSShape("General Resources", "User")
 			} else {
-				content["Image"] = drawio.AWSShape("General Resources", "Users")
+				content[imageColumn] = drawio.AWSShape("General Resources", "Users")
 			}
 			content["DrawioID"] = object.GetID()
 		}
@@ -103,9 +103,9 @@ func detailUsers(_ *cobra.Command, _ []string) {
 	for _, policy := range policylist {
 		content := make(map[string]any)
 		content[nameColumn] = policy.Name
-		content["Type"] = "Policy"
+		content[typeColumn] = "Policy"
 		if settings.IsDrawIO() {
-			content["Image"] = drawio.AWSShape("Security Identity Compliance", "Permissions")
+			content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Permissions")
 			content["AttachedToUsers"] = policy.Users
 			content["AttachedToGroups"] = policy.Groups
 			content["DrawioID"] = createID("Policy" + policy.Name)

--- a/cmd/organizationsstructure.go
+++ b/cmd/organizationsstructure.go
@@ -36,9 +36,9 @@ func orgstructure(_ *cobra.Command, _ []string) {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	keys := []string{"Name", "Type", childrenColumn}
+	keys := []string{nameColumn, typeColumn, childrenColumn}
 	if settings.IsDrawIO() {
-		keys = append(keys, "Image")
+		keys = append(keys, imageColumn)
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
@@ -46,7 +46,7 @@ func orgstructure(_ *cobra.Command, _ []string) {
 		output.Settings.DrawIOHeader = createOrganizationsStructureDrawIOHeader()
 	}
 	if output.Settings.NeedsFromToColumns() {
-		output.Settings.AddFromToColumns("Name", childrenColumn)
+		output.Settings.AddFromToColumns(nameColumn, childrenColumn)
 	}
 	traverseOrgStructureEntry(organization, &output)
 	output.Write()
@@ -56,14 +56,14 @@ func traverseOrgStructureEntry(entry helpers.OrganizationEntry, output *format.O
 	imageConversion := map[string]string{
 		"ROOT":                drawio.AWSShape("Management Governance", "Organizations"),
 		"ORGANIZATIONAL_UNIT": drawio.AWSShape("Management Governance", "Organizational Unit"),
-		"ACCOUNT":             drawio.AWSShape("Management Governance", "Account"),
+		"ACCOUNT":             drawio.AWSShape("Management Governance", accountColumn),
 	}
 	content := make(map[string]any)
-	content["Name"] = entry.String()
-	content["Type"] = entry.Type
+	content[nameColumn] = entry.String()
+	content[typeColumn] = entry.Type
 	content[childrenColumn] = entry.String()
 	if settings.IsDrawIO() {
-		content["Image"] = imageConversion[entry.Type]
+		content[imageColumn] = imageConversion[entry.Type]
 	}
 	children := []string{}
 	for _, child := range entry.Children {

--- a/cmd/s3list.go
+++ b/cmd/s3list.go
@@ -40,7 +40,7 @@ func s3List(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "S3 Buckets"
 	buckets := helpers.GetBucketDetails(awsConfig.S3Client())
-	keys := []string{"Name", "AccountID", "AccountName", "Region", "Is Private", "Policy is locked down", "ACLs are locked down", "Public Access Block", "Logs to", "Encryption", "Replication", "Versioning", "Versioning MFA delete"}
+	keys := []string{nameColumn, accountIDColumn, "AccountName", "Region", "Is Private", "Policy is locked down", "ACLs are locked down", "Public Access Block", "Logs to", "Encryption", "Replication", "Versioning", "Versioning MFA delete"}
 	if includeTags != "" {
 		taglist := strings.SplitSeq(includeTags, ",")
 		for tag := range taglist {
@@ -68,8 +68,8 @@ func s3List(_ *cobra.Command, _ []string) {
 			continue
 		}
 		content := make(map[string]any)
-		content["Name"] = bucket.Name
-		content["AccountID"] = awsConfig.AccountID
+		content[nameColumn] = bucket.Name
+		content[accountIDColumn] = awsConfig.AccountID
 		content["AccountName"] = getName(awsConfig.AccountID)
 		content["Region"] = bucket.Region
 		content["Owner"] = bucket.Owner

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -395,7 +395,7 @@ func displayEnhancedProfileResults(result *helpers.ProfileGenerationResult) {
 	}
 
 	// Create enhanced output for generated profiles
-	keys := []string{"ProfileName", "Account", "Role", "Region", "Format", "Status", "Action"}
+	keys := []string{"ProfileName", accountColumn, "Role", "Region", "Format", "Status", "Action"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = "Generated AWS CLI Profiles"
 	output.Settings.SortKey = "ProfileName"
@@ -403,7 +403,7 @@ func displayEnhancedProfileResults(result *helpers.ProfileGenerationResult) {
 	for _, profile := range result.GeneratedProfiles {
 		content := make(map[string]any)
 		content["ProfileName"] = profile.Name
-		content["Account"] = fmt.Sprintf("%s (%s)", profile.AccountName, profile.AccountID)
+		content[accountColumn] = fmt.Sprintf("%s (%s)", profile.AccountName, profile.AccountID)
 		content["Role"] = profile.RoleName
 		content["Region"] = profile.Region
 

--- a/cmd/ssodangling.go
+++ b/cmd/ssodangling.go
@@ -28,13 +28,13 @@ func ssoDangling(_ *cobra.Command, _ []string) {
 	if err != nil {
 		panic(err)
 	}
-	keys := []string{"PermissionSet", "Arn", "ManagedPolicies", "InlinePolicy"}
+	keys := []string{permissionSetColumn, "Arn", "ManagedPolicies", "InlinePolicy"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
 	for _, permissionset := range ssoInstance.PermissionSets {
 		if len(permissionset.Accounts) == 0 {
 			content := make(map[string]any)
-			content["PermissionSet"] = permissionset.Name
+			content[permissionSetColumn] = permissionset.Name
 			content["Arn"] = permissionset.Arn
 			content["ManagedPolicies"] = permissionset.GetManagedPolicyNames()
 			content["InlinePolicy"] = permissionset.InlinePolicy

--- a/cmd/ssooverviewaccount.go
+++ b/cmd/ssooverviewaccount.go
@@ -35,26 +35,26 @@ func ssoOverviewByAccount(_ *cobra.Command, _ []string) {
 	if err != nil {
 		panic(err)
 	}
-	keys := []string{"AccountID", permissionSetColumn, "Principal"}
+	keys := []string{accountIDColumn, permissionSetColumn, "Principal"}
 	if settings.IsVerbose() {
 		keys = append(keys, "ManagedPolicies", "InlinePolicy")
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
-	output.Settings.SortKey = "AccountID"
+	output.Settings.SortKey = accountIDColumn
 	switch {
 	case settings.IsDrawIO():
 		output.Settings.DrawIOHeader = createSSOAccountsDrawIOHeader()
 		createSSOAccountDrawIOContents(ssoInstance, &output)
 	case output.Settings.NeedsFromToColumns():
-		output.Settings.AddFromToColumns("DrawIOID", "Children")
+		output.Settings.AddFromToColumns(drawIOIDColumn, childrenColumn)
 		createSSOAccountDrawIOContents(ssoInstance, &output)
 	default:
 		for _, account := range ssoInstance.Accounts {
 			if filteredSSOAccount(account) {
 				for _, assignment := range account.AccountAssignments {
 					content := make(map[string]any)
-					content["AccountID"] = getName(account.AccountID)
+					content[accountIDColumn] = getName(account.AccountID)
 					content[permissionSetColumn] = assignment.PermissionSet.Name
 					content["Principal"] = getName(assignment.PrincipalID)
 					if settings.IsVerbose() {
@@ -85,21 +85,21 @@ func createSSOAccountsDrawIOHeader() drawio.Header {
 	drawioheader.SetLayout(drawio.LayoutHorizontalTree)
 	connection := drawio.NewConnection()
 	connection.Invert = false
-	connection.From = "Children"
-	connection.To = "DrawIOID"
+	connection.From = childrenColumn
+	connection.To = drawIOIDColumn
 	drawioheader.AddConnection(connection)
 	return drawioheader
 }
 
 func createSSOAccountDrawIOContents(instance helpers.SSOInstance, output *format.OutputArray) {
-	output.Keys = []string{"Name", "DrawIOID", "Type", "Children", "Image"}
+	output.Keys = []string{nameColumn, drawIOIDColumn, typeColumn, childrenColumn, imageColumn}
 
 	content := make(map[string]any)
-	content["Name"] = getName(instance.Arn)
-	content["DrawIOID"] = getName(instance.Arn)
-	content["Type"] = "SSO"
-	content["Image"] = drawio.AWSShape("Security Identity Compliance", "Single Sign-On")
-	content["Children"] = instance.GetAccountList()
+	content[nameColumn] = getName(instance.Arn)
+	content[drawIOIDColumn] = getName(instance.Arn)
+	content[typeColumn] = "SSO"
+	content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Single Sign-On")
+	content[childrenColumn] = instance.GetAccountList()
 	holder := format.OutputHolder{Contents: content}
 	output.AddHolder(holder)
 	uniquefilter := []string{}
@@ -109,39 +109,39 @@ func createSSOAccountDrawIOContents(instance helpers.SSOInstance, output *format
 		}
 		accountchildren := []string{}
 		content := make(map[string]any)
-		content["Name"] = getName(account.AccountID)
-		content["DrawIOID"] = account.AccountID
-		content["Type"] = "Account"
-		content["Image"] = drawio.AWSShape("Security Identity Compliance", "Organizations Account")
+		content[nameColumn] = getName(account.AccountID)
+		content[drawIOIDColumn] = account.AccountID
+		content[typeColumn] = accountColumn
+		content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Organizations Account")
 		for _, assignment := range account.AccountAssignments {
 			accountchildren = append(accountchildren, assignment.PermissionSet.Name+account.AccountID)
 		}
-		content["Children"] = unique(accountchildren)
+		content[childrenColumn] = unique(accountchildren)
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
 		for _, assignment := range account.AccountAssignments {
 			if !contains(uniquefilter, assignment.PermissionSet.Name+account.AccountID) {
 				uniquefilter = append(uniquefilter, assignment.PermissionSet.Name+account.AccountID)
 				content := make(map[string]any)
-				content["Name"] = getName(assignment.PermissionSet.Name)
-				content["DrawIOID"] = getName(assignment.PermissionSet.Name + account.AccountID)
-				content["Type"] = permissionSetColumn
-				content["Image"] = drawio.AWSShape("Security Identity Compliance", "Permissions")
-				content["Children"] = assignment.PermissionSet.GetAssignmentIDsByAccount(account.AccountID)
+				content[nameColumn] = getName(assignment.PermissionSet.Name)
+				content[drawIOIDColumn] = getName(assignment.PermissionSet.Name + account.AccountID)
+				content[typeColumn] = permissionSetColumn
+				content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Permissions")
+				content[childrenColumn] = assignment.PermissionSet.GetAssignmentIDsByAccount(account.AccountID)
 				holder := format.OutputHolder{Contents: content}
 				output.AddHolder(holder)
 			}
 			if !contains(uniquefilter, assignment.PrincipalID) {
 				uniquefilter = append(uniquefilter, assignment.PrincipalID)
 				content := make(map[string]any)
-				content["Name"] = getName(assignment.PrincipalID)
-				content["DrawIOID"] = assignment.PrincipalID
-				content["Type"] = assignment.PrincipalType
+				content[nameColumn] = getName(assignment.PrincipalID)
+				content[drawIOIDColumn] = assignment.PrincipalID
+				content[typeColumn] = assignment.PrincipalType
 				switch assignment.PrincipalType {
 				case "USER":
-					content["Image"] = drawio.AWSShape("General Resources", "User")
+					content[imageColumn] = drawio.AWSShape("General Resources", "User")
 				case "GROUP":
-					content["Image"] = drawio.AWSShape("General Resources", "Users")
+					content[imageColumn] = drawio.AWSShape("General Resources", "Users")
 				}
 				holder := format.OutputHolder{Contents: content}
 				output.AddHolder(holder)

--- a/cmd/ssooverviewpermissionset.go
+++ b/cmd/ssooverviewpermissionset.go
@@ -34,19 +34,19 @@ func ssoOverviewByPermissionSet(_ *cobra.Command, _ []string) {
 	if err != nil {
 		panic(err)
 	}
-	keys := []string{"PermissionSet", "AccountID", "Principal"}
+	keys := []string{permissionSetColumn, accountIDColumn, "Principal"}
 	if settings.IsVerbose() {
 		keys = append(keys, "ManagedPolicies", "InlinePolicy")
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
-	output.Settings.SortKey = "PermissionSet"
+	output.Settings.SortKey = permissionSetColumn
 	switch {
 	case settings.IsDrawIO():
 		output.Settings.DrawIOHeader = createSSOPermissionsetsDrawIOHeader()
 		createSSOPermissionsetsDrawIOContents(ssoInstance, &output)
 	case output.Settings.NeedsFromToColumns():
-		output.Settings.AddFromToColumns("DrawIOID", "Children")
+		output.Settings.AddFromToColumns(drawIOIDColumn, childrenColumn)
 		createSSOPermissionsetsDrawIOContents(ssoInstance, &output)
 	default:
 		for _, permissionset := range ssoInstance.PermissionSets {
@@ -56,8 +56,8 @@ func ssoOverviewByPermissionSet(_ *cobra.Command, _ []string) {
 			for _, account := range permissionset.Accounts {
 				for _, assignment := range account.AccountAssignments {
 					content := make(map[string]any)
-					content["PermissionSet"] = assignment.PermissionSet.Name
-					content["AccountID"] = getName(account.AccountID)
+					content[permissionSetColumn] = assignment.PermissionSet.Name
+					content[accountIDColumn] = getName(account.AccountID)
 					content["Principal"] = getName(assignment.PrincipalID)
 					if settings.IsVerbose() {
 						content["ManagedPolicies"] = assignment.PermissionSet.GetManagedPolicyNames()
@@ -87,21 +87,21 @@ func createSSOPermissionsetsDrawIOHeader() drawio.Header {
 	drawioheader.SetLayout(drawio.LayoutHorizontalTree)
 	connection := drawio.NewConnection()
 	connection.Invert = false
-	connection.From = "Children"
-	connection.To = "DrawIOID"
+	connection.From = childrenColumn
+	connection.To = drawIOIDColumn
 	drawioheader.AddConnection(connection)
 	return drawioheader
 }
 
 func createSSOPermissionsetsDrawIOContents(instance helpers.SSOInstance, output *format.OutputArray) {
-	output.Keys = []string{"Name", "DrawIOID", "Type", "Children", "Image"}
+	output.Keys = []string{nameColumn, drawIOIDColumn, typeColumn, childrenColumn, imageColumn}
 
 	content := make(map[string]any)
-	content["Name"] = getName(instance.Arn)
-	content["DrawIOID"] = getName(instance.Arn)
-	content["Type"] = "SSO"
-	content["Image"] = drawio.AWSShape("Security Identity Compliance", "Single Sign-On")
-	content["Children"] = instance.GetPermissionSetList()
+	content[nameColumn] = getName(instance.Arn)
+	content[drawIOIDColumn] = getName(instance.Arn)
+	content[typeColumn] = "SSO"
+	content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Single Sign-On")
+	content[childrenColumn] = instance.GetPermissionSetList()
 	holder := format.OutputHolder{Contents: content}
 	output.AddHolder(holder)
 	uniquefilter := []string{}
@@ -111,23 +111,23 @@ func createSSOPermissionsetsDrawIOContents(instance helpers.SSOInstance, output 
 		}
 		permchildren := []string{}
 		content := make(map[string]any)
-		content["Name"] = getName(permissionset.Name)
-		content["DrawIOID"] = getName(permissionset.Name)
-		content["Type"] = "PermissionSet"
-		content["Image"] = drawio.AWSShape("Security Identity Compliance", "Permissions")
+		content[nameColumn] = getName(permissionset.Name)
+		content[drawIOIDColumn] = getName(permissionset.Name)
+		content[typeColumn] = permissionSetColumn
+		content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Permissions")
 		for _, account := range permissionset.Accounts {
 			permchildren = append(permchildren, account.AccountID+permissionset.Name)
 		}
-		content["Children"] = permchildren
+		content[childrenColumn] = permchildren
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
 		for _, account := range permissionset.Accounts {
 			content := make(map[string]any)
-			content["Name"] = getName(account.AccountID)
-			content["DrawIOID"] = account.AccountID + permissionset.Name
-			content["Type"] = "Account"
-			content["Image"] = drawio.AWSShape("Security Identity Compliance", "Organizations Account")
-			content["Children"] = account.GetPrincipalIDsForPermissionSet(permissionset)
+			content[nameColumn] = getName(account.AccountID)
+			content[drawIOIDColumn] = account.AccountID + permissionset.Name
+			content[typeColumn] = accountColumn
+			content[imageColumn] = drawio.AWSShape("Security Identity Compliance", "Organizations Account")
+			content[childrenColumn] = account.GetPrincipalIDsForPermissionSet(permissionset)
 			holder := format.OutputHolder{Contents: content}
 			output.AddHolder(holder)
 			for _, assignment := range account.AccountAssignments {
@@ -135,14 +135,14 @@ func createSSOPermissionsetsDrawIOContents(instance helpers.SSOInstance, output 
 					if !contains(uniquefilter, assignment.PrincipalID) {
 						uniquefilter = append(uniquefilter, assignment.PrincipalID)
 						content := make(map[string]any)
-						content["Name"] = getName(assignment.PrincipalID)
-						content["DrawIOID"] = assignment.PrincipalID
-						content["Type"] = assignment.PrincipalType
+						content[nameColumn] = getName(assignment.PrincipalID)
+						content[drawIOIDColumn] = assignment.PrincipalID
+						content[typeColumn] = assignment.PrincipalType
 						switch assignment.PrincipalType {
 						case "USER":
-							content["Image"] = drawio.AWSShape("General Resources", "User")
+							content[imageColumn] = drawio.AWSShape("General Resources", "User")
 						case "GROUP":
-							content["Image"] = drawio.AWSShape("General Resources", "Users")
+							content[imageColumn] = drawio.AWSShape("General Resources", "Users")
 						}
 						holder := format.OutputHolder{Contents: content}
 						output.AddHolder(holder)

--- a/cmd/tgwdangling.go
+++ b/cmd/tgwdangling.go
@@ -27,7 +27,7 @@ func tgwdangling(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "Transit Gateway uni-directional routes"
 	gateways := helpers.GetAllTransitGateways(awsConfig.Ec2Client())
-	keys := []string{"VPC", "VPCName", "DestinationVPC", "DestinationName"}
+	keys := []string{vpcColumn, "VPCName", "DestinationVPC", "DestinationName"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
 	vpcs := make(map[string][]string)
@@ -47,7 +47,7 @@ func tgwdangling(_ *cobra.Command, _ []string) {
 		for _, target := range targets {
 			if !contains(vpcs[target], vpcid) {
 				content := make(map[string]any)
-				content["VPC"] = vpcid
+				content[vpcColumn] = vpcid
 				content["VPCName"] = getName(vpcid)
 				content["DestinationVPC"] = target
 				content["DestinationName"] = getName(target)

--- a/cmd/tgwoverview.go
+++ b/cmd/tgwoverview.go
@@ -35,13 +35,13 @@ func tgwoverview(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "Transit Gateway Routes in account " + getName(helpers.GetAccountID(awsConfig.StsClient()))
 	gateways := helpers.GetAllTransitGateways(awsConfig.Ec2Client())
-	keys := []string{"Transit Gateway Account", "Transit Gateway", "Route Table", "CIDR", "Target", "Target Type", "State"}
+	keys := []string{"Transit Gateway Account", "Transit Gateway", routeTableColumn, cidrColumn, "Target", "Target Type", "State"}
 	if settings.IsDrawIO() {
-		keys = []string{"ID", "Name", "Destinations", "Image"}
+		keys = []string{"ID", nameColumn, destinationsColumn, imageColumn}
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
-	output.Settings.SortKey = "Route Table"
+	output.Settings.SortKey = routeTableColumn
 	if settings.IsDrawIO() {
 		createTgwOverviewDrawIO(&output, gateways)
 	} else {
@@ -63,8 +63,8 @@ func tgwoverview(_ *cobra.Command, _ []string) {
 					content := make(map[string]any)
 					content["Transit Gateway Account"] = getNameWithID(gateway.AccountID)
 					content["Transit Gateway"] = getNameWithID(gateway.ID)
-					content["Route Table"] = getNameWithID(routetable.ID)
-					content["CIDR"] = route.CIDR
+					content[routeTableColumn] = getNameWithID(routetable.ID)
+					content[cidrColumn] = route.CIDR
 					if route.Attachment.ResourceID != "" {
 						content["Target"] = getNameWithID(route.Attachment.ResourceID)
 					} else {
@@ -92,8 +92,8 @@ func tgwoverview(_ *cobra.Command, _ []string) {
 					content := make(map[string]any)
 					content["Transit Gateway Account"] = getNameWithID(gateway.AccountID)
 					content["Transit Gateway"] = getNameWithID(gateway.ID)
-					content["Route Table"] = getNameWithID(routetable.ID)
-					content["CIDR"] = "-"
+					content[routeTableColumn] = getNameWithID(routetable.ID)
+					content[cidrColumn] = "-"
 					content["Target"] = getNameWithID(attachment.ResourceID)
 					content["Target Type"] = attachment.ResourceType
 					content["State"] = "associated"
@@ -107,10 +107,10 @@ func tgwoverview(_ *cobra.Command, _ []string) {
 }
 
 func createTgwOverviewDrawIO(output *format.OutputArray, gateways []helpers.TransitGateway) {
-	drawioheader := drawio.NewHeader("%Name%", "%Image%", "Image")
+	drawioheader := drawio.NewHeader("%Name%", "%Image%", imageColumn)
 	drawioheader.SetHeightAndWidth("78", "78")
 	connection := drawio.NewConnection()
-	connection.From = "Destinations"
+	connection.From = destinationsColumn
 	connection.To = "ID"
 	connection.Invert = false
 	connection.Style = drawio.BidirectionalConnectionStyle
@@ -128,9 +128,9 @@ func createTgwOverviewDrawIO(output *format.OutputArray, gateways []helpers.Tran
 		for _, row := range previousResults {
 			targetTgwMapping[row[headers["ID"]]] = targetTgwMap{
 				ID:           row[headers["ID"]],
-				Name:         row[headers["Name"]],
-				Destinations: strings.Split(row[headers["Destinations"]], ","),
-				Image:        row[headers["Image"]],
+				Name:         row[headers[nameColumn]],
+				Destinations: strings.Split(row[headers[destinationsColumn]], ","),
+				Image:        row[headers[imageColumn]],
 			}
 		}
 	}
@@ -149,7 +149,7 @@ func createTgwOverviewDrawIO(output *format.OutputArray, gateways []helpers.Tran
 			image := ""
 			switch helpers.TypeByResourceID(resourceid) {
 			case vpcResourceType:
-				image = drawio.AWSShape("Network Content Delivery", "VPC")
+				image = drawio.AWSShape("Network Content Delivery", vpcColumn)
 			case "vpn":
 				image = drawio.AWSShape("Network Content Delivery", "Site-to-Site VPN")
 			case "dxgw":
@@ -168,9 +168,9 @@ func createTgwOverviewDrawIO(output *format.OutputArray, gateways []helpers.Tran
 	for _, mapping := range targetTgwMapping {
 		content := make(map[string]any)
 		content["ID"] = mapping.ID
-		content["Name"] = mapping.Name
-		content["Destinations"] = mapping.Destinations
-		content["Image"] = mapping.Image
+		content[nameColumn] = mapping.Name
+		content[destinationsColumn] = mapping.Destinations
+		content[imageColumn] = mapping.Image
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
 	}

--- a/cmd/tgwroutes.go
+++ b/cmd/tgwroutes.go
@@ -48,9 +48,9 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "Overview of all routes"
 	gateways := helpers.GetAllTransitGateways(awsConfig.Ec2Client())
-	keys := []string{"ID", "Name", "Destinations", "TargetGateway"}
+	keys := []string{"ID", nameColumn, destinationsColumn, targetGatewayColumn}
 	if settings.IsDrawIO() {
-		keys = append(keys, "Image")
+		keys = append(keys, imageColumn)
 	}
 	if simplelist {
 		simplelistOnly(awsConfig)
@@ -58,12 +58,12 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
-	output.Settings.SortKey = "TargetGateway"
+	output.Settings.SortKey = targetGatewayColumn
 	if settings.IsDrawIO() {
 		output.Settings.DrawIOHeader = createTgwRoutesDrawIOHeader()
 	}
 	if output.Settings.NeedsFromToColumns() {
-		output.Settings.AddFromToColumns("Destinations", "ID")
+		output.Settings.AddFromToColumns(destinationsColumn, "ID")
 	}
 
 	attachedresources, tgwrts := filterGateway(gateways)
@@ -71,10 +71,10 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 	for rt, connectedvpcs := range tgwrts {
 		content := make(map[string]any)
 		content["ID"] = rt
-		content["Name"] = getName(rt)
-		content["Destinations"] = unique(connectedvpcs)
+		content[nameColumn] = getName(rt)
+		content[destinationsColumn] = unique(connectedvpcs)
 		if settings.IsDrawIO() {
-			content["Image"] = drawio.AWSShape("Network Content Delivery", "Route Table")
+			content[imageColumn] = drawio.AWSShape("Network Content Delivery", routeTableColumn)
 		}
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
@@ -82,16 +82,16 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 	for resourceid, resourceInfo := range attachedresources {
 		content := make(map[string]any)
 		content["ID"] = resourceid
-		content["Name"] = getName(resourceid)
+		content[nameColumn] = getName(resourceid)
 		if settings.IsDrawIO() {
 			// Use raw ID for DrawIO to enable proper connection matching
-			content["TargetGateway"] = resourceInfo.RouteTableID
+			content[targetGatewayColumn] = resourceInfo.RouteTableID
 		} else {
 			// Use composite name for other output formats
 			if getName(resourceInfo.RouteTableID) != resourceInfo.RouteTableID && getName(resourceInfo.RouteTableID) != "" {
-				content["TargetGateway"] = getNameWithID(resourceInfo.RouteTableID)
+				content[targetGatewayColumn] = getNameWithID(resourceInfo.RouteTableID)
 			} else {
-				content["TargetGateway"] = resourceInfo.RouteTableID
+				content[targetGatewayColumn] = resourceInfo.RouteTableID
 			}
 		}
 
@@ -104,23 +104,23 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 			}
 			switch resourceType {
 			case vpcResourceType:
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "VPC")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", vpcColumn)
 			case "vpn":
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Site-to-Site VPN")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Site-to-Site VPN")
 			case "dxgw":
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Direct Connect Gateway")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Direct Connect Gateway")
 			case tgwResourceType:
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
 			case "peering":
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
 			case "tgw-peering":
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
 			case "direct-connect-gateway":
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Direct Connect")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Direct Connect")
 			case "connect":
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Transit Gateway")
 			default:
-				content["Image"] = drawio.AWSShape("General Resources", "General")
+				content[imageColumn] = drawio.AWSShape("General Resources", "General")
 			}
 		}
 		holder := format.OutputHolder{Contents: content}
@@ -130,17 +130,17 @@ func tgwroutes(_ *cobra.Command, _ []string) {
 }
 
 func simplelistOnly(awsConfig config.AWSConfig) {
-	keys := []string{"CIDR", "Target", "Route Type", "State"}
+	keys := []string{cidrColumn, "Target", "Route Type", "State"}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = fmt.Sprintf("Simple route list for %s", tgwresourceid)
-	output.Settings.SortKey = "CIDR"
+	output.Settings.SortKey = cidrColumn
 
 	activeroutes := helpers.GetActiveRoutesForTransitGatewayRouteTable(tgwresourceid, awsConfig.Ec2Client())
 	blackholeroutes := helpers.GetBlackholeRoutesForTransitGatewayRouteTable(tgwresourceid, awsConfig.Ec2Client())
 
 	for _, route := range activeroutes {
 		content := make(map[string]any)
-		content["CIDR"] = route.CIDR
+		content[cidrColumn] = route.CIDR
 		content["Target"] = getName(route.Attachment.ResourceID)
 		// content["Target Type"] = getName(route.Attachment.ResourceType)
 		content["Route Type"] = route.RouteType
@@ -151,7 +151,7 @@ func simplelistOnly(awsConfig config.AWSConfig) {
 	}
 	for _, route := range blackholeroutes {
 		content := make(map[string]any)
-		content["CIDR"] = route.CIDR
+		content[cidrColumn] = route.CIDR
 		content["Target"] = "-"
 		// content["Target Type"] = "-"
 		content["Route Type"] = route.RouteType
@@ -252,16 +252,16 @@ func filterGateway(gateways []helpers.TransitGateway) (map[string]attachedResour
 }
 
 func createTgwRoutesDrawIOHeader() drawio.Header {
-	drawioheader := drawio.NewHeader("%Name%", "%Image%", "Image")
+	drawioheader := drawio.NewHeader("%Name%", "%Image%", imageColumn)
 	drawioheader.SetHeightAndWidth("78", "78")
 	connection := drawio.NewConnection()
-	connection.From = "Destinations"
+	connection.From = destinationsColumn
 	connection.To = "ID"
 	connection.Invert = false
 	connection.Label = "Outbound"
 	drawioheader.AddConnection(connection)
 	connection2 := drawio.NewConnection()
-	connection2.From = "TargetGateway"
+	connection2.From = targetGatewayColumn
 	connection2.To = "ID"
 	connection2.Invert = false
 	connection2.Label = "Inbound"

--- a/cmd/vpcenis.go
+++ b/cmd/vpcenis.go
@@ -51,15 +51,15 @@ func enis(_ *cobra.Command, _ []string) {
 }
 
 func printENIs(interfaces []types.NetworkInterface, names map[string]string, resultTitle string, split bool, svc *ec2.Client) {
-	keys := []string{"ENI", "Type", "Attachment", "IPs", "VPC", "Subnet"}
+	keys := []string{"ENI", typeColumn, attachmentColumn, "IPs", vpcColumn, subnetColumn}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
-	output.Settings.SortKey = "Subnet"
+	output.Settings.SortKey = subnetColumn
 	if split {
 		// unset VPC and subnet
-		output.Keys = []string{"ENI", "Type", "Attachment", "IPs"}
+		output.Keys = []string{"ENI", typeColumn, attachmentColumn, "IPs"}
 		output.Settings.SeparateTables = true
-		output.Settings.SortKey = "Attachment"
+		output.Settings.SortKey = attachmentColumn
 	}
 
 	// Build cache once for all ENIs to avoid per-ENI API calls (T-727).
@@ -77,11 +77,11 @@ func printENIs(interfaces []types.NetworkInterface, names map[string]string, res
 			}
 		}
 		content["ENI"] = aws.ToString(netinterface.NetworkInterfaceId)
-		content["Type"] = netinterface.InterfaceType
-		content["Attachment"] = getNameAndIDFromMap(helpers.GetAttachmentFromCache(netinterface, cache), names)
+		content[typeColumn] = netinterface.InterfaceType
+		content[attachmentColumn] = getNameAndIDFromMap(helpers.GetAttachmentFromCache(netinterface, cache), names)
 		content["IPs"] = iparray
-		content["VPC"] = getNameAndIDFromMap(aws.ToString(netinterface.VpcId), names)
-		content["Subnet"] = getNameAndIDFromMap(aws.ToString(netinterface.SubnetId), names)
+		content[vpcColumn] = getNameAndIDFromMap(aws.ToString(netinterface.VpcId), names)
+		content[subnetColumn] = getNameAndIDFromMap(aws.ToString(netinterface.SubnetId), names)
 		output.AddContents(content)
 	}
 	output.AddToBuffer()

--- a/cmd/vpcipfinder.go
+++ b/cmd/vpcipfinder.go
@@ -67,7 +67,7 @@ func formatIPFinderOutput(result helpers.IPFinderResult) {
 		return
 	}
 
-	keys := []string{"Field", "Value"}
+	keys := []string{fieldColumn, valueColumn}
 	output := format.OutputArray{
 		Keys:     keys,
 		Settings: settings.NewOutputSettings(),
@@ -103,14 +103,14 @@ func formatIPFinderOutput(result helpers.IPFinderResult) {
 	}
 
 	outputData := []map[string]any{
-		{"Field": "IP Address", "Value": result.IPAddress},
-		{"Field": "ENI ID", "Value": eniID},
-		{"Field": "Resource Type", "Value": result.ResourceType},
-		{"Field": "Resource Name", "Value": resourceName},
-		{"Field": "Resource ID", "Value": result.ResourceID},
-		{"Field": "VPC", "Value": vpcDisplay},
-		{"Field": "Subnet", "Value": subnetDisplay},
-		{"Field": "Is Secondary IP", "Value": result.IsSecondaryIP},
+		{fieldColumn: "IP Address", valueColumn: result.IPAddress},
+		{fieldColumn: "ENI ID", valueColumn: eniID},
+		{fieldColumn: "Resource Type", valueColumn: result.ResourceType},
+		{fieldColumn: "Resource Name", valueColumn: resourceName},
+		{fieldColumn: "Resource ID", valueColumn: result.ResourceID},
+		{fieldColumn: vpcColumn, valueColumn: vpcDisplay},
+		{fieldColumn: subnetColumn, valueColumn: subnetDisplay},
+		{fieldColumn: "Is Secondary IP", valueColumn: result.IsSecondaryIP},
 	}
 
 	// Add security groups if present
@@ -124,23 +124,23 @@ func formatIPFinderOutput(result helpers.IPFinderResult) {
 			}
 		}
 		outputData = append(outputData, map[string]any{
-			"Field": "Security Groups",
-			"Value": sgList,
+			fieldColumn: "Security Groups",
+			valueColumn: sgList,
 		})
 	}
 
 	// Add route table information if present
 	if result.RouteTable.ID != "" {
 		outputData = append(outputData, map[string]any{
-			"Field": "Route Table",
-			"Value": result.RouteTable.Name,
+			fieldColumn: routeTableColumn,
+			valueColumn: result.RouteTable.Name,
 		})
 
 		// Add routes if present
 		if len(result.RouteTable.Routes) > 0 {
 			outputData = append(outputData, map[string]any{
-				"Field": "Routes",
-				"Value": result.RouteTable.Routes,
+				fieldColumn: routesColumn,
+				valueColumn: result.RouteTable.Routes,
 			})
 		}
 	}

--- a/cmd/vpcoverview.go
+++ b/cmd/vpcoverview.go
@@ -60,13 +60,13 @@ func vpcOverview(_ *cobra.Command, _ []string) {
 	}
 
 	// Create separate subnet overview tables for each VPC
-	subnetKeys := []string{"Subnet", "CIDR", "Type", "Route Table", "Routes", "Total IPs", "Available IPs", "Used IPs"}
+	subnetKeys := []string{subnetColumn, cidrColumn, typeColumn, routeTableColumn, routesColumn, "Total IPs", "Available IPs", "Used IPs"}
 
 	for _, vpc := range filteredVPCs {
 		vpcDisplay := getResourceDisplayName(vpc.ID, vpc.Tags)
 		subnetOutput := format.OutputArray{Keys: subnetKeys, Settings: settings.NewOutputSettings()}
 		subnetOutput.Settings.Title = "Subnet Overview for " + vpcDisplay + " in account " + accountName
-		subnetOutput.Settings.SortKey = "CIDR"
+		subnetOutput.Settings.SortKey = cidrColumn
 		subnetOutput.Settings.SeparateTables = true
 
 		for _, subnet := range vpc.Subnets {
@@ -78,15 +78,15 @@ func vpcOverview(_ *cobra.Command, _ []string) {
 			routeTableName, routes := helpers.FormatRouteTableInfo(routeTable)
 
 			content := make(map[string]any)
-			content["Subnet"] = subnetDisplay
-			content["CIDR"] = subnet.CIDR
+			content[subnetColumn] = subnetDisplay
+			content[cidrColumn] = subnet.CIDR
 			if subnet.IsPublic {
-				content["Type"] = "Public"
+				content[typeColumn] = "Public"
 			} else {
-				content["Type"] = "Private"
+				content[typeColumn] = "Private"
 			}
-			content["Route Table"] = routeTableName
-			content["Routes"] = routes
+			content[routeTableColumn] = routeTableName
+			content[routesColumn] = routes
 			content["Total IPs"] = subnet.TotalIPs
 			content["Available IPs"] = subnet.AvailableIPs
 			content["Used IPs"] = subnet.UsedIPs

--- a/cmd/vpcpeerings.go
+++ b/cmd/vpcpeerings.go
@@ -30,9 +30,9 @@ func peerings(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "VPC Peerings for account " + getName(helpers.GetAccountID(awsConfig.StsClient()))
 	peerings := helpers.GetAllVpcPeers(awsConfig.Ec2Client())
-	keys := []string{"ID", "Name", "AccountID", "PeeringIDs"}
+	keys := []string{"ID", nameColumn, accountIDColumn, "PeeringIDs"}
 	if settings.IsDrawIO() {
-		keys = append(keys, "Image")
+		keys = append(keys, imageColumn)
 	}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
@@ -48,7 +48,7 @@ func peerings(_ *cobra.Command, _ []string) {
 		headers, previousResults := drawio.GetHeaderAndContentsFromFile(settings.GetString("output.file"))
 		for _, row := range previousResults {
 			id := row[headers["ID"]]
-			accountid := row[headers["AccountID"]]
+			accountid := row[headers[accountIDColumn]]
 			peeringids := row[headers["PeeringIDs"]]
 			if peeringids != "" {
 				sorted[id] = strings.Split(peeringids, ",")
@@ -84,15 +84,15 @@ func peerings(_ *cobra.Command, _ []string) {
 		peeringIDs := unique(entry)
 		content := make(map[string]any)
 		content["ID"] = id
-		content["Name"] = getName(id)
+		content[nameColumn] = getName(id)
 		if len(entry) > 0 {
-			content["AccountID"] = vpcs[id].AccountID
+			content[accountIDColumn] = vpcs[id].AccountID
 			content["PeeringIDs"] = peeringIDs
 			if settings.IsDrawIO() {
-				content["Image"] = drawio.AWSShape("Network Content Delivery", "VPC")
+				content[imageColumn] = drawio.AWSShape("Network Content Delivery", vpcColumn)
 			}
 		} else if settings.IsDrawIO() {
-			content["Image"] = drawio.AWSShape("Network Content Delivery", "Peering Connection")
+			content[imageColumn] = drawio.AWSShape("Network Content Delivery", "Peering Connection")
 		}
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
@@ -101,7 +101,7 @@ func peerings(_ *cobra.Command, _ []string) {
 }
 
 func createVpcPeeringsDrawIOHeader() drawio.Header {
-	drawioheader := drawio.NewHeader("%Name%", "%Image%", "Image")
+	drawioheader := drawio.NewHeader("%Name%", "%Image%", imageColumn)
 	drawioheader.SetHeightAndWidth("78", "78")
 	connection := drawio.NewConnection()
 	connection.From = "PeeringIDs"

--- a/cmd/vpcroutes.go
+++ b/cmd/vpcroutes.go
@@ -25,32 +25,32 @@ func routes(_ *cobra.Command, _ []string) {
 	awsConfig := config.DefaultAwsConfig(*settings)
 	resultTitle := "VPC Routes for account " + getName(helpers.GetAccountID(awsConfig.StsClient()))
 	routes := helpers.GetAllVPCRouteTables(awsConfig.Ec2Client())
-	keys := []string{"AccountID", "Account Name", "ID", "Name", "VPC", "VPC Name", "Subnets", "Routes"}
+	keys := []string{accountIDColumn, "Account Name", "ID", nameColumn, vpcColumn, "VPC Name", "Subnets", routesColumn}
 	output := format.OutputArray{Keys: keys, Settings: settings.NewOutputSettings()}
 	output.Settings.Title = resultTitle
 	for _, routetable := range routes {
 		content := make(map[string]any)
 		content["ID"] = routetable.ID
-		content["Name"] = getName(routetable.ID)
-		content["VPC"] = routetable.Vpc.ID
+		content[nameColumn] = getName(routetable.ID)
+		content[vpcColumn] = routetable.Vpc.ID
 		content["VPC Name"] = getName(routetable.Vpc.ID)
 		var subnets []string
 		for _, subnet := range routetable.Subnets {
 			subnets = append(subnets, fmt.Sprintf("%v (%v)", getName(subnet), subnet))
 		}
 		content["Subnets"] = subnets
-		content["AccountID"] = routetable.Vpc.AccountID
+		content[accountIDColumn] = routetable.Vpc.AccountID
 		content["Account Name"] = getName(routetable.Vpc.AccountID)
 		var routelist []string
 		for _, route := range routetable.Routes {
 			routelist = append(routelist, fmt.Sprintf("%v: %v", route.DestinationCIDR, route.DestinationTarget))
 		}
-		content["Routes"] = routelist
+		content[routesColumn] = routelist
 		holder := format.OutputHolder{Contents: content}
 		output.AddHolder(holder)
 	}
 	// if settings.IsDrawIO() {
-	// 	keys = append(keys, "Image")
+	// 	keys = append(keys, imageColumn)
 	// }
 	//
 	// switch settings.GetOutputFormat() {
@@ -69,7 +69,7 @@ func routes(_ *cobra.Command, _ []string) {
 	// 	headers, previousResults := drawio.GetHeaderAndContentsFromFile(*settings.OutputFile)
 	// 	for _, row := range previousResults {
 	// 		id := row[headers["ID"]]
-	// 		accountid := row[headers["AccountID"]]
+	// 		accountid := row[headers[accountIDColumn]]
 	// 		peeringids := row[headers["PeeringIDs"]]
 	// 		if peeringids != "" {
 	// 			sorted[id] = strings.Split(peeringids, ",")
@@ -105,16 +105,16 @@ func routes(_ *cobra.Command, _ []string) {
 	// 	peeringIDs := unique(entry)
 	// 	content := make(map[string]interface{})
 	// 	content["ID"] = id
-	// 	content["Name"] = getName(id)
+	// 	content[nameColumn] = getName(id)
 	// 	if len(entry) > 0 {
-	// 		content["AccountID"] = vpcs[id].AccountID
+	// 		content[accountIDColumn] = vpcs[id].AccountID
 	// 		content["PeeringIDs"] = peeringIDs
 	// 		if settings.IsDrawIO() {
-	// 			content["Image"] = drawio.ShapeAWSVPC
+	// 			content[imageColumn] = drawio.ShapeAWSVPC
 	// 		}
 	// 	} else {
 	// 		if settings.IsDrawIO() {
-	// 			content["Image"] = drawio.ShapeAWSVPCPeering
+	// 			content[imageColumn] = drawio.ShapeAWSVPCPeering
 	// 		}
 	// 	}
 	// }

--- a/helpers/ec2.go
+++ b/helpers/ec2.go
@@ -26,6 +26,7 @@ const (
 	interfaceType      = "interface"
 	lambdaFunctionType = "Lambda Function"
 	awsServiceType     = "AWS Service"
+	noRouteTableLabel  = "No route table"
 )
 
 // GetEc2Name returns the name of the provided EC2 Resource
@@ -1196,7 +1197,7 @@ func GetSubnetRouteTable(subnetID string, vpcID string, routeTables []types.Rout
 // FormatRouteTableInfo formats route table information similar to vpc routes command
 func FormatRouteTableInfo(routeTable *types.RouteTable) (string, []string) {
 	if routeTable == nil {
-		return "No route table", []string{}
+		return noRouteTableLabel, []string{}
 	}
 
 	// Use the same tiered lookup as other resources
@@ -2298,8 +2299,8 @@ func getRouteTableInfo(svc *ec2.Client, subnetID string, vpcID string) RouteTabl
 	routeTable := GetSubnetRouteTable(subnetID, vpcID, routeTables)
 	if routeTable == nil {
 		return RouteTableInfo{
-			ID:     "No route table",
-			Name:   "No route table",
+			ID:     noRouteTableLabel,
+			Name:   noRouteTableLabel,
 			Routes: []string{},
 		}
 	}


### PR DESCRIPTION
Extracts repeated string literals into named constants to clear the 35 pre-existing `goconst` lint failures that were blocking CI on main and every open PR.

## What changed
- Added new column-name constants to `cmd/constants.go` (e.g. `accountIDColumn`, `cidrColumn`, `typeColumn`, `vpcColumn`, `subnetColumn`, `routeTableColumn`, `routesColumn`, `destinationsColumn`, `drawIOIDColumn`, `imageColumn`, `accountColumn`, `fieldColumn`, `attachmentColumn`, `descriptionColumn`, plus `stackColumn`, `exportColumn`, `valueColumn`, `targetGatewayColumn`, `importedColumn` and the `s3BucketARNDescription` value).
- Reused existing constants (`nameColumn`, `childrenColumn`, `permissionSetColumn`) where they already existed.
- Added `noRouteTableLabel` to the helpers package for `helpers/ec2.go` (separate package, no cross-package references).
- Replaced all matching string literals with the constants.

## Verification
- `golangci-lint run --timeout=5m` reports 0 issues
- `go build ./...` passes
- `go test ./...` passes (exit 0)
- `gofmt -s -l .` lists no files

No behavior changes: every constant has the same value as the literal it replaced, so output column headers and values are byte-identical.