### PR TITLE
T-1535: Add global --file-format flag for separate file output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,21 +79,22 @@ Available Commands:
   vpc           VPC commands
 
 Flags:
-  -a, --append            Add to the provided output file instead of replacing it
-      --config string     config file (default is .awstools.yaml in current directory, or $HOME/.awstools.yaml)
-      --emoji             Use emoji in the output
-  -f, --file string       Optional file to save the output to
-  -h, --help              help for awstools
-  -n, --namefile string   Use this file to provide names
-  -o, --output string     Format for the output, currently supported are csv, table, json, html, dot, and drawio (default "json")
-      --profile string    Use a specific profile
-      --region string     Use a specific region
-  -v, --verbose           Give verbose output
+  -a, --append               Add to the provided output file instead of replacing it
+      --config string        config file (default is .awstools.yaml in current directory, or $HOME/.awstools.yaml)
+      --emoji                Use emoji in the output
+  -f, --file string          Optional file to save the output to
+      --file-format string   Optional format for the file set with --file, defaults to the same as --output
+  -h, --help                 help for awstools
+  -n, --namefile string      Use this file to provide names
+  -o, --output string        Format for the output, currently supported are csv, table, json, yaml, html, markdown, mermaid, dot, and drawio (default "json")
+      --profile string       Use a specific profile
+      --region string        Use a specific region
+  -v, --verbose              Give verbose output
 
 Use "awstools [command] --help" for more information about a command.
 ```
 
-Output options are csv, table, json, html, markdown, dot, and drawio with json being the default so you can easily pass it to a tool like [jq](https://stedolan.github.io/jq/). The dot and drawio formats are input for graphical tools and only available for certain actions. You can also directly save the output into a file. Most commands will have a verbose option that will show some additional information that you often won't need.
+Output options are csv, table, json, yaml, html, markdown, mermaid, dot, and drawio with json being the default so you can easily pass it to a tool like [jq](https://stedolan.github.io/jq/). The dot, mermaid, and drawio formats are input for graphical tools and only available for certain actions. You can also directly save the output into a file, and with `--file-format` the file can use a different format than what is shown on screen (for example a table on screen and json in the file). Most commands will have a verbose option that will show some additional information that you often won't need.
 
 ## Pretty names
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,8 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Give verbose output")
 	rootCmd.PersistentFlags().StringP("file", "f", "", "Optional file to save the output to")
-	rootCmd.PersistentFlags().StringP("output", "o", "json", "Format for the output, currently supported are csv, table, json, html, dot, and drawio")
+	rootCmd.PersistentFlags().String("file-format", "", "Optional format for the file set with --file, defaults to the same as --output")
+	rootCmd.PersistentFlags().StringP("output", "o", "json", "Format for the output, currently supported are csv, table, json, yaml, html, markdown, mermaid, dot, and drawio")
 	rootCmd.PersistentFlags().BoolP("append", "a", false, "Add to the provided output file instead of replacing it")
 	rootCmd.PersistentFlags().StringP("namefile", "n", "", "Use this file to provide names")
 	rootCmd.PersistentFlags().String("profile", "", "Use a specific profile")
@@ -62,6 +63,9 @@ func init() {
 		panic(err)
 	}
 	if err := viper.BindPFlag("output.file", rootCmd.PersistentFlags().Lookup("file")); err != nil {
+		panic(err)
+	}
+	if err := viper.BindPFlag("output.file-format", rootCmd.PersistentFlags().Lookup("file-format")); err != nil {
 		panic(err)
 	}
 	if err := viper.BindPFlag("output.append", rootCmd.PersistentFlags().Lookup("append")); err != nil {

--- a/cmd/root_flags_test.go
+++ b/cmd/root_flags_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileFormatFlagRegistration verifies that --file-format is registered as
+// a global persistent flag on the root command and bound to the
+// output.file-format viper key, so every subcommand can write the --file
+// output in a different format than stdout (T-1535).
+func TestFileFormatFlagRegistration(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("file-format")
+	require.NotNil(t, flag, "--file-format must be a persistent flag on the root command")
+	assert.Equal(t, "", flag.DefValue, "--file-format must default to empty so the file falls back to the --output format")
+
+	require.NoError(t, flag.Value.Set("csv"))
+	t.Cleanup(func() {
+		// Restore the flag instead of viper.Reset(), which would tear down
+		// the package-wide flag bindings created in init().
+		_ = flag.Value.Set("")
+		flag.Changed = false
+	})
+	assert.Equal(t, "csv", viper.GetString("output.file-format"), "--file-format must be bound to the output.file-format viper key")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -69,13 +69,17 @@ func (config *Config) ShouldAppend() bool {
 
 // ShouldCombineAndAppend returns if the output should be combined
 func (config *Config) ShouldCombineAndAppend() bool {
-	if !config.NewOutputSettings().ShouldAppend {
+	settings := config.NewOutputSettings()
+	if !settings.ShouldAppend {
 		return false
 	}
-	if config.NewOutputSettings().OutputFormat == "html" {
-		return false
+	// The HTML exclusion concerns the file being appended to, so it has to
+	// look at the format the file is written in, not the stdout format.
+	fileFormat := settings.OutputFileFormat
+	if fileFormat == "" {
+		fileFormat = settings.OutputFormat
 	}
-	return true
+	return fileFormat != "html"
 }
 
 // IsVerbose returns whether verbose output is enabled
@@ -89,6 +93,7 @@ func (config *Config) NewOutputSettings() *format.OutputSettings {
 	settings.UseEmoji = config.GetBool("output.use-emoji")
 	settings.SetOutputFormat(config.GetLCString("output.format"))
 	settings.OutputFile = config.GetString("output.file")
+	settings.OutputFileFormat = config.GetLCString("output.file-format")
 	settings.ShouldAppend = config.GetBool("output.append")
 	settings.TableStyle = format.TableStyles[config.GetString("output.table.style")]
 	settings.TableMaxColumnWidth = config.GetInt("output.table.max-column-width")

--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,10 @@ func (config *Config) IsVerbose() bool {
 	return config.GetBool("output.verbose")
 }
 
-// NewOutputSettings creates and returns a new OutputSettings instance with current configuration
+// NewOutputSettings creates and returns a new OutputSettings instance with
+// current configuration. It must return a fresh object on every call: the
+// library's Write() mutates the settings it is given (e.g. filling in an empty
+// OutputFileFormat), so sharing one instance across calls would leak state.
 func (config *Config) NewOutputSettings() *format.OutputSettings {
 	settings := format.NewOutputSettings()
 	settings.UseEmoji = config.GetBool("output.use-emoji")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	format "github.com/ArjenSchwarz/go-output"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -192,6 +195,24 @@ func TestConfig_ShouldCombineAndAppend(t *testing.T) {
 		assert.True(t, result)
 		viper.Reset()
 	})
+
+	t.Run("returns false when the file format is html even though stdout format is not", func(t *testing.T) {
+		viper.Set("output.append", true)
+		viper.Set("output.format", "csv")
+		viper.Set("output.file-format", "html")
+		result := config.ShouldCombineAndAppend()
+		assert.False(t, result)
+		viper.Reset()
+	})
+
+	t.Run("returns true when the file format overrides an html stdout format", func(t *testing.T) {
+		viper.Set("output.append", true)
+		viper.Set("output.format", "html")
+		viper.Set("output.file-format", "csv")
+		result := config.ShouldCombineAndAppend()
+		assert.True(t, result)
+		viper.Reset()
+	})
 }
 
 func TestConfig_IsVerbose(t *testing.T) {
@@ -219,6 +240,7 @@ func TestConfig_NewOutputSettings(t *testing.T) {
 		viper.Set("output.use-emoji", true)
 		viper.Set("output.format", "json")
 		viper.Set("output.file", "/tmp/output.json")
+		viper.Set("output.file-format", "csv")
 		viper.Set("output.append", true)
 		viper.Set("output.table.style", "default")
 		viper.Set("output.table.max-column-width", 50)
@@ -228,9 +250,19 @@ func TestConfig_NewOutputSettings(t *testing.T) {
 		assert.True(t, settings.UseEmoji)
 		assert.Equal(t, "json", settings.OutputFormat)
 		assert.Equal(t, "/tmp/output.json", settings.OutputFile)
+		assert.Equal(t, "csv", settings.OutputFileFormat)
 		assert.True(t, settings.ShouldAppend)
 		assert.Equal(t, 50, settings.TableMaxColumnWidth)
 
+		viper.Reset()
+	})
+
+	t.Run("lowercases the file format like the output format", func(t *testing.T) {
+		viper.Set("output.file-format", "CSV")
+
+		settings := config.NewOutputSettings()
+
+		assert.Equal(t, "csv", settings.OutputFileFormat)
 		viper.Reset()
 	})
 
@@ -253,7 +285,32 @@ func TestConfig_NewOutputSettings(t *testing.T) {
 		assert.False(t, settings.UseEmoji)
 		assert.Equal(t, "", settings.OutputFormat)
 		assert.Equal(t, "", settings.OutputFile)
+		// An empty OutputFileFormat makes the library fall back to the
+		// stdout format when writing the file.
+		assert.Equal(t, "", settings.OutputFileFormat)
 		assert.False(t, settings.ShouldAppend)
 		assert.Equal(t, 0, settings.TableMaxColumnWidth)
+	})
+}
+
+func TestConfig_FileFormatWrite(t *testing.T) {
+	config := &Config{}
+
+	t.Run("writes the file in the file format while stdout keeps the output format", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "output")
+		viper.Set("output.format", "json")
+		viper.Set("output.file", outputFile)
+		viper.Set("output.file-format", "csv")
+		t.Cleanup(viper.Reset)
+
+		output := format.OutputArray{Keys: []string{"Name", "Value"}, Settings: config.NewOutputSettings()}
+		output.AddContents(map[string]any{"Name": "first", "Value": "one"})
+		output.Write()
+
+		contents, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+		assert.Contains(t, string(contents), "Name,Value")
+		assert.Contains(t, string(contents), "first,one")
+		assert.NotContains(t, string(contents), "{")
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -293,6 +294,32 @@ func TestConfig_NewOutputSettings(t *testing.T) {
 	})
 }
 
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what
+// was written. Write() prints the stdout rendering via os.Stdout directly, so
+// this is the only way to observe it in a test.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+	os.Stdout = old
+	captured, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
+	}
+	return string(captured)
+}
+
 func TestConfig_FileFormatWrite(t *testing.T) {
 	config := &Config{}
 
@@ -303,14 +330,37 @@ func TestConfig_FileFormatWrite(t *testing.T) {
 		viper.Set("output.file-format", "csv")
 		t.Cleanup(viper.Reset)
 
-		output := format.OutputArray{Keys: []string{"Name", "Value"}, Settings: config.NewOutputSettings()}
-		output.AddContents(map[string]any{"Name": "first", "Value": "one"})
-		output.Write()
+		stdout := captureStdout(t, func() {
+			output := format.OutputArray{Keys: []string{"Name", "Value"}, Settings: config.NewOutputSettings()}
+			output.AddContents(map[string]any{"Name": "first", "Value": "one"})
+			output.Write()
+		})
 
 		contents, err := os.ReadFile(outputFile)
 		assert.NoError(t, err)
 		assert.Contains(t, string(contents), "Name,Value")
 		assert.Contains(t, string(contents), "first,one")
 		assert.NotContains(t, string(contents), "{")
+
+		assert.Contains(t, stdout, `"Name":"first"`)
+		assert.NotContains(t, stdout, "Name,Value")
+	})
+
+	t.Run("file format without a file is a no-op", func(t *testing.T) {
+		outputDir := t.TempDir()
+		viper.Set("output.format", "json")
+		viper.Set("output.file-format", "csv")
+		t.Cleanup(viper.Reset)
+
+		stdout := captureStdout(t, func() {
+			output := format.OutputArray{Keys: []string{"Name", "Value"}, Settings: config.NewOutputSettings()}
+			output.AddContents(map[string]any{"Name": "first", "Value": "one"})
+			output.Write()
+		})
+
+		assert.Contains(t, stdout, `"Name":"first"`)
+		entries, err := os.ReadDir(outputDir)
+		assert.NoError(t, err)
+		assert.Empty(t, entries, "no file may be written when --file is not set")
 	})
 }

--- a/specs/file-output-format/decision_log.md
+++ b/specs/file-output-format/decision_log.md
@@ -1,0 +1,97 @@
+# Decision Log: File Output Format
+
+## Decision 1: Use go-output v1.4.0's built-in OutputFileFormat
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+T-1535 asks for a separate output format for the file written via `--file`, like fog's `--file-format` flag. fog implements this on go-output v2 with multiple writers. awstools is pinned to go-output v1.4.0.
+
+### Decision
+
+Wire up `OutputSettings.OutputFileFormat`, which already exists in go-output v1.4.0 and is already honoured by `OutputArray.Write()`. Do not migrate to go-output v2.
+
+### Rationale
+
+The v1 library already renders the file separately using `OutputFileFormat`, falling back to the stdout format when unset. awstools only needs to expose a flag and set one field. A v2 migration would touch every command in `cmd/` for no functional gain on this ticket.
+
+### Alternatives Considered
+
+- **Migrate to go-output v2 (fog's approach)**: Cleaner multi-writer model - Rejected because it rewrites the output path of every command to deliver a one-field feature.
+- **Render the file in awstools itself**: Format the contents twice in command code - Rejected because the library already does exactly this; duplicating it adds maintenance burden.
+
+### Consequences
+
+**Positive:**
+- ~10 lines of production code across two files.
+- Behaviour identical to the library's tested fallback path when the flag is unset.
+
+**Negative:**
+- Inherits v1 quirks: `html`/`drawio` renderers write directly to the file, and graph formats exit with an error on commands that do not configure them.
+
+---
+
+## Decision 2: Key ShouldCombineAndAppend's HTML exclusion to the effective file format
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+`Config.ShouldCombineAndAppend()` (config/config.go:71) gates the multi-account combine-and-append flow and excludes HTML, because HTML appending is handled inside the library's renderer. The exclusion currently checks the stdout format, which was also the file format until now. With `--file-format`, the two can diverge and the check is about the file.
+
+### Decision
+
+Evaluate the HTML exclusion against the effective file format: `output.file-format` when set, otherwise `output.format`.
+
+### Rationale
+
+The function exists solely to decide how the output file is appended to; consulting the stdout format would give wrong answers exactly when the new flag is used (e.g. `-o csv --file-format html` would attempt to parse an HTML file as CSV rows).
+
+### Alternatives Considered
+
+- **Leave it keyed to the stdout format and document the combination as undefined**: Zero code change - Rejected because the fix is a few lines and avoids a foreseeable parse failure.
+- **Block `--append` together with `--file-format` entirely**: Simple guard - Rejected because same-format appends (the multi-account collection use case) remain valid and useful.
+
+### Consequences
+
+**Positive:**
+- Combine-and-append behaves correctly whichever flag carries the HTML format.
+
+**Negative:**
+- Appending runs that mix incompatible formats in one file remain possible and remain the user's responsibility (unchanged from today, where varying `--output` between runs does the same).
+
+---
+
+## Decision 3: No validation of --file-format values
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+`--output` performs no validation; unknown values fall back to JSON inside the library's `Write()`. The new flag could validate against the known format list instead.
+
+### Decision
+
+`--file-format` inherits the same no-validation behaviour as `--output`.
+
+### Rationale
+
+Two flags accepting the same value set should fail (or not) the same way. Adding validation to only the new flag creates an inconsistency, and adding it to both expands scope beyond this ticket.
+
+### Alternatives Considered
+
+- **Validate against the supported format list**: Earlier, clearer errors - Rejected for this ticket to keep behaviour consistent with `--output`; could be done for both flags as a follow-up.
+
+### Consequences
+
+**Positive:**
+- Consistent flag behaviour; no new failure mode.
+
+**Negative:**
+- A typo in `--file-format` silently produces a JSON file.
+
+---

--- a/specs/file-output-format/implementation.md
+++ b/specs/file-output-format/implementation.md
@@ -1,0 +1,61 @@
+# Implementation Explanation: File Output Format (T-1535)
+
+Branch `T-1535/file-output-format`, two commits implementing `specs/file-output-format/smolspec.md`.
+
+## Beginner Level
+
+### What Changed
+awstools commands can print their results to the screen and, optionally, also save them to a file with `--file`. Until now the file always contained exactly what the screen showed: ask for a table, get a table in the file too. This change adds a new option, `--file-format`, that lets the file use a different format. You can now look at a readable table on screen while the saved file contains JSON that scripts can process.
+
+### Why It Matters
+People using awstools often want two things at once from a single run: something readable for themselves and something parseable for automation. Without this flag they had to run the same command twice, which means twice the AWS API calls — these are slow and sometimes rate-limited. The user's other tool, fog, already works this way; awstools now matches it.
+
+### Key Concepts
+- **Output format**: how results are presented — `json` (machine-readable), `table` (human-readable), `csv` (spreadsheets), and so on.
+- **Flag**: an option you pass on the command line, like `--file out.json`. A *global* (persistent) flag works on every awstools subcommand.
+- **Config file**: instead of typing flags every time, awstools reads defaults from `.awstools.yaml`. The new flag can be set there as `output.file-format`.
+
+Example: `awstools s3 list -o table --file buckets.json --file-format json` shows a table and writes JSON.
+
+## Intermediate Level
+
+### Changes Overview
+- `cmd/root.go`: new persistent flag `--file-format` (default empty) bound to viper key `output.file-format`; the stale `--output` help text was corrected (it omitted yaml, markdown, mermaid).
+- `config/config.go`: `NewOutputSettings()` now populates `OutputSettings.OutputFileFormat` via `GetLCString` (lowercased, matching how `output.format` is normalised). `ShouldCombineAndAppend()` now evaluates its HTML exclusion against the *effective file format* (file-format when set, else the stdout format) and builds the settings object once instead of twice.
+- `config/config_test.go`: subtests for set/unset/mixed-case values, divergent-format combine-and-append cases, and an end-to-end test that calls `OutputArray.Write()` with json stdout + csv file-format and asserts the file content is CSV.
+- `cmd/root_flags_test.go`: asserts the flag is registered on the root command and bound to the viper key.
+- `README.md`: help capture and format prose updated.
+
+### Implementation Approach
+The rendering split already existed: go-output v1.4.0's `OutputArray.Write()` renders stdout from `OutputFormat` and, when `OutputFile` is set, re-renders from `OutputFileFormat`, falling back to `OutputFormat` when empty. awstools simply never set that field. The whole feature is therefore wiring: one flag, one viper binding, one field assignment — following the exact flag/binding pattern already in `cmd/root.go`.
+
+### Trade-offs
+- **Stay on go-output v1 vs migrate to v2**: fog implements this on v2's multi-writer model. Migrating awstools would rewrite the output path of every command for no functional gain here (decision log #1).
+- **No format validation**: `--output` doesn't validate values (unknown ones fall back to JSON in the library), so `--file-format` behaves identically rather than introducing an inconsistent failure mode (decision log #3).
+- **`ShouldCombineAndAppend` fix vs documenting it as undefined**: keying the HTML exclusion to the file format is a few lines and prevents a foreseeable parse failure, so it was fixed rather than scoped out (decision log #2).
+
+## Expert Level
+
+### Technical Deep Dive
+`Write()` in v1.4.0 is two sequential render passes over the same `OutputArray`. The stdout pass renders `OutputFormat` and prints via `PrintByteSlice(result, "", ...)`; the file pass mutates `Settings.OutputFileFormat` to `OutputFormat` when empty, then renders again and writes to `OutputFile`. Because awstools constructs a fresh `OutputSettings` per command invocation (`NewOutputSettings()`), the library's mutation of the settings object has no cross-command effect.
+
+The `GetLCString` choice matters: `SetOutputFormat()` lowercases internally, but `OutputFileFormat` is a bare field with no setter, so the lowercasing must happen on the awstools side to keep `--file-format CSV` working and to keep the `ShouldCombineAndAppend` comparison (`!= "html"`) reliable.
+
+`ShouldCombineAndAppend()` gates the multi-account collection flow (`cmd/vpcpeerings.go`, `cmd/tgwoverview.go`, `cmd/names.go`) that re-reads the existing output file via `drawio.GetHeaderAndContentsFromFile` and merges prior rows. The HTML exclusion exists because the HTML renderer handles appending itself. That check is semantically about the file, so with divergent formats it must consult the effective file format — otherwise `-o csv --file x.html --file-format html` would attempt to parse HTML as CSV rows.
+
+### Architecture Impact
+Zero new abstractions; one new field flows through the existing settings pipeline. Every command picks the feature up automatically because output handling is centralised in `Config.NewOutputSettings()`. A future go-output v2 migration maps this directly onto fog's `GetFileOutputOptions()` pattern (separate Output instance when formats differ).
+
+### Potential Issues
+- **v1 renderer quirks are inherited, not fixed**: the HTML renderer writes directly to `OutputSettings.OutputFile`, so `-o html --file x --file-format csv` writes HTML to the file during the stdout pass, then overwrites it with CSV in the file pass. Stdout shows nothing for the HTML pass. Pre-existing, documented out of scope.
+- **Graph formats as file format**: `drawio`/`dot`/`mermaid` require per-command configuration (`DrawIOHeader`, `FromToColumns`) that commands only set when the *stdout* format requests them (`settings.IsDrawIO()` checks `OutputFormat`). Requesting them only via `--file-format` hits the library's `log.Fatal`. Same failure as an unsupported `--output` today.
+- **Append with format drift**: nothing prevents appending csv rows to a file that previously contained json. Already possible by varying `--output` between runs; remains user responsibility.
+- **Buffered multi-section commands**: `vpc enis` builds a combined `OutputArray` precisely because the library's section buffer is consumed by the stdout pass; the file pass re-renders from `Contents` only. That workaround keeps working with divergent formats.
+
+## Completeness Assessment
+
+**Fully implemented**: all six MUST requirements (global flag, fallback default, same value handling, config key support, stdout untouched, combine-and-append keyed to effective file format) and both SHOULD items (help text states the default; `--output` help corrected). Tests cover config wiring, combine-and-append divergence, flag registration/binding, and an end-to-end divergent-format write. CLI behaviour verified manually with `demo tables -o table --file out --file-format json`.
+
+**Partially implemented**: none.
+
+**Missing**: nothing against the spec. The out-of-scope list (v2 migration, renderer quirks, validation, docs/ regeneration) is intentional and recorded in the decision log.

--- a/specs/file-output-format/smolspec.md
+++ b/specs/file-output-format/smolspec.md
@@ -1,0 +1,45 @@
+# File Output Format
+
+Transit ticket: T-1535
+
+## Overview
+
+awstools can write command output to a file with `--file`, but the file always uses the same format as stdout (`--output`). Users who want, for example, a human-readable table on screen and a machine-readable JSON file have to run the command twice. This change adds a `--file-format` flag, mirroring the equivalent flag in fog, so the file can use a different format than stdout.
+
+## Requirements
+
+- The system MUST accept a `--file-format` flag as a global persistent flag on the root command (available to every subcommand, exactly like `--file`) that specifies the output format used for the file written via `--file`.
+- When `--file-format` is not provided, the system MUST write the file in the same format as stdout (current behaviour, unchanged).
+- The system MUST accept the same format values for `--file-format` as for `--output`, with the same case-insensitive handling and the same fallback for unknown values (the library falls back to JSON; neither flag validates input).
+- The system MUST support setting the file format via the config file (key `output.file-format` in `.awstools.yaml`), consistent with how `output.format` and `output.file` work.
+- The system MUST NOT change stdout output in any way when `--file-format` is provided.
+- The combine-and-append flow (`Config.ShouldCombineAndAppend`, used by multi-account collection commands) MUST evaluate its HTML exclusion against the effective file format (`--file-format` when set, otherwise `--output`), since that check is about the file being appended to.
+- The flag's help text SHOULD state that it defaults to the value of `--output`.
+- The `--output` flag's stale help text SHOULD be corrected while editing the adjacent line: it currently omits markdown, mermaid, and yaml, which the library supports.
+
+## Implementation Approach
+
+go-output v1.4.0 (already the pinned version in `go.mod`) natively supports this: `OutputSettings.OutputFileFormat` exists and `OutputArray.Write()` renders stdout using `OutputFormat` and the file using `OutputFileFormat`, falling back to `OutputFormat` when unset. awstools just never sets the field. The change is wiring only:
+
+- `cmd/root.go`: add a persistent string flag `--file-format` (default `""`) alongside the existing `--file` flag, and bind it to viper key `output.file-format`, following the exact pattern of the existing `output.file` binding (`cmd/root.go:44-66`). Correct the `--output` help text format list on the adjacent line.
+- `config/config.go`: in `NewOutputSettings()` (`config/config.go:87-96`), set `settings.OutputFileFormat = config.GetLCString("output.file-format")`. Use `GetLCString` to match the lowercasing applied to `output.format` via `SetOutputFormat`. In `ShouldCombineAndAppend()` (`config/config.go:71-79`), compare against the effective file format instead of `OutputFormat`.
+- `config/config_test.go`: extend `TestConfig_NewOutputSettings` with cases for: file format set, file format absent (asserts `OutputFileFormat` is the empty string — the fallback itself happens inside the library), and case-insensitivity. Add `ShouldCombineAndAppend` cases for a divergent file format. Add one end-to-end test that builds a small `format.OutputArray` from `NewOutputSettings()` with `output.format=json`, `output.file-format=csv`, and a temp file, calls `Write()`, and asserts the file contains CSV — this proves the library integration rather than only the field wiring.
+
+Command help output updates automatically via Cobra. The generated docs under `docs/` are refreshed separately via `awstools gen docs` when the site is updated, not per change.
+
+Dependencies: `github.com/ArjenSchwarz/go-output v1.4.0` (no upgrade needed), Cobra/Viper flag binding patterns already in `cmd/root.go`.
+
+Out of Scope:
+- Upgrading to go-output v2 (how fog implements this) — unnecessary for this feature.
+- Fixing pre-existing go-output v1 quirks: `html` and `drawio` renderers write directly to the output file inside the library, so `-o html --file x --file-format y` combinations inherit existing odd behaviour; graph formats (`dot`, `mermaid`, `drawio`) terminate with an error on commands that do not configure them. These behave identically today when chosen via `--output`.
+- Validating format values for either flag.
+- Regenerating the committed Cobra docs under `docs/`.
+- Guarding `--append` runs that mix formats in one file across invocations; that is already possible today by varying `--output` between runs and remains the user's responsibility.
+
+## Risks and Assumptions
+
+- Risk: choosing `drawio`, `dot`, or `mermaid` as `--file-format` on a command that does not configure those formats causes the library to exit with an error mid-write. | Mitigation: identical to existing `--output` behaviour for those formats, so no regression; documented as out of scope.
+- Risk: `-o html` combined with a different `--file-format` produces surprising results because the v1 HTML renderer writes to the file directly. | Mitigation: pre-existing library behaviour, out of scope; the common direction (readable stdout + machine-readable file) is unaffected.
+- Risk: commands whose combine-and-append flow parses the existing file (e.g. `vpc peerings` via `drawio.GetHeaderAndContentsFromFile`) cannot parse a file written in an incompatible format. | Mitigation: same failure exists today when `--output` varies between appending runs; the `ShouldCombineAndAppend` change keeps the HTML exclusion keyed to the right format, the rest stays user responsibility.
+- Assumption: go-output v1.4.0's `OutputFileFormat` rendering path works as designed; validated by the end-to-end `Write()` test above rather than only by reading the library source.
+- Assumption: `--file-format` without `--file` is a harmless no-op (the library only consults `OutputFileFormat` when `OutputFile` is set).

--- a/specs/file-output-format/tasks.md
+++ b/specs/file-output-format/tasks.md
@@ -1,0 +1,16 @@
+---
+references:
+    - specs/file-output-format/smolspec.md
+    - specs/file-output-format/decision_log.md
+---
+# File Output Format
+
+- [x] 1. The root command exposes --file-format as a global persistent flag (available to every subcommand, like --file), bound to config key output.file-format; the --output help text lists all supported formats
+
+- [x] 2. Output settings carry the configured file format: NewOutputSettings populates OutputFileFormat lowercased, empty when unset; unit tests cover set, unset, and mixed-case values
+
+- [x] 3. Combine-and-append decisions use the effective file format: ShouldCombineAndAppend excludes HTML based on file-format when set, otherwise output format; unit tests cover divergent combinations
+
+- [x] 4. A divergent file format is proven end to end: a Write() test with json stdout and csv file-format produces a CSV file while stdout remains json
+
+- [x] 5. Full suite passes and the feature works from the CLI: go fmt clean, make test green, and demo tables with -o table --file out --file-format json writes a JSON file alongside table stdout


### PR DESCRIPTION
## Summary

Adds a global `--file-format` flag (config key `output.file-format`) so the file written via `--file` can use a different output format than stdout — e.g. a readable table on screen and machine-readable JSON in the file. Mirrors fog's equivalent flag.

go-output v1.4.0 already renders the file separately via `OutputSettings.OutputFileFormat`; this wires up the flag and field, keys `ShouldCombineAndAppend()`'s HTML exclusion to the effective file format, and corrects the stale `--output` help text (markdown, mermaid, yaml were missing).

Spec: `specs/file-output-format/smolspec.md` (decisions in `decision_log.md`). Transit: T-1535.

## Changes

- `cmd/root.go`: `--file-format` persistent flag + viper binding; corrected `--output` help text
- `config/config.go`: populate `OutputFileFormat`; `ShouldCombineAndAppend()` uses the effective file format
- `cmd/root_flags_test.go`: flag registration/binding guard
- `config/config_test.go`: wiring tests, divergent combine-and-append cases, end-to-end divergent-format `Write()` test
- `README.md`: help capture and prose synced

## Testing

- `make test` (lint + full suite) green
- Manual: `demo tables -o table --file out --file-format json` shows a table and writes JSON
