### PR TITLE
fix: repair vpc enis build break from T-1145/T-1294 merge

### DIFF
--- a/cmd/vpcenis.go
+++ b/cmd/vpcenis.go
@@ -63,10 +63,11 @@ func enis(_ *cobra.Command, _ []string) error {
 
 	if vpceenisSplit {
 		writeENIsBySubnet(interfaces, names, resultTitle, attachmentFor)
-		return
+		return nil
 	}
 
 	writeENIs(interfaces, names, resultTitle, attachmentFor)
+	return nil
 }
 
 // writeENIs renders the single (non-split) ENI table. It writes the populated
@@ -77,7 +78,6 @@ func enis(_ *cobra.Command, _ []string) error {
 func writeENIs(interfaces []types.NetworkInterface, names map[string]string, resultTitle string, attachmentFor func(types.NetworkInterface) string) {
 	output := buildENIOutput(interfaces, names, resultTitle, false, attachmentFor)
 	output.Write()
-	return nil
 }
 
 // writeENIsBySubnet renders one separate table per subnet group. Each group is


### PR DESCRIPTION
main HEAD (5f67962) does not compile. PRs #126 (T-1145) and #128 (T-1294) both edited cmd/vpcenis.go and merged sequentially without rebasing, fusing T-1145's `RunE` conversion with T-1294's writeENIs split into non-compiling code:
- `enis()` returns `error` but had a bare `return` and no trailing return
- the void `writeENIs()` had a stray `return nil`

This repairs both. `go build`, `go test ./...`, `go vet`, and golangci-lint all pass.